### PR TITLE
test: Phase 5.2 — unit tests for pure helpers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -168,18 +168,18 @@ Pay down what's already known to be wrong before adding more surface area.
 - [ ] Fix amount parsing fragility in `/registers/monthly/[account]` — `each.split('|')[1].split(' ')[1]` assumes `<unit> <amount>` shape, breaks for unit-less amounts
 - [ ] ESLint 10 upgrade — revisit when `eslint-plugin-react` lands a compatible release
 
-### 5.2 Tests
+### 5.2 Tests _(mostly complete)_
 
 Bring in Vitest and cover the pure functions first (no `ledger` shell-out needed):
 
-- [ ] `Dashboard.utils#getHighestExpense`
-- [ ] `Accounts.utils#buildTree`
-- [ ] `MonthlyComparison.utils#getCashFlow`
-- [ ] `Reconcile#parseRows`
-- [ ] `validateAccount`
-- [ ] `formatAmount` / `formatDate`
-- [ ] Journal helpers: `detectMain`, `replaceJournalFromZip` path-traversal guard
-- [ ] `addTransaction` round-trip (write → re-read via `ledger reg`)
+- [x] `Dashboard.utils#getHighestExpense`
+- [x] `Accounts.utils#buildTree`
+- [ ] `MonthlyComparison.utils#getCashFlow` _(shells out to ledger; deferred — would need a `runLedger` mock to be worth writing)_
+- [x] `Reconcile#parseRows` _(extracted from `Reconcile.tsx` to `Reconcile.utils.ts` so it can be unit-tested)_
+- [x] `validateAccount`
+- [x] `formatAmount` _(via `renderToStaticMarkup` since it returns JSX)_ / `formatDate`
+- [x] Journal helpers: `detectMain` _(exercised via `replaceFromZip` happy paths)_; `replaceJournalFromZip` path-traversal guard _(see note below — adm-zip normalizes input names, so this is tracked for Phase 7 to test via a hand-crafted malicious zip fixture)_
+- [ ] `addTransaction` round-trip _(already covered by `JournalService` tests merged in Phase 4.2)_
 
 ### 5.3 Errors & UX rough edges
 

--- a/features/accounts/Accounts.utils.test.ts
+++ b/features/accounts/Accounts.utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildTree } from './Accounts.utils';
+
+describe('buildTree', () => {
+  it('returns an empty object for no accounts', () => {
+    expect(buildTree([])).toEqual({});
+  });
+
+  it('builds a flat tree for top-level accounts', () => {
+    expect(buildTree(['Cash', 'Bank'])).toEqual({
+      Cash: {},
+      Bank: {},
+    });
+  });
+
+  it('builds a nested tree from colon-separated segments', () => {
+    expect(buildTree(['Expenses:Food', 'Expenses:Rent'])).toEqual({
+      Expenses: { Food: {}, Rent: {} },
+    });
+  });
+
+  it('merges multi-level paths under shared ancestors', () => {
+    const result = buildTree([
+      'Assets:Bank:Checking',
+      'Assets:Bank:Savings',
+      'Assets:Cash',
+    ]);
+    expect(result).toEqual({
+      Assets: {
+        Bank: { Checking: {}, Savings: {} },
+        Cash: {},
+      },
+    });
+  });
+
+  it('is idempotent across duplicate inputs', () => {
+    const a = buildTree(['Expenses:Food', 'Expenses:Food']);
+    const b = buildTree(['Expenses:Food']);
+    expect(a).toEqual(b);
+  });
+});

--- a/features/dashboard/Dashboard.utils.test.ts
+++ b/features/dashboard/Dashboard.utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { getHighestExpense } from './Dashboard.utils';
+
+describe('getHighestExpense', () => {
+  it('picks the largest row by amount', () => {
+    const stdout = [
+      'Expenses:Food|USD 42.00',
+      'Expenses:Rent|USD 1500',
+      'Expenses:Coffee|USD 7.50',
+      '',
+    ].join('\n');
+    expect(getHighestExpense(stdout)).toBe('Expenses:Rent|USD 1500');
+  });
+
+  it('handles comma thousands separators', () => {
+    const stdout = [
+      'Expenses:Food|USD 1,500',
+      'Expenses:Rent|USD 999',
+      '',
+    ].join('\n');
+    expect(getHighestExpense(stdout)).toBe('Expenses:Food|USD 1,500');
+  });
+
+  it('returns empty string when no rows have an amount', () => {
+    expect(getHighestExpense('')).toBe('');
+    expect(getHighestExpense('\n\n')).toBe('');
+  });
+
+  it('skips rows whose amount field is malformed', () => {
+    const stdout = ['Expenses:Food|garbage', 'Expenses:Rent|USD 100', ''].join(
+      '\n'
+    );
+    expect(getHighestExpense(stdout)).toBe('Expenses:Rent|USD 100');
+  });
+});

--- a/features/reconcile/Reconcile.tsx
+++ b/features/reconcile/Reconcile.tsx
@@ -1,3 +1,4 @@
+import { parseReconcileRows } from './Reconcile.utils';
 import Help from '@/components/Help';
 import formatAmount from '@/utils/formatAmount';
 import formatDate, { Format } from '@/utils/formatDate';
@@ -7,28 +8,6 @@ import Link from 'next/link';
 
 const STALE_DAYS = 30;
 
-type Row = {
-  date: string;
-  payee: string;
-  account: string;
-  amount: string;
-  days: number;
-};
-
-const parseRows = (stdout: string): Row[] => {
-  const today = Date.now();
-  return stdout
-    .split('NNN')
-    .map((line) => line.split('|').map((s) => s.trim()))
-    .filter((cols) => cols.length >= 4 && cols[0])
-    .map(([date, payee, account, amount]) => {
-      const d = new Date(date);
-      const days = Math.floor((today - d.getTime()) / 86_400_000);
-      return { date, payee, account, amount, days };
-    })
-    .sort((a, b) => b.days - a.days);
-};
-
 const Reconcile = async () => {
   const currency = getDefaultCurrency() ?? 'USD';
   const stdout = await runLedger(
@@ -36,7 +15,7 @@ const Reconcile = async () => {
     { sortByDate: false }
   );
 
-  const rows = parseRows(stdout);
+  const rows = parseReconcileRows(stdout);
 
   const stale = rows.filter((r) => r.days > STALE_DAYS).length;
 

--- a/features/reconcile/Reconcile.utils.test.ts
+++ b/features/reconcile/Reconcile.utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { parseReconcileRows } from './Reconcile.utils';
+
+const NOW = Date.UTC(2026, 4, 22);
+
+describe('parseReconcileRows', () => {
+  it('returns an empty array for empty stdout', () => {
+    expect(parseReconcileRows('', NOW)).toEqual([]);
+  });
+
+  it('parses NNN-delimited rows into typed records', () => {
+    const stdout =
+      "NNN2026-05-01|Trader Joe's|Expenses:Food|USD 42\n" +
+      'NNN2026-05-15|Landlord|Expenses:Rent|USD 1500\n';
+    const rows = parseReconcileRows(stdout, NOW);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].account).toBe('Expenses:Food');
+    expect(rows[1].account).toBe('Expenses:Rent');
+  });
+
+  it('sorts oldest first (largest days first)', () => {
+    const stdout =
+      'NNN2026-05-15|recent|Expenses:Coffee|USD 5\n' +
+      'NNN2026-01-01|old|Expenses:Rent|USD 1500\n';
+    const rows = parseReconcileRows(stdout, NOW);
+    expect(rows[0].account).toBe('Expenses:Rent');
+    expect(rows[1].account).toBe('Expenses:Coffee');
+    expect(rows[0].days).toBeGreaterThan(rows[1].days);
+  });
+
+  it('computes days since the row date', () => {
+    const stdout = 'NNN2026-05-15|x|Expenses:Coffee|USD 5\n';
+    const rows = parseReconcileRows(stdout, NOW);
+    expect(rows[0].days).toBe(7);
+  });
+
+  it('skips malformed rows', () => {
+    const stdout =
+      'NNN\n' + // empty date column
+      'NNN2026-05-15|||\n' + // valid (empty payee/account/amount but date present)
+      'NNN2026-05-01|p|a|amt\n';
+    const rows = parseReconcileRows(stdout, NOW);
+    // The fully empty entry is filtered; the others keep going.
+    expect(rows.every((r) => r.date)).toBe(true);
+  });
+
+  it('trims whitespace from columns', () => {
+    const stdout = 'NNN 2026-05-01 |  payee  | account | amount\n';
+    const rows = parseReconcileRows(stdout, NOW);
+    expect(rows[0].payee).toBe('payee');
+    expect(rows[0].account).toBe('account');
+    expect(rows[0].amount).toBe('amount');
+  });
+});

--- a/features/reconcile/Reconcile.utils.ts
+++ b/features/reconcile/Reconcile.utils.ts
@@ -1,0 +1,29 @@
+export type ReconcileRow = {
+  date: string;
+  payee: string;
+  account: string;
+  amount: string;
+  /** Days since `date`, inclusive of today. */
+  days: number;
+};
+
+/**
+ * Parses the `NNN%D|%P|%A|%t\n` output of `ledger reg --uncleared` into typed
+ * rows, dropping malformed lines and sorting oldest-first. `now` is injected
+ * so the `days` field is deterministic in tests.
+ */
+export const parseReconcileRows = (
+  stdout: string,
+  now: number = Date.now()
+): ReconcileRow[] => {
+  return stdout
+    .split('NNN')
+    .map((line) => line.split('|').map((s) => s.trim()))
+    .filter((cols) => cols.length >= 4 && cols[0])
+    .map(([date, payee, account, amount]) => {
+      const d = new Date(date);
+      const days = Math.floor((now - d.getTime()) / 86_400_000);
+      return { date, payee, account, amount, days };
+    })
+    .sort((a, b) => b.days - a.days);
+};

--- a/lib/journal/service-zip.test.ts
+++ b/lib/journal/service-zip.test.ts
@@ -1,0 +1,125 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import AdmZip from 'adm-zip';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+import { JournalService } from './service';
+import * as schema from '@/db/schema';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+const insertTestUser = (ctx: TestDbContext) => {
+  ctx.sqlite
+    .prepare(`INSERT INTO "user" ("id","name","email") VALUES (?,?,?)`)
+    .run('test-user', 'Test', 'test@example.com');
+};
+
+const buildZip = (
+  entries: Array<{ name: string; content: string }>
+): Buffer => {
+  const zip = new AdmZip();
+  for (const { name, content } of entries) {
+    zip.addFile(name, Buffer.from(content, 'utf-8'));
+  }
+  return zip.toBuffer();
+};
+
+describe('JournalService.replaceFromZip', () => {
+  let ctx: TestDbContext;
+  let service: JournalService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('zip-');
+    insertTestUser(ctx);
+    const db = drizzle(ctx.sqlite, { schema });
+    service = new JournalService(new JournalRepository(db));
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  describe('detectMain', () => {
+    it('picks main.ledger when present', async () => {
+      const zip = buildZip([
+        { name: 'main.ledger', content: '2024-01-01 a\n    A  USD 1\n    B\n' },
+        {
+          name: 'other.ledger',
+          content: '2024-01-02 b\n    A  USD 2\n    B\n',
+        },
+      ]);
+      const result = await service.replaceFromZip('test-user', zip);
+      expect(result.mainFile).toBe('main.ledger');
+    });
+
+    it('picks ledger.ledger when main.ledger is absent', async () => {
+      const zip = buildZip([
+        { name: 'ledger.ledger', content: '' },
+        { name: 'extra.ledger', content: '' },
+      ]);
+      const result = await service.replaceFromZip('test-user', zip);
+      expect(result.mainFile).toBe('ledger.ledger');
+    });
+
+    it('falls back to the shallowest .ledger file when no preferred name matches', async () => {
+      const zip = buildZip([
+        { name: 'deep/nested/foo.ledger', content: '' },
+        { name: 'shallow.ledger', content: '' },
+      ]);
+      const result = await service.replaceFromZip('test-user', zip);
+      expect(result.mainFile).toBe('shallow.ledger');
+    });
+
+    it('skips price-db.ledger when picking a shallowest fallback', async () => {
+      const zip = buildZip([
+        { name: 'price-db.ledger', content: '' },
+        { name: 'whatever.ledger', content: '' },
+      ]);
+      const result = await service.replaceFromZip('test-user', zip);
+      expect(result.mainFile).toBe('whatever.ledger');
+    });
+
+    it('breaks shallow-depth ties alphabetically', async () => {
+      const zip = buildZip([
+        { name: 'b.ledger', content: '' },
+        { name: 'a.ledger', content: '' },
+      ]);
+      const result = await service.replaceFromZip('test-user', zip);
+      expect(result.mainFile).toBe('a.ledger');
+    });
+  });
+
+  describe('path safety', () => {
+    // Note: `adm-zip.addFile()` silently normalizes entry names — `../foo`
+    // becomes `foo`, `a/../b` becomes `b`, `/etc/x` becomes `etc/x`. So we
+    // can't construct a hostile zip through the same library that reads it.
+    // The production guard in `replaceFromZip` (regex + `path.isAbsolute`
+    // + `resolved.startsWith(dir + sep)` final check) is defense-in-depth
+    // for zips built by other tools (`zip` CLI, Python's `zipfile`) that
+    // don't normalize on write. Proper coverage would require checking in
+    // a hand-crafted malicious zip fixture; tracked for Phase 7.
+
+    it('a safe zip lands every file under the user journal directory', async () => {
+      const zip = buildZip([
+        { name: 'main.ledger', content: 'include ./sub/sub.ledger\n' },
+        {
+          name: 'sub/sub.ledger',
+          content: '2024-01-01 a\n    A  USD 1\n    B\n',
+        },
+      ]);
+      await service.replaceFromZip('test-user', zip);
+      const dir = getJournalDir('test-user');
+      expect(
+        await fs.readFile(path.join(dir, 'main.ledger'), 'utf-8')
+      ).toContain('include ./sub/sub.ledger');
+      expect(
+        await fs.readFile(path.join(dir, 'sub', 'sub.ledger'), 'utf-8')
+      ).toContain('2024-01-01 a');
+    });
+  });
+});

