### PR TITLE
fix: Phase 5.1 — amount parsing + plan housekeeping

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -164,9 +164,9 @@ Pay down what's already known to be wrong before adding more surface area.
 
 ### 5.1 From `TODO.md`
 
-- [ ] Delete orphan `FileUpload` component (no UI references it) — `components/FileUpload/FileUpload.tsx` already shows as deleted in `git status`, just commit
-- [ ] Fix amount parsing fragility in `/registers/monthly/[account]` — `each.split('|')[1].split(' ')[1]` assumes `<unit> <amount>` shape, breaks for unit-less amounts
-- [ ] ESLint 10 upgrade — revisit when `eslint-plugin-react` lands a compatible release
+- [x] Delete orphan `FileUpload` component _(landed earlier — verified absent in main; the bullet in `TODO.md` was already stale by the time this phase opened)_
+- [x] Fix amount parsing fragility in `/registers/monthly/[account]` _(replaced the brittle `split(' ')[1]` with a regex-based `parseAmountColumn` helper in `utils/parseAmountColumn.ts`; 8 unit tests cover unit-less amounts, currency-prefix/suffix orderings, comma thousands, and the null/garbage fallback)_
+- [ ] ESLint 10 upgrade — revisit when `eslint-plugin-react` lands a compatible release _(still blocked on upstream)_
 
 ### 5.2 Tests
 

--- a/app/registers/monthly/[account]/page.tsx
+++ b/app/registers/monthly/[account]/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import formatAmount from '@/utils/formatAmount';
 import formatDate, { Format } from '@/utils/formatDate';
 import getDefaultCurrency from '@/utils/getDefaultCurrency';
+import parseAmountColumn from '@/utils/parseAmountColumn';
 import runLedger from '@/utils/runLedger';
 import isValidAccount from '@/utils/validateAccount';
 import { notFound } from 'next/navigation';
@@ -102,9 +103,7 @@ const Monthly = async ({
                 const [date, raw] = each.split('|');
                 return {
                   month: formatDate(date, Format.SHORT_MONTH_YEAR),
-                  balance: Number(
-                    (raw.split(' ')[1] ?? '0').replaceAll(',', '')
-                  ),
+                  balance: parseAmountColumn(raw),
                 };
               })}
               xKey="month"

--- a/utils/parseAmountColumn.test.ts
+++ b/utils/parseAmountColumn.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { parseAmountColumn } from './parseAmountColumn';
+
+describe('parseAmountColumn', () => {
+  it('extracts a unit-less amount', () => {
+    expect(parseAmountColumn('100')).toBe(100);
+  });
+
+  it('extracts amount with currency prefix and space', () => {
+    expect(parseAmountColumn('USD 100')).toBe(100);
+  });
+
+  it('extracts amount with currency suffix and space', () => {
+    expect(parseAmountColumn('100 USD')).toBe(100);
+  });
+
+  it('extracts amount with currency symbol prefix (no space)', () => {
+    expect(parseAmountColumn('$100')).toBe(100);
+  });
+
+  it('strips comma thousands separators', () => {
+    expect(parseAmountColumn('-1,234.56 USD')).toBe(-1234.56);
+  });
+
+  it('handles negative amounts', () => {
+    expect(parseAmountColumn('USD -42.50')).toBe(-42.5);
+  });
+
+  it('returns 0 for null / undefined / empty', () => {
+    expect(parseAmountColumn(null)).toBe(0);
+    expect(parseAmountColumn(undefined)).toBe(0);
+    expect(parseAmountColumn('')).toBe(0);
+  });
+
+  it('returns 0 when no numeric token is present', () => {
+    expect(parseAmountColumn('no digits here')).toBe(0);
+  });
+});

--- a/utils/parseAmountColumn.ts
+++ b/utils/parseAmountColumn.ts
@@ -1,0 +1,24 @@
+/**
+ * Extract a JS number from the numeric portion of a ledger `%t`-formatted
+ * amount column. Tolerates the three shapes ledger emits in practice:
+ *
+ *   "USD 100"   → 100
+ *   "100 USD"   → 100
+ *   "$100"      → 100
+ *   "100"       → 100
+ *   "-1,234.56" → -1234.56
+ *
+ * Returns 0 when no numeric token is present (empty cell, garbage input).
+ */
+const NUMERIC_REGEX = /-?[\d,]+(?:\.\d+)?/;
+
+export const parseAmountColumn = (raw: string | null | undefined): number => {
+  if (!raw) return 0;
+  const match = raw.match(NUMERIC_REGEX);
+  if (!match) return 0;
+  const cleaned = match[0].replaceAll(',', '');
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : 0;
+};
+
+export default parseAmountColumn;


### PR DESCRIPTION
## Summary

Phase 5.1 of \`PLAN.md\` — two of three bullets land here, one stays parked.

- **Amount parsing fragility** in \`app/registers/monthly/[account]/page.tsx\`. The chart's bar values came from \`raw.split(' ')[1]\` on a ledger \`%t\` column, which assumes a space-separated \`<unit> <amount>\` shape. Breaks silently (drops to 0) for unit-less amounts and for currency-symbol prefixes like \`\$100\`. Replaced with a regex-based \`parseAmountColumn\` helper in \`utils/parseAmountColumn.ts\` that pulls the first signed numeric token regardless of position, strips comma thousands, and returns 0 for empty/garbage input. 8 unit tests cover all five shapes ledger emits in practice.
- **FileUpload orphan component** — already removed from \`main\` (history confirms); the bullet was stale. Ticked off in PLAN.md.
- **ESLint 10 upgrade** stays blocked on upstream \`eslint-plugin-react\`.

96 tests pass (was 88). Type-check + lint clean.

## Test plan

- [ ] CI green (lint / type-check / 96 tests).
- [ ] Manual: visit \`/registers/monthly/<some-account>\`; chart renders correct bar values for each month (no zero-stub bars).
- [ ] Manual smoke against an account whose ledger emits unit-less amounts (e.g., \`-X\` currency conversion that produces a pure-number column).