### PR TITLE
ci: add lint, type-check, and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      BETTER_AUTH_SECRET: ci-dummy-secret-32-chars-minimum-XX
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm type-check
+
+      - run: pnpm test


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs on push to `main` and on every pull request. Steps: install dependencies (pnpm with frozen lockfile), `pnpm lint`, `pnpm type-check`, `pnpm test`.

`BETTER_AUTH_SECRET` is set to a 32-char dummy in workflow env because `lib/env/index.ts` validates required env vars at module load time. The value is never used at runtime in CI — the test files set their own per-test secret.

## Test plan

- [ ] CI run on this PR is green for all three steps.
- [ ] PR cannot be merged if any of the three steps fails.