--- a/utils/formatAmount.test.tsx
+++ b/utils/formatAmount.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import formatAmount from './formatAmount';
+
+const html = (node: React.ReactNode): string => renderToStaticMarkup(node);
+
+describe('formatAmount', () => {
+  it('renders an em-dash placeholder for empty input', () => {
+    expect(html(formatAmount('', true))).toContain('—');
+    expect(html(formatAmount(null, true))).toContain('—');
+    expect(html(formatAmount(undefined, true))).toContain('—');
+  });
+
+  it('formats a positive unit-less amount with the positive color class', () => {
+    const out = html(formatAmount('42', true));
+    expect(out).toContain('42');
+    expect(out).toContain('text-positive');
+    expect(out).not.toContain('text-negative');
+  });
+
+  it('formats a negative unit-less amount with the negative color class and parens', () => {
+    const out = html(formatAmount('-42', true));
+    expect(out).toContain('text-negative');
+    expect(out).toMatch(/\(42\.000\)/);
+  });
+
+  it('renders unit prefix when withUnit is true and stdout has a unit', () => {
+    const out = html(formatAmount('USD 100', true));
+    expect(out).toContain('USD');
+    expect(out).toContain('100');
+  });
+
+  it('omits unit prefix when withUnit is false', () => {
+    const out = html(formatAmount('USD 100', false));
+    expect(out).not.toContain('USD');
+    expect(out).toContain('100');
+  });
+
+  it('formats a negative amount with comma thousands', () => {
+    const out = html(formatAmount('USD -1234567.89', true));
+    expect(out).toContain('text-negative');
+    expect(out).toMatch(/1,234,567\.890/);
+  });
+});

--- a/utils/formatDate.test.ts
+++ b/utils/formatDate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import formatDate, { Format } from './formatDate';
+
+// Pin DATE_LOCALE so the tests don't depend on the developer's `.env`.
+let savedLocale: string | undefined;
+beforeAll(() => {
+  savedLocale = process.env.DATE_LOCALE;
+  process.env.DATE_LOCALE = 'en-US';
+});
+afterAll(() => {
+  if (savedLocale === undefined) delete process.env.DATE_LOCALE;
+  else process.env.DATE_LOCALE = savedLocale;
+});
+
+describe('formatDate', () => {
+  it('formats Format.DATE as MM/DD/YYYY (en-US)', () => {
+    expect(formatDate('2024-09-01', Format.DATE)).toBe('09/01/2024');
+  });
+
+  it('formats Format.MONTH_YEAR as long-month year (en-US)', () => {
+    expect(formatDate('2024-09-01', Format.MONTH_YEAR)).toBe('September 2024');
+  });
+
+  it('formats Format.SHORT_MONTH_YEAR as short-month year (en-US)', () => {
+    expect(formatDate('2024-09-01', Format.SHORT_MONTH_YEAR)).toBe('Sep 2024');
+  });
+
+  it('accepts a full ISO timestamp', () => {
+    expect(formatDate('2024-09-01T12:34:56Z', Format.MONTH_YEAR)).toBe(
+      'September 2024'
+    );
+  });
+});

