### PR TITLE
feat: Phase 4.3 — cache & freshness (mtime-keyed)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -186,6 +186,7 @@ Bring in Vitest and cover the pure functions first (no `ledger` shell-out needed
 - [ ] Server-side error boundary that doesn't leak `ledger` stderr to the client
 - [ ] "Journal is empty" empty-state on Dashboard pointing to `/import` or `/transactions/new`
 - [ ] Loading skeletons (currently most pages just block on `ledger`)
+- [ ] **Verify writes with `ledger`** — after `JournalService.addTransaction` / `editTransaction` / `deleteTransaction` and after the `/import` flow, shell out to `ledger -f <main> stats` (or equivalent) and surface a parse error if the journal is no longer valid. Today our parser/writer is trusted to produce ledger-compatible output; if they ever diverge or the user's existing journal has syntax we silently mishandle, broken state lands in the file and only surfaces when a report page renders wrong.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -150,11 +150,11 @@ The remaining authoring work that didn't land in Phase 2's MVP. Edit/delete depe
 - [ ] "New from template" prefills the add-transaction form
 - [ ] Unblocks the paused Budget item (`TODO.md` Tier 2) once periodic transactions are easy
 
-### 4.3 Cache & freshness
+### 4.3 Cache & freshness _(complete)_
 
-- [ ] Replace `unstable_cache` key with one that includes the user's journal mtime so writes invalidate immediately
-- [ ] Or: drop caching entirely for mutating users and keep it for read-heavy sessions (measure first)
-- [ ] Confirm `revalidatePath('/', 'layout')` after every mutation is sufficient
+- [x] Replace `unstable_cache` key with one that includes the user's journal mtime so writes invalidate immediately
+- [x] Or: drop caching entirely for mutating users and keep it for read-heavy sessions (measure first) _(parked — mtime-keyed cache supersedes; see spec)_
+- [x] Confirm `revalidatePath('/', 'layout')` after every mutation is sufficient _(audited — yes; cleanup landed: upload route stopped duplicating it, service is sole source)_
 
 ---
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
-import { revalidatePath } from 'next/cache';
 import { NextResponse, type NextRequest } from 'next/server';
 
 const ALLOWED_SINGLE_EXTS = new Set(['.ledger', '.dat', '.journal', '.txt']);
@@ -31,7 +30,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     if (ext === ZIP_EXT) {
       const result = await journalService.replaceFromZip(user.id, buffer);
-      revalidatePath('/', 'layout');
       return NextResponse.json({
         ok: true,
         mode: 'archive',
@@ -47,7 +45,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         user.id,
         buffer
       );
-      revalidatePath('/', 'layout');
       return NextResponse.json({
         ok: true,
         mode: 'single',

--- a/docs/superpowers/plans/2026-05-20-phase-4-3-cache.md
+++ b/docs/superpowers/plans/2026-05-20-phase-4-3-cache.md
@@ -1,0 +1,675 @@
+# Phase 4.3 — Cache & Freshness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `unstable_cache` reflect journal changes immediately — both internal mutations and external edits — by including the journal's max mtime in the cache key.
+
+**Architecture:** Add `JournalRepository.getMaxMtime(userId)` that returns the max `mtimeMs` across the user's include graph. Both cache consumers (`utils/runLedger.ts` and `features/transactions/Transactions.tsx`) call it and include the result in `unstable_cache` `keyParts`. `JournalService.invalidateCache` drops `updateTag` (now redundant); `revalidatePath('/', 'layout')` stays for Next.js RSC payload invalidation. `JournalService.replaceFromSingleFile` / `.replaceFromZip` gain explicit `invalidateCache(userId)` calls so the upload route can drop its own.
+
+**Tech Stack:** TypeScript · Next.js 16 (`unstable_cache`, `revalidatePath`) · vitest · existing `lib/journal/` repository + service classes.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-20-phase-4-3-cache-design.md`.
+
+---
+
+## File Map
+
+**Modified:**
+
+- `lib/journal/repository.ts` — add `getMaxMtime(userId): Promise<number>` method.
+- `utils/runLedger.ts` — `buildExecLedger(tag, mtimeMs)`; runner fetches mtime + threads it into the key.
+- `features/transactions/Transactions.tsx` — `buildLoader(tag, mtimeMs)`; `loadTransactions` becomes async and fetches mtime first.
+- `lib/journal/service.ts` — drop `updateTag` from `invalidateCache`; add `invalidateCache(userId)` calls at end of `replaceFromSingleFile` and `replaceFromZip`; trim unused imports.
+- `app/api/upload/route.ts` — drop both `revalidatePath('/', 'layout')` calls; drop the import if unused.
+
+**Created:**
+
+- `lib/journal/repository.test.ts` — vitest suite for `getMaxMtime`.
+
+**Untouched:**
+
+- The template surface and `revalidatePath('/templates')` calls — correctly scoped.
+- `JournalService` internal mutex / fingerprint / file writing — no change to mutation semantics.
+- The 60s `revalidate` TTL in both cache consumers — kept as memory-pressure safety net.
+
+---
+
+## Task 1 — Add `JournalRepository.getMaxMtime` + tests
+
+**Files:**
+
+- Create: `lib/journal/repository.test.ts`
+- Modify: `lib/journal/repository.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/journal/repository.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from '@/db/schema';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+
+const insertTestUser = (ctx: TestDbContext) => {
+  ctx.sqlite
+    .prepare(`INSERT INTO "user" ("id","name","email") VALUES (?,?,?)`)
+    .run('test-user', 'Test', 'test@example.com');
+};
+
+describe('JournalRepository.getMaxMtime', () => {
+  let ctx: TestDbContext;
+  let repo: JournalRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('repo-mtime-');
+    insertTestUser(ctx);
+    const db = drizzle(ctx.sqlite, { schema });
+    repo = new JournalRepository(db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('returns the stub file mtime for a brand-new user (calls ensureLayout)', async () => {
+    const mtime = await repo.getMaxMtime('test-user');
+    expect(mtime).toBeGreaterThan(0);
+  });
+
+  it('returns the main file mtime when there are no includes', async () => {
+    const userId = 'test-user';
+    await repo.ensureLayout(userId);
+    const mainPath = path.join(getJournalDir(userId), 'main.ledger');
+    const target = 1_700_000_000_000; // 2023-11-14 in ms
+    await fs.utimes(mainPath, new Date(target), new Date(target));
+    const mtime = await repo.getMaxMtime(userId);
+    expect(mtime).toBe(target);
+  });
+
+  it('returns the max mtime across the include graph', async () => {
+    const userId = 'test-user';
+    const dir = getJournalDir(userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'main.ledger'),
+      'include ./sub.ledger\n\n2024-01-01 main\n    Expenses:Food  USD 1\n    Assets:Cash\n'
+    );
+    await fs.writeFile(
+      path.join(dir, 'sub.ledger'),
+      '2024-01-02 sub\n    Expenses:Food  USD 2\n    Assets:Cash\n'
+    );
+    const older = 1_700_000_000_000;
+    const newer = 1_800_000_000_000;
+    await fs.utimes(
+      path.join(dir, 'main.ledger'),
+      new Date(older),
+      new Date(older)
+    );
+    await fs.utimes(
+      path.join(dir, 'sub.ledger'),
+      new Date(newer),
+      new Date(newer)
+    );
+
+    const mtime = await repo.getMaxMtime(userId);
+    expect(mtime).toBe(newer);
+  });
+
+  it('reflects a sub-file change on the next call', async () => {
+    const userId = 'test-user';
+    const dir = getJournalDir(userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'main.ledger'),
+      'include ./sub.ledger\n'
+    );
+    await fs.writeFile(path.join(dir, 'sub.ledger'), '');
+    const first = 1_700_000_000_000;
+    await fs.utimes(
+      path.join(dir, 'main.ledger'),
+      new Date(first),
+      new Date(first)
+    );
+    await fs.utimes(
+      path.join(dir, 'sub.ledger'),
+      new Date(first),
+      new Date(first)
+    );
+    expect(await repo.getMaxMtime(userId)).toBe(first);
+
+    const later = 1_800_000_000_000;
+    await fs.utimes(
+      path.join(dir, 'sub.ledger'),
+      new Date(later),
+      new Date(later)
+    );
+    expect(await repo.getMaxMtime(userId)).toBe(later);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm test lib/journal/repository.test.ts`
+Expected: module imports fine but `getMaxMtime` is not a function on `JournalRepository`, so all four tests fail.
+
+- [ ] **Step 3: Implement `getMaxMtime`**
+
+In `lib/journal/repository.ts`, add the import next to the existing `parseJournal` import:
+
+```ts
+import {
+  parseJournal,
+  resolveIncludes,
+  type ParsedJournal,
+  type Transaction,
+} from './parser';
+```
+
+(`resolveIncludes` was already exported from `./parser`; only the named import in this file changes.)
+
+Then add the method to the `JournalRepository` class — place it next to `list` and `find` for readability:
+
+```ts
+  /** Returns max mtimeMs across the user's include graph. Used as a cache-key
+   * input so any file change (internal or external) invalidates `unstable_cache`. */
+  async getMaxMtime(userId: string): Promise<number> {
+    const { mainPath } = await this.ensureLayout(userId);
+    const files = await resolveIncludes(mainPath);
+    if (files.length === 0) return 0;
+    const stats = await Promise.all(files.map((f) => fs.stat(f)));
+    return Math.max(...stats.map((s) => s.mtimeMs));
+  }
+```
+
+- [ ] **Step 4: Run tests, expect 4 passed**
+
+Run: `pnpm test lib/journal/repository.test.ts`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `pnpm test`
+Expected: 88 tests pass (84 existing + 4 new).
+
+- [ ] **Step 6: Type-check + lint**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/journal/repository.ts lib/journal/repository.test.ts
+git commit -m "feat(journal): add JournalRepository.getMaxMtime"
+```
+
+---
+
+## Task 2 — Thread mtime into `utils/runLedger.ts`
+
+**Files:**
+
+- Modify: `utils/runLedger.ts`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat utils/runLedger.ts`
+
+Confirm the shape: `buildExecLedger(tag)` returns a `unstable_cache`-wrapped function; `runLedger` awaits `ensureLayout` then builds the execLedger and calls it.
+
+- [ ] **Step 2: Replace the file contents**
+
+Overwrite `utils/runLedger.ts` with:
+
+```ts
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalRepository } from '@/lib/journal';
+import { getJournalCacheTag } from '@/lib/journal/layout';
+import { unstable_cache } from 'next/cache';
+import { connection } from 'next/server';
+
+const execFilePromise = promisify(execFile);
+
+const LEDGER_CACHE_TTL_SECONDS = 60;
+
+const buildExecLedger = (tag: string, mtimeMs: number) =>
+  unstable_cache(
+    async (allArgs: string[]): Promise<string> => {
+      const { stdout } = await execFilePromise('ledger', allArgs);
+      return stdout;
+    },
+    ['ledger-cli-exec', tag, String(mtimeMs)],
+    { revalidate: LEDGER_CACHE_TTL_SECONDS, tags: [tag] }
+  );
+
+type Options = {
+  sortByDate?: boolean;
+};
+
+const runLedger = async (
+  args: string[],
+  options?: Options
+): Promise<string> => {
+  await connection();
+  const user = await requireUser();
+  const { mainPath, priceDbPath } = await journalRepository.ensureLayout(
+    user.id
+  );
+  const mtimeMs = await journalRepository.getMaxMtime(user.id);
+
+  const baseArgs: string[] = ['--file', mainPath];
+  if (priceDbPath) baseArgs.push('--price-db', priceDbPath);
+  if (options?.sortByDate ?? true) baseArgs.push('--sort', '-date');
+
+  const execLedger = buildExecLedger(getJournalCacheTag(user.id), mtimeMs);
+  return execLedger([...baseArgs, ...args]);
+};
+
+export default runLedger;
+```
+
+The diff vs. the original: `buildExecLedger` gains a `mtimeMs: number` parameter and includes `String(mtimeMs)` in `keyParts`; `runLedger` fetches `mtimeMs` after `ensureLayout` and passes it through. Nothing else moves.
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm type-check`
+Expected: clean.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `pnpm test`
+Expected: 88 tests still pass (no test changes; type-check exercises the file).
+
+- [ ] **Step 5: Lint**
+
+Run: `pnpm lint`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/runLedger.ts
+git commit -m "feat(cache): thread journal mtime into runLedger cache key"
+```
+
+---
+
+## Task 3 — Thread mtime into `features/transactions/Transactions.tsx`
+
+**Files:**
+
+- Modify: `features/transactions/Transactions.tsx`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat features/transactions/Transactions.tsx`
+
+Confirm the shape: `buildLoader(tag)` returns a `unstable_cache`-wrapped function; `loadTransactions(userId)` is a sync function that builds the loader and immediately calls it.
+
+- [ ] **Step 2: Add the `journalRepository` import**
+
+Find the import block at the top. After `import { journalService } from '@/lib/journal';` add (alphabetical-ish):
+
+```ts
+import { journalRepository } from '@/lib/journal';
+```
+
+Or merge the two imports:
+
+```ts
+import { journalRepository, journalService } from '@/lib/journal';
+```
+
+Whichever the existing file style prefers (single-import-per-name vs. combined). Both work.
+
+- [ ] **Step 3: Update `buildLoader` to take `mtimeMs`**
+
+Find the existing definition:
+
+```ts
+const buildLoader = (tag: string) =>
+  unstable_cache(
+    async (userId: string): Promise<Transaction[]> => {
+      const journal = await journalService.listTransactions(userId);
+      return journal.transactions;
+    },
+    ['journal-transactions', tag],
+    { revalidate: 60, tags: [tag] }
+  );
+```
+
+Replace with:
+
+```ts
+const buildLoader = (tag: string, mtimeMs: number) =>
+  unstable_cache(
+    async (userId: string): Promise<Transaction[]> => {
+      const journal = await journalService.listTransactions(userId);
+      return journal.transactions;
+    },
+    ['journal-transactions', tag, String(mtimeMs)],
+    { revalidate: 60, tags: [tag] }
+  );
+```
+
+- [ ] **Step 4: Update `loadTransactions` to be async + fetch mtime**
+
+Find:
+
+```ts
+const loadTransactions = (userId: string) =>
+  buildLoader(getJournalCacheTag(userId))(userId);
+```
+
+Replace with:
+
+```ts
+const loadTransactions = async (userId: string) => {
+  const mtimeMs = await journalRepository.getMaxMtime(userId);
+  return buildLoader(getJournalCacheTag(userId), mtimeMs)(userId);
+};
+```
+
+The single call site inside `Transactions` already `await`s the result, so no caller change is needed.
+
+- [ ] **Step 5: Type-check**
+
+Run: `pnpm type-check`
+Expected: clean.
+
+- [ ] **Step 6: Run full suite**
+
+Run: `pnpm test`
+Expected: 88 tests still pass.
+
+- [ ] **Step 7: Lint**
+
+Run: `pnpm lint`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add features/transactions/Transactions.tsx
+git commit -m "feat(cache): thread journal mtime into Transactions list cache key"
+```
+
+---
+
+## Task 4 — Drop redundant invalidations
+
+Two cleanups: (a) remove `updateTag` from `JournalService.invalidateCache` and add explicit `invalidateCache(userId)` calls inside the two replace methods; (b) drop both `revalidatePath('/', 'layout')` calls from `app/api/upload/route.ts`.
+
+**Files:**
+
+- Modify: `lib/journal/service.ts`
+- Modify: `app/api/upload/route.ts`
+
+- [ ] **Step 1: Read the current service**
+
+Run: `cat lib/journal/service.ts`
+
+Confirm the existing shape: top-level helper `invalidateCache(userId)` calls `updateTag(getJournalCacheTag(userId))` + `revalidatePath('/', 'layout')`. It's called from `addTransaction`, `performEdit`, `performDelete`. NOT called from `replaceFromSingleFile` or `replaceFromZip`.
+
+- [ ] **Step 2: Trim `invalidateCache` in `lib/journal/service.ts`**
+
+Find:
+
+```ts
+const invalidateCache = (userId: string) => {
+  // Cache invalidation is best-effort outside the Next.js runtime context
+  // (e.g. inside vitest); inside Next, updateTag + revalidatePath fire normally.
+  try {
+    updateTag(getJournalCacheTag(userId));
+    revalidatePath('/', 'layout');
+  } catch {
+    // no-op outside Next.js
+  }
+};
+```
+
+Replace with:
+
+```ts
+const invalidateCache = (_userId: string) => {
+  // Cache invalidation is best-effort outside the Next.js runtime context
+  // (e.g. inside vitest); inside Next, revalidatePath fires normally.
+  //
+  // The journal's max mtime is part of every cache key (see runLedger and
+  // Transactions.tsx), so any file change implicitly invalidates the data
+  // cache. revalidatePath here forces the RSC payload re-render.
+  try {
+    revalidatePath('/', 'layout');
+  } catch {
+    // no-op outside Next.js
+  }
+};
+```
+
+(Renamed parameter to `_userId` to silence the unused-parameter lint since the helper signature is preserved for symmetry with potential future per-route paths.)
+
+- [ ] **Step 3: Trim the imports in `lib/journal/service.ts`**
+
+In the import block at the top of `lib/journal/service.ts`:
+
+- Change `import { revalidatePath, updateTag } from 'next/cache';` to `import { revalidatePath } from 'next/cache';`.
+- Remove `getJournalCacheTag` from the `'./layout'` import; the others (`DEFAULT_MAIN`, `PRICE_DB_NAME`, `VALID_EXTS`, `getJournalDir`) stay.
+
+Concretely, find the existing layout import:
+
+```ts
+import {
+  DEFAULT_MAIN,
+  PRICE_DB_NAME,
+  VALID_EXTS,
+  getJournalCacheTag,
+  getJournalDir,
+} from './layout';
+```
+
+Replace with:
+
+```ts
+import {
+  DEFAULT_MAIN,
+  PRICE_DB_NAME,
+  VALID_EXTS,
+  getJournalDir,
+} from './layout';
+```
+
+- [ ] **Step 4: Add `invalidateCache` calls to the two replace methods**
+
+In `JournalService.replaceFromSingleFile`, find the body — it currently ends with:
+
+```ts
+    const backfill = await this.backfillUids(userId);
+    return { uidsAdded: backfill.uidsAdded };
+  }
+```
+
+Replace with:
+
+```ts
+    const backfill = await this.backfillUids(userId);
+    invalidateCache(userId);
+    return { uidsAdded: backfill.uidsAdded };
+  }
+```
+
+In `JournalService.replaceFromZip`, find the body — it currently ends with:
+
+```ts
+    const backfill = await this.backfillUids(userId);
+    return {
+      mainFile,
+      fileCount: entries.length,
+      uidsAdded: backfill.uidsAdded,
+    };
+  }
+```
+
+Replace with:
+
+```ts
+    const backfill = await this.backfillUids(userId);
+    invalidateCache(userId);
+    return {
+      mainFile,
+      fileCount: entries.length,
+      uidsAdded: backfill.uidsAdded,
+    };
+  }
+```
+
+- [ ] **Step 5: Drop `revalidatePath` calls from `app/api/upload/route.ts`**
+
+Read the file:
+
+```bash
+cat app/api/upload/route.ts
+```
+
+Confirm the two `revalidatePath('/', 'layout');` calls — one in the `ext === ZIP_EXT` branch, one in the `ALLOWED_SINGLE_EXTS.has(ext)` branch.
+
+In both branches, remove the line `revalidatePath('/', 'layout');`. The structure changes from:
+
+```ts
+if (ext === ZIP_EXT) {
+  const result = await journalService.replaceFromZip(user.id, buffer);
+  revalidatePath('/', 'layout');
+  return NextResponse.json({ ... });
+}
+```
+
+to:
+
+```ts
+if (ext === ZIP_EXT) {
+  const result = await journalService.replaceFromZip(user.id, buffer);
+  return NextResponse.json({ ... });
+}
+```
+
+After both removals, the `revalidatePath` import at the top is unused. Remove it from the `next/cache` import:
+
+Find:
+
+```ts
+import { revalidatePath } from 'next/cache';
+```
+
+Delete the line.
+
+- [ ] **Step 6: Type-check**
+
+Run: `pnpm type-check`
+Expected: clean. If there are unused-import errors, address those — they should be resolved by Step 5.
+
+- [ ] **Step 7: Run full suite**
+
+Run: `pnpm test`
+Expected: 88 tests still pass. `service.test.ts` exercises `invalidateCache` (which is wrapped in try/catch outside Next), so removing `updateTag` is transparent to tests.
+
+- [ ] **Step 8: Lint**
+
+Run: `pnpm lint`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/journal/service.ts app/api/upload/route.ts
+git commit -m "refactor(cache): drop redundant updateTag and upload-route revalidatePath"
+```
+
+---
+
+## Task 5 — Final verification
+
+No code changes. Confirms the whole pipeline is green and the new behavior actually fires.
+
+- [ ] **Step 1: Full suite**
+
+Run: `pnpm test`
+Expected: 88 tests pass.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm type-check`
+Expected: clean.
+
+- [ ] **Step 3: Lint**
+
+Run: `pnpm lint`
+Expected: clean.
+
+- [ ] **Step 4: Build**
+
+Run: `pnpm build`
+Expected: compiles. (Runtime page evaluation may fail due to missing env in CI; only the compile step matters here.)
+
+- [ ] **Step 5: Manual smoke — internal mutation invalidates cache**
+
+In a dev server (`pnpm dev`):
+
+1. Visit `/`. The Dashboard renders.
+2. Add a transaction via `/transactions/new`. Submit successfully.
+3. Visit `/` again. The new transaction should be reflected in "Recent transactions" and any current-month totals without a manual refresh delay.
+
+- [ ] **Step 6: Manual smoke — external edit invalidates cache**
+
+In the same dev server:
+
+1. Visit `/balance`. Note a balance figure.
+2. In a terminal, edit the journal file directly (e.g., `vim data/journals/<userId>/main.ledger`) and add `\n\n2099-01-01 test\n    Expenses:Misc  USD 100\n    Assets:Cash`. Save.
+3. Refresh `/balance`. The new transaction's effect should be visible immediately (no 60s TTL wait).
+
+- [ ] **Step 7: PLAN.md tick-off**
+
+Open `PLAN.md`. Under Phase 4.3, change all three items from `[ ]` to `[x]`:
+
+```markdown
+### 4.3 Cache & freshness
+
+- [x] Replace `unstable_cache` key with one that includes the user's journal mtime so writes invalidate immediately
+- [x] Or: drop caching entirely for mutating users and keep it for read-heavy sessions (measure first)  _(parked — mtime key supersedes; see spec)_
+- [x] Confirm `revalidatePath('/', 'layout')` after every mutation is sufficient
+```
+
+Commit:
+
+```bash
+git add PLAN.md
+git commit -m "docs(plan): tick off Phase 4.3 items"
+```
+
+---
+
+## Summary
+
+5 tasks, ~16 commits worth of work (small targeted changes). Effective behavior change after the PR merges:
+
+- Any internal mutation or external edit to the journal invalidates the data cache immediately. The 60s TTL becomes pure memory-pressure safety, not a correctness window.
+- `revalidatePath('/', 'layout')` after `JournalService` mutations forces the RSC payload re-render so the new data lands on the next navigation.
+- One source of truth for journal-cache invalidation: `JournalService`. The upload route no longer maintains its own copy.
+
+## Out of scope (matches the spec)
+
+- Dropping caching entirely (plan item 2).
+- Content-hash keys.
+- Cache hit/miss instrumentation.
+- Verifying writes by shelling out to `ledger` (now Phase 5.3).
+- Narrowing `revalidatePath('/', 'layout')` to specific paths.

--- a/docs/superpowers/specs/2026-05-20-phase-4-3-cache-design.md
+++ b/docs/superpowers/specs/2026-05-20-phase-4-3-cache-design.md
@@ -1,0 +1,286 @@
+# Phase 4.3 — Cache & Freshness (Design)
+
+Status: approved during brainstorming, awaiting implementation plan.
+Date: 2026-05-20.
+
+## Goal
+
+Phase 4.3 of `PLAN.md`. After mutations land, cached data should reflect them immediately. The same should be true when the user edits the journal outside the app (vim, another ledger tool). Today's `unstable_cache` setup invalidates on internal mutations via `updateTag`, but external edits stay stale for up to 60 seconds (the configured TTL). This phase removes that window by making the cache key carry the journal's mtime.
+
+The audit item from the plan ("Confirm `revalidatePath('/', 'layout')` after every mutation is sufficient") is included — answer is yes, with one redundancy worth cleaning up.
+
+The drop-caching-entirely alternative from the plan is parked: with the mtime key in place, it's no longer the simplest option, and measurement of the current cache hit-rate would be the prerequisite anyway.
+
+## Scope
+
+In:
+
+- `JournalRepository.getMaxMtime(userId)` — returns the max `mtimeMs` across the user's include graph.
+- Both `unstable_cache` consumers gain the mtime in their `keyParts`: `utils/runLedger.ts` (report pages) and `features/transactions/Transactions.tsx` (list page).
+- `JournalService.invalidateCache` drops `updateTag(...)` — it's redundant with mtime-keyed invalidation.
+- `app/api/upload/route.ts` drops its own `revalidatePath('/', 'layout')` calls — the service does it inside `replaceFromZip` / `replaceFromSingleFile`.
+- Test for `getMaxMtime` in a new `lib/journal/repository.test.ts`.
+
+Out (named explicitly so they don't creep in):
+
+- Dropping caching entirely (plan item 2). Once mtime-keyed invalidation is in place, the cache is correct without it; turning it off would need measurement first.
+- Content-hash-based keys. mtime is cheaper and sufficient.
+- Cache hit/miss instrumentation.
+- Verifying writes by shelling out to `ledger` (now a Phase 5.3 task per the PLAN.md update).
+- Trimming `revalidatePath('/', 'layout')` to narrower paths. It's broader than strictly necessary, but the cost of over-revalidation is one extra render on the next visit — not worth optimizing now.
+
+## Architectural decisions (locked during brainstorming)
+
+- **Two cache layers, two invalidation mechanisms.**
+  - Layer 1: `unstable_cache` (data). Invalidated by *key change* — mtime in the key means any file change creates a new key and the cache misses.
+  - Layer 2: Next.js RSC page cache. Invalidated by `revalidatePath('/', 'layout')` on `JournalService` mutations. Forces the page to re-execute against the new Layer 1 data.
+- **mtime strategy:** max across the include graph (option A from brainstorming). Cheaper than content-hash, sufficient given file mtime is monotonic per write.
+- **`ensureLayout` not `getLayout` inside `getMaxMtime`.** First-ever request from a new user has no journal directory; `ensureLayout` creates the stub so the caller never has to handle ENOENT.
+- **TTL stays at 60s.** No longer doing correctness work, but kept as memory-pressure safety net for the Next.js cache LRU.
+- **`updateTag` removed from `JournalService.invalidateCache`.** With the mtime key in place, tag-based invalidation is redundant. The `tags: [tag]` field on `unstable_cache` stays as cheap insurance — no harm, doesn't fire automatically.
+
+## File map
+
+**Modified:**
+
+- `lib/journal/repository.ts` — add `getMaxMtime(userId): Promise<number>`.
+- `utils/runLedger.ts` — `buildExecLedger(tag, mtimeMs)`; `runLedger` calls `journalRepository.getMaxMtime(user.id)` and threads it into the key.
+- `features/transactions/Transactions.tsx` — `buildLoader(tag, mtimeMs)`; `loadTransactions` calls `journalRepository.getMaxMtime(userId)` and threads it into the key.
+- `lib/journal/service.ts` — drop `updateTag(getJournalCacheTag(userId))` from `invalidateCache`; trim unused imports.
+- `app/api/upload/route.ts` — drop both `revalidatePath('/', 'layout')` calls (the service handles it).
+
+**Created:**
+
+- `lib/journal/repository.test.ts` — tests for `getMaxMtime`.
+
+**Stays untouched:**
+
+- The template surface (`features/templates/actions/*`, `lib/templates/*`). Template mutations correctly use `revalidatePath('/templates')` — narrower than journal mutations, and right for their scope.
+- `JournalService` internal mutex, fingerprint check, file writing — unchanged.
+- The 60-second `revalidate` TTL stays in both `unstable_cache` consumers as a memory-pressure safety net.
+
+## Section 1 — `JournalRepository.getMaxMtime`
+
+```ts
+async getMaxMtime(userId: string): Promise<number> {
+  const { mainPath } = await this.ensureLayout(userId);
+  const files = await resolveIncludes(mainPath);
+  if (files.length === 0) return 0;
+  const stats = await Promise.all(files.map((f) => fs.stat(f)));
+  return Math.max(...stats.map((s) => s.mtimeMs));
+}
+```
+
+Key choices:
+
+- **`ensureLayout`, not `getLayout`** — first-ever request creates the stub. No ENOENT path to handle in callers.
+- **Reuses `resolveIncludes`** — no duplicate include-graph walking.
+- **`Promise.all` of stats** — the user's real journal is 11 files; total cost is sub-millisecond on a warm filesystem.
+- **Returns `0` for the empty case** — defensive sentinel. `Math.max()` of no args is `-Infinity`, which serializes oddly in a cache key.
+- **Not cached itself** — the whole point is fresh-on-every-call.
+
+Production usage is per-request, so two requests in flight at the same instant both hit `fs.stat` independently. That's fine; the OS-level stat cache absorbs the duplication.
+
+## Section 2 — Wiring into `utils/runLedger.ts`
+
+Today:
+
+```ts
+const buildExecLedger = (tag: string) =>
+  unstable_cache(
+    async (allArgs: string[]) => {
+      const { stdout } = await execFilePromise('ledger', allArgs);
+      return stdout;
+    },
+    ['ledger-cli-exec', tag],
+    { revalidate: LEDGER_CACHE_TTL_SECONDS, tags: [tag] }
+  );
+
+const runLedger = async (args, options?) => {
+  await connection();
+  const user = await requireUser();
+  const { mainPath, priceDbPath } = await journalRepository.ensureLayout(user.id);
+  // ...
+  const execLedger = buildExecLedger(getJournalCacheTag(user.id));
+  return execLedger([...baseArgs, ...args]);
+};
+```
+
+After:
+
+```ts
+const buildExecLedger = (tag: string, mtimeMs: number) =>
+  unstable_cache(
+    async (allArgs: string[]) => {
+      const { stdout } = await execFilePromise('ledger', allArgs);
+      return stdout;
+    },
+    ['ledger-cli-exec', tag, String(mtimeMs)],
+    { revalidate: LEDGER_CACHE_TTL_SECONDS, tags: [tag] }
+  );
+
+const runLedger = async (args, options?) => {
+  await connection();
+  const user = await requireUser();
+  const { mainPath, priceDbPath } = await journalRepository.ensureLayout(user.id);
+  const mtimeMs = await journalRepository.getMaxMtime(user.id);
+  // ...
+  const execLedger = buildExecLedger(getJournalCacheTag(user.id), mtimeMs);
+  return execLedger([...baseArgs, ...args]);
+};
+```
+
+Every report page that goes through `runLedger` (Dashboard, Balance, Net Worth, Cash Flow, Payees, Debts, Reconcile, per-account register, etc.) automatically benefits.
+
+`mtimeMs` is coerced to a string for the cache key. `unstable_cache` serializes `keyParts` to construct the cache key; mixing number and string types between calls can produce key churn. Coercing to string keeps it deterministic.
+
+`getJournalCacheTag(user.id)` stays as the `tag` argument: it's still part of the key (scopes cache entries per user) and it's still in the `tags: [tag]` array (cheap insurance, even though nothing fires `updateTag` after this PR).
+
+## Section 3 — Wiring into `features/transactions/Transactions.tsx`
+
+Same shape, smaller diff:
+
+```ts
+const buildLoader = (tag: string, mtimeMs: number) =>
+  unstable_cache(
+    async (userId: string): Promise<Transaction[]> => {
+      const journal = await journalService.listTransactions(userId);
+      return journal.transactions;
+    },
+    ['journal-transactions', tag, String(mtimeMs)],
+    { revalidate: 60, tags: [tag] }
+  );
+
+const loadTransactions = async (userId: string) => {
+  const mtimeMs = await journalRepository.getMaxMtime(userId);
+  return buildLoader(getJournalCacheTag(userId), mtimeMs)(userId);
+};
+```
+
+Note: `loadTransactions` was a sync function returning a Promise (`(userId) => buildLoader(...)(userId)`). It becomes `async` because we now `await` the mtime before passing it to `buildLoader`. The single call site in `Transactions` already `await`s the result.
+
+## Section 4 — `JournalService.invalidateCache` cleanup
+
+Today:
+
+```ts
+const invalidateCache = (userId: string) => {
+  try {
+    updateTag(getJournalCacheTag(userId));
+    revalidatePath('/', 'layout');
+  } catch {
+    // no-op outside Next.js
+  }
+};
+```
+
+After:
+
+```ts
+const invalidateCache = (userId: string) => {
+  try {
+    revalidatePath('/', 'layout');
+  } catch {
+    // no-op outside Next.js
+  }
+};
+
+// The userId parameter is preserved on the helper for symmetry with future
+// per-route invalidations, even though only the path-based call is left here.
+```
+
+Trim:
+
+- Remove `updateTag` from the `next/cache` import.
+- Remove `getJournalCacheTag` from the `'./layout'` import.
+
+The remaining `revalidatePath('/', 'layout')` is Layer 2 — forces the page to re-execute against the new Layer 1 data.
+
+## Section 5 — `app/api/upload/route.ts` cleanup
+
+Today: after each of the two branches (zip / single file), the route handler calls `revalidatePath('/', 'layout')` directly:
+
+```ts
+const result = await journalService.replaceFromZip(user.id, buffer);
+revalidatePath('/', 'layout');
+return NextResponse.json({ ... });
+```
+
+`journalService.replaceFromZip` (and `replaceFromSingleFile`) goes through `backfillUids` → `appendFile` → `writeFileAtomic` calls but **does not** call `invalidateCache` today; the upload route does it. After this phase, `invalidateCache` moves into both replace methods so the service is self-contained:
+
+```ts
+async replaceFromSingleFile(userId, content) {
+  // ... existing body ...
+  const backfill = await this.backfillUids(userId);
+  invalidateCache(userId);   // <-- new
+  return { uidsAdded: backfill.uidsAdded };
+}
+
+async replaceFromZip(userId, buffer) {
+  // ... existing body ...
+  const mainFile = detectMain(...);
+  await this.repo.setMainFile(userId, mainFile);
+  const backfill = await this.backfillUids(userId);
+  invalidateCache(userId);   // <-- new
+  return { mainFile, fileCount: entries.length, uidsAdded: backfill.uidsAdded };
+}
+```
+
+And the upload route drops both `revalidatePath` calls. Single source of truth for journal-cache invalidation: the service.
+
+## Section 6 — Audit findings (plan item 3)
+
+The audit confirmed `revalidatePath('/', 'layout')` after every mutation is sufficient. Detailed findings:
+
+| Concern                                                  | Status                                       |
+| -------------------------------------------------------- | -------------------------------------------- |
+| Every user-facing page re-renders on mutation            | ✅ All routes share the root layout           |
+| Necessary in addition to mtime-keyed `unstable_cache`?   | ✅ Yes — Layer 2 (RSC payload cache) needs it |
+| Broader than strictly necessary?                         | ⚠️ Yes, but cost is negligible — keeping it  |
+| Duplicated between `JournalService` and the upload route | 🔧 Cleaning up — service becomes sole source |
+| Template mutations correctly scoped?                     | ✅ `revalidatePath('/templates')` — narrower  |
+
+## Section 7 — Edge cases
+
+- **First-ever request from a new user** — `getMaxMtime` calls `ensureLayout`, which creates the stub `main.ledger`. `fs.stat` returns its mtime. Cache key works; cache populates on next request with the same mtime.
+- **Concurrent mutation + read** — request A reads mtime T1, writes file (mtime now T2), invalidates layer 2. Request B (in flight, started after A's write but with its own server component re-render) reads mtime T2, computes new cache key, gets fresh data. No stale window.
+- **External edit during cached read** — `vim` updates the file mtime. Next page render computes new mtime → new key → cache miss → fresh data. No 60s window.
+- **mtime collisions within the same millisecond** — `fs.stat` returns ms precision. Two writes within the same ms would land on the same mtime and theoretically share a cache entry. In single-process Node, this is bounded by the per-user mutex inside `JournalService`, which serializes writes. Practically impossible.
+- **Filesystem doesn't support mtime precision well (FAT, network mounts)** — out of scope. The deploy target is a Linux/macOS server with ext4/APFS.
+
+## Section 8 — Testing
+
+New: `lib/journal/repository.test.ts` (file doesn't exist today).
+
+Test cases:
+
+- `getMaxMtime` on a fresh user — returns the stub's mtime, not 0.
+- `getMaxMtime` with a single-file journal — returns that file's mtime.
+- `getMaxMtime` with an `include` graph — returns the max mtime across all reachable files. Achieved by setting different mtimes via `fs.utimes(path, atime, mtime)` deterministically (no `setTimeout` flakiness).
+- `getMaxMtime` reflects a sub-file change — write a fresh journal, capture mtime; touch a sub-file with a later mtime; re-call → result reflects the sub-file.
+
+Existing tests (`service.test.ts`, `integration.test.ts`) need no changes. Their `invalidateCache` calls are no-ops outside Next.js; the cache wiring lives in consumers, not in the service.
+
+Coverage target stays at 95% on `lib/journal/*`. `getMaxMtime` is ~5 lines; ~4 tests cover all branches.
+
+No tests for `runLedger.ts` or `Transactions.tsx` cache wiring — those would need a real Next.js test harness. Plumbing-only changes; type-check + manual smoke is sufficient.
+
+## Section 9 — Implementation order
+
+Five slices. Steps 1–3 ship the new behavior; step 4 cleans up the redundant invalidations; step 5 verifies.
+
+1. **Add `JournalRepository.getMaxMtime` + tests.** New method, new `repository.test.ts`. Mergeable on its own; no call sites yet.
+2. **Wire mtime into `utils/runLedger.ts`.** All report pages auto-benefit.
+3. **Wire mtime into `features/transactions/Transactions.tsx`.** Same treatment for the `/transactions` list loader.
+4. **Drop redundant invalidations.**
+   - `lib/journal/service.ts`: remove `updateTag(getJournalCacheTag(userId))` from `invalidateCache`; trim now-unused imports. Add `invalidateCache(userId)` at the end of `replaceFromSingleFile` and `replaceFromZip`.
+   - `app/api/upload/route.ts`: drop both `revalidatePath('/', 'layout')` calls.
+5. **Final verification.**
+   - `pnpm test` — 84 existing + 4 new = 88 green.
+   - `pnpm type-check` clean.
+   - `pnpm lint` clean.
+   - Manual: add / edit / delete a transaction — no stale data on the next page render. Edit the journal in vim — next report page shows fresh data without waiting 60s.
+
+## Open questions
+
+None at design time. If implementation surfaces any, they go on the plan, not retro-added to this spec.

--- a/features/transactions/Transactions.tsx
+++ b/features/transactions/Transactions.tsx
@@ -3,7 +3,7 @@ import Filters from './Filters';
 import TransactionTable from './TransactionTable';
 import Help from '@/components/Help';
 import { requireUser } from '@/lib/auth/require-user';
-import { journalService } from '@/lib/journal';
+import { journalRepository, journalService } from '@/lib/journal';
 import { getJournalCacheTag } from '@/lib/journal/layout';
 import { type Transaction } from '@/lib/journal/parser';
 import { unstable_cache } from 'next/cache';
@@ -16,18 +16,20 @@ type SearchParams = {
   q?: string;
 };
 
-const buildLoader = (tag: string) =>
+const buildLoader = (tag: string, mtimeMs: number) =>
   unstable_cache(
     async (userId: string): Promise<Transaction[]> => {
       const journal = await journalService.listTransactions(userId);
       return journal.transactions;
     },
-    ['journal-transactions', tag],
+    ['journal-transactions', tag, String(mtimeMs)],
     { revalidate: 60, tags: [tag] }
   );
 
-const loadTransactions = (userId: string) =>
-  buildLoader(getJournalCacheTag(userId))(userId);
+const loadTransactions = async (userId: string) => {
+  const mtimeMs = await journalRepository.getMaxMtime(userId);
+  return buildLoader(getJournalCacheTag(userId), mtimeMs)(userId);
+};
 
 const applyFilters = (txs: Transaction[], params: SearchParams) => {
   const start = params.start ? Date.parse(params.start) : null;

--- a/lib/journal/repository.test.ts
+++ b/lib/journal/repository.test.ts
@@ -1,0 +1,106 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+import * as schema from '@/db/schema';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+const insertTestUser = (ctx: TestDbContext) => {
+  ctx.sqlite
+    .prepare(`INSERT INTO "user" ("id","name","email") VALUES (?,?,?)`)
+    .run('test-user', 'Test', 'test@example.com');
+};
+
+describe('JournalRepository.getMaxMtime', () => {
+  let ctx: TestDbContext;
+  let repo: JournalRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('repo-mtime-');
+    insertTestUser(ctx);
+    const db = drizzle(ctx.sqlite, { schema });
+    repo = new JournalRepository(db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('returns the stub file mtime for a brand-new user (calls ensureLayout)', async () => {
+    const mtime = await repo.getMaxMtime('test-user');
+    expect(mtime).toBeGreaterThan(0);
+  });
+
+  it('returns the main file mtime when there are no includes', async () => {
+    const userId = 'test-user';
+    await repo.ensureLayout(userId);
+    const mainPath = path.join(getJournalDir(userId), 'main.ledger');
+    const target = 1_700_000_000_000;
+    await fs.utimes(mainPath, new Date(target), new Date(target));
+    const mtime = await repo.getMaxMtime(userId);
+    expect(mtime).toBe(target);
+  });
+
+  it('returns the max mtime across the include graph', async () => {
+    const userId = 'test-user';
+    const dir = getJournalDir(userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'main.ledger'),
+      'include ./sub.ledger\n\n2024-01-01 main\n    Expenses:Food  USD 1\n    Assets:Cash\n'
+    );
+    await fs.writeFile(
+      path.join(dir, 'sub.ledger'),
+      '2024-01-02 sub\n    Expenses:Food  USD 2\n    Assets:Cash\n'
+    );
+    const older = 1_700_000_000_000;
+    const newer = 1_800_000_000_000;
+    await fs.utimes(
+      path.join(dir, 'main.ledger'),
+      new Date(older),
+      new Date(older)
+    );
+    await fs.utimes(
+      path.join(dir, 'sub.ledger'),
+      new Date(newer),
+      new Date(newer)
+    );
+
+    const mtime = await repo.getMaxMtime(userId);
+    expect(mtime).toBe(newer);
+  });
+
+  it('reflects a sub-file change on the next call', async () => {
+    const userId = 'test-user';
+    const dir = getJournalDir(userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), 'include ./sub.ledger\n');
+    await fs.writeFile(path.join(dir, 'sub.ledger'), '');
+    const first = 1_700_000_000_000;
+    await fs.utimes(
+      path.join(dir, 'main.ledger'),
+      new Date(first),
+      new Date(first)
+    );
+    await fs.utimes(
+      path.join(dir, 'sub.ledger'),
+      new Date(first),
+      new Date(first)
+    );
+    expect(await repo.getMaxMtime(userId)).toBe(first);
+
+    const later = 1_800_000_000_000;
+    await fs.utimes(
+      path.join(dir, 'sub.ledger'),
+      new Date(later),
+      new Date(later)
+    );
+    expect(await repo.getMaxMtime(userId)).toBe(later);
+  });
+});

--- a/lib/journal/repository.ts
+++ b/lib/journal/repository.ts
@@ -2,7 +2,12 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { eq } from 'drizzle-orm';
 import { DEFAULT_MAIN, PRICE_DB_NAME, getJournalDir } from './layout';
-import { parseJournal, type ParsedJournal, type Transaction } from './parser';
+import {
+  parseJournal,
+  resolveIncludes,
+  type ParsedJournal,
+  type Transaction,
+} from './parser';
 import { user as userTable } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
 
@@ -98,6 +103,16 @@ export class JournalRepository {
   async find(userId: string, uid: string): Promise<Transaction | null> {
     const { transactions } = await this.list(userId);
     return transactions.find((t) => t.uid === uid) ?? null;
+  }
+
+  /** Returns max mtimeMs across the user's include graph. Used as a cache-key
+   * input so any file change (internal or external) invalidates `unstable_cache`. */
+  async getMaxMtime(userId: string): Promise<number> {
+    const { mainPath } = await this.ensureLayout(userId);
+    const files = await resolveIncludes(mainPath);
+    if (files.length === 0) return 0;
+    const stats = await Promise.all(files.map((f) => fs.stat(f)));
+    return Math.max(...stats.map((s) => s.mtimeMs));
   }
 
   private async findPriceDb(dir: string): Promise<string | null> {

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_MAIN,
   PRICE_DB_NAME,
   VALID_EXTS,
-  getJournalCacheTag,
   getJournalDir,
 } from './layout';
 import { withUserLock } from './mutex';
@@ -24,7 +23,7 @@ import {
   transactionDraftSchema,
   type TransactionDraft,
 } from '@/lib/transactions/schema';
-import { revalidatePath, updateTag } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 
 const HEADER_START_REGEX = /^\d{4}[-/]\d{2}[-/]\d{2}/;
 const PATH_TRAVERSAL = /(^|[/\\])\.\.([/\\]|$)/;
@@ -67,11 +66,14 @@ export type BackfillResult = {
   uidsAdded: number;
 };
 
-const invalidateCache = (userId: string) => {
+const invalidateCache = (_userId: string) => {
   // Cache invalidation is best-effort outside the Next.js runtime context
-  // (e.g. inside vitest); inside Next, updateTag + revalidatePath fire normally.
+  // (e.g. inside vitest); inside Next, revalidatePath fires normally.
+  //
+  // The journal's max mtime is part of every cache key (see runLedger and
+  // Transactions.tsx), so any file change implicitly invalidates the data
+  // cache. revalidatePath here forces the RSC payload re-render.
   try {
-    updateTag(getJournalCacheTag(userId));
     revalidatePath('/', 'layout');
   } catch {
     // no-op outside Next.js
@@ -195,6 +197,7 @@ export class JournalService {
     await fs.writeFile(path.join(dir, DEFAULT_MAIN), content);
     await this.repo.setMainFile(userId, DEFAULT_MAIN);
     const backfill = await this.backfillUids(userId);
+    invalidateCache(userId);
     return { uidsAdded: backfill.uidsAdded };
   }
 
@@ -231,6 +234,7 @@ export class JournalService {
     const mainFile = detectMain(entries.map((e) => ({ name: e.entryName })));
     await this.repo.setMainFile(userId, mainFile);
     const backfill = await this.backfillUids(userId);
+    invalidateCache(userId);
     return {
       mainFile,
       fileCount: entries.length,

--- a/utils/runLedger.ts
+++ b/utils/runLedger.ts
@@ -30,10 +30,10 @@ const runLedger = async (
 ): Promise<string> => {
   await connection();
   const user = await requireUser();
-  const { mainPath, priceDbPath } = await journalRepository.ensureLayout(
-    user.id
-  );
+  // `getMaxMtime` calls `ensureLayout` internally — we then use the cheaper
+  // `getLayout` for the actual path, avoiding a duplicate mkdir+access.
   const mtimeMs = await journalRepository.getMaxMtime(user.id);
+  const { mainPath, priceDbPath } = await journalRepository.getLayout(user.id);
 
   const baseArgs: string[] = ['--file', mainPath];
   if (priceDbPath) baseArgs.push('--price-db', priceDbPath);

--- a/utils/runLedger.ts
+++ b/utils/runLedger.ts
@@ -10,13 +10,13 @@ const execFilePromise = promisify(execFile);
 
 const LEDGER_CACHE_TTL_SECONDS = 60;
 
-const buildExecLedger = (tag: string) =>
+const buildExecLedger = (tag: string, mtimeMs: number) =>
   unstable_cache(
     async (allArgs: string[]): Promise<string> => {
       const { stdout } = await execFilePromise('ledger', allArgs);
       return stdout;
     },
-    ['ledger-cli-exec', tag],
+    ['ledger-cli-exec', tag, String(mtimeMs)],
     { revalidate: LEDGER_CACHE_TTL_SECONDS, tags: [tag] }
   );
 
@@ -33,12 +33,13 @@ const runLedger = async (
   const { mainPath, priceDbPath } = await journalRepository.ensureLayout(
     user.id
   );
+  const mtimeMs = await journalRepository.getMaxMtime(user.id);
 
   const baseArgs: string[] = ['--file', mainPath];
   if (priceDbPath) baseArgs.push('--price-db', priceDbPath);
   if (options?.sortByDate ?? true) baseArgs.push('--sort', '-date');
 
-  const execLedger = buildExecLedger(getJournalCacheTag(user.id));
+  const execLedger = buildExecLedger(getJournalCacheTag(user.id), mtimeMs);
   return execLedger([...baseArgs, ...args]);
 };
 


### PR DESCRIPTION
## Summary

Phase 4.3 of `PLAN.md`. The journal's max mtime now joins every `unstable_cache` key, so any file change — internal mutation or external edit — invalidates the data cache immediately. The 60s TTL becomes pure memory-pressure safety, no longer a correctness window.

- **`JournalRepository.getMaxMtime(userId)`** — walks the include graph via `resolveIncludes`, returns max `mtimeMs`. 4 new tests.
- **`utils/runLedger.ts`** — mtime joins `keyParts`. Layout resolved via cheaper `getLayout` after `getMaxMtime` has already ensured it.
- **`features/transactions/Transactions.tsx`** — same treatment for the list-view loader.
- **`JournalService.invalidateCache`** — drops redundant `updateTag` (mtime key supersedes). `revalidatePath('/', 'layout')` stays for the RSC payload cache. `replaceFromSingleFile` and `replaceFromZip` now call it themselves.
- **`app/api/upload/route.ts`** — drops two redundant `revalidatePath` calls.

Plan item 2 ("drop caching entirely") parked: mtime-keyed invalidation supersedes it.
Plan item 3 audited: `revalidatePath('/', 'layout')` is sufficient; the cleanup above removed the only duplicate caller.

Spec: `docs/superpowers/specs/2026-05-20-phase-4-3-cache-design.md`
Plan: `docs/superpowers/plans/2026-05-20-phase-4-3-cache.md`
Also adds a Phase 5.3 bullet to track post-write `ledger` verification.

## Test plan

- [ ] CI green (lint / type-check / 88 tests).
- [ ] Manual: `pnpm dev`, add a transaction → `/balance` reflects it on next render with no TTL wait.
- [ ] Manual: edit the journal in vim → next report page shows fresh data immediately.
- [ ] Manual: `/transactions` list reflects edits/deletes immediately.