--- a/utils/validateAccount.test.ts
+++ b/utils/validateAccount.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import isValidAccount from './validateAccount';
+
+describe('isValidAccount', () => {
+  it('accepts a normal account', () => {
+    expect(isValidAccount('Expenses:Food')).toBe(true);
+  });
+
+  it('accepts a single-segment account', () => {
+    expect(isValidAccount('Cash')).toBe(true);
+  });
+
+  it('rejects empty', () => {
+    expect(isValidAccount('')).toBe(false);
+  });
+
+  it('rejects accounts starting with a hyphen', () => {
+    // Hyphen-prefixed strings look like CLI flags to ledger; reject before
+    // they reach the shell.
+    expect(isValidAccount('-foo')).toBe(false);
+  });
+
+  it('rejects accounts containing NUL or newline', () => {
+    expect(isValidAccount('foo\0bar')).toBe(false);
+    expect(isValidAccount('foo\nbar')).toBe(false);
+    expect(isValidAccount('foo\rbar')).toBe(false);
+  });
+
+  it('rejects accounts longer than 256 characters', () => {
+    expect(isValidAccount('a'.repeat(256))).toBe(true);
+    expect(isValidAccount('a'.repeat(257))).toBe(false);
+  });
+
+  it('accepts colons, slashes, dots, parentheses, spaces', () => {
+    expect(isValidAccount('Assets:Bank:Checking (US)')).toBe(true);
+    expect(isValidAccount('Expenses:Food/Groceries')).toBe(true);
+  });
+});

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,0 +1,10 @@
+// Set the env vars that `lib/env` validates at module-load time before any
+// test file's imports kick in. Individual tests that need a real journal or
+// DB still call `setupTestDb` to overwrite DATA_DIR / DATABASE_URL with a
+// tmpdir-scoped value; this file only provides safe defaults so modules
+// importing `lib/env` don't throw during test collection.
+
+process.env.BETTER_AUTH_SECRET =
+  process.env.BETTER_AUTH_SECRET ?? 'x'.repeat(32);
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? ':memory:';
+process.env.DATA_DIR = process.env.DATA_DIR ?? '/tmp/ledger-cli-ui-tests';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['**/*.test.ts'],
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+    setupFiles: ['./vitest-setup.ts'],
     coverage: {
       provider: 'v8',
       include: ['lib/journal/**/*.ts'],


### PR DESCRIPTION
## Summary

Phase 5.2 of \`PLAN.md\` — Vitest coverage for pure helpers across the codebase. 38 new tests; suite goes 88 → 126.

**New test files:**

- \`utils/validateAccount.test.ts\` (7) — account-name sanitization rules.
- \`utils/formatDate.test.ts\` (4) — three format variants under a pinned \`DATE_LOCALE\`.
- \`utils/formatAmount.test.tsx\` (6) — JSX output via \`renderToStaticMarkup\`; covers placeholder, positive/negative coloring, unit prefix toggle, comma-thousands.
- \`features/dashboard/Dashboard.utils.test.ts\` (4) — \`getHighestExpense\` over synthetic ledger stdout.
- \`features/accounts/Accounts.utils.test.ts\` (5) — \`buildTree\` shape construction.
- \`features/reconcile/Reconcile.utils.test.ts\` (6) — \`parseReconcileRows\`, extracted from the inline private helper in \`Reconcile.tsx\`. Reconcile.tsx now imports it.
- \`lib/journal/service-zip.test.ts\` (6) — \`JournalService.replaceFromZip\` detectMain ordering rules + safe-zip happy path.

**Test infra:**

- New \`vitest-setup.ts\` sets \`BETTER_AUTH_SECRET\` / \`DATA_DIR\` / \`DATABASE_URL\` defaults so test files that transitively touch \`lib/env\` at module-load time don't trip the Zod validator before the test runs. Wired via \`vitest.config.ts\` \`setupFiles\`.
- \`vitest.config.ts\` \`include\` now also matches \`**/*.test.tsx\`.

**Plan items not landed (with reasons in PLAN.md):**

- \`MonthlyComparison#getCashFlow\` — shells out to ledger; would need a runLedger mock. Deferred.
- \`addTransaction\` round-trip — already covered by \`JournalService\` tests merged in Phase 4.2.
- \`replaceFromZip\` path-traversal guard — adm-zip silently normalizes entry names on \`addFile\` (verified empirically: \`../foo\` → \`foo\`, \`/etc/x\` → \`etc/x\`, \`a/../b\` → \`b\`), so the regex/isAbsolute layer can't be exercised through the same library that reads the zip. Production guard (3-layer, ending in \`path.resolve\` + \`startsWith\`) remains defense-in-depth for non-adm-zip uploads. Tracked for Phase 7 via a hand-crafted malicious fixture.

## Test plan

- [ ] CI green (lint / type-check / 126 tests).
- [ ] Manual: \`/reconcile\` still renders correctly after the \`parseRows\` → \`parseReconcileRows\` extraction (the only behavior-affecting refactor in this PR).