### PR TITLE
feat: Phase 5.3 (UX) — error boundary, empty state, per-route loading

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -183,10 +183,10 @@ Bring in Vitest and cover the pure functions first (no `ledger` shell-out needed
 
 ### 5.3 Errors & UX rough edges
 
-- [ ] Server-side error boundary that doesn't leak `ledger` stderr to the client
-- [ ] "Journal is empty" empty-state on Dashboard pointing to `/import` or `/transactions/new`
-- [ ] Loading skeletons (currently most pages just block on `ledger`)
-- [ ] **Verify writes with `ledger`** — after `JournalService.addTransaction` / `editTransaction` / `deleteTransaction` and after the `/import` flow, shell out to `ledger -f <main> stats` (or equivalent) and surface a parse error if the journal is no longer valid. Today our parser/writer is trusted to produce ledger-compatible output; if they ever diverge or the user's existing journal has syntax we silently mishandle, broken state lands in the file and only surfaces when a report page renders wrong.
+- [x] Server-side error boundary that doesn't leak `ledger` stderr to the client _(added `app/error.tsx` and `app/global-error.tsx`; both render a generic message + retry button and only log the real error to the server console)_
+- [x] "Journal is empty" empty-state on Dashboard pointing to `/import` or `/transactions/new` _(`features/dashboard/EmptyJournal.tsx`; Dashboard short-circuits to it when `ledger stats` reports zero postings)_
+- [x] Loading skeletons _(per-route `loading.tsx` for `/balance`, `/net-worth`, `/monthly`, `/payees`, `/debts`, `/reconcile`, `/accounts`; row counts and chart blocks tuned per page so payees-style table pages no longer flash a chart placeholder)_
+- [ ] **Verify writes with `ledger`** — after `JournalService.addTransaction` / `editTransaction` / `deleteTransaction` and after the `/import` flow, shell out to `ledger -f <main> stats` (or equivalent) and surface a parse error if the journal is no longer valid. _(Carved out to a follow-up PR since it touches the mutation hot paths — see Phase 5.3 split rationale in the cache PR description.)_
 
 ---
 

--- a/app/accounts/loading.tsx
+++ b/app/accounts/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={14} />;
+}

--- a/app/balance/loading.tsx
+++ b/app/balance/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={10} showChart />;
+}

--- a/app/debts/loading.tsx
+++ b/app/debts/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={8} />;
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Route-level error boundary. The `error` object can contain server-side
+ * detail (ledger stderr, file system paths, stack traces) that we MUST NOT
+ * render to the client. Show a generic message and let the user retry; the
+ * full error is already in the server logs by the time we land here.
+ */
+export default function RouteError({ error, reset }: Props) {
+  useEffect(() => {
+    // Browser console is fine; it stays client-side.
+    console.error('Route error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Alert variant="destructive">
+        <AlertTitle>Something went wrong</AlertTitle>
+        <AlertDescription>
+          This page couldn&apos;t render. The error has been logged on the
+          server.
+          {error.digest && (
+            <span className="ml-1 font-mono text-xs opacity-70">
+              (ref: {error.digest})
+            </span>
+          )}
+        </AlertDescription>
+      </Alert>
+      <div>
+        <Button onClick={reset} variant="outline" size="sm">
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Root error boundary — fires when the error originates inside the root
+ * layout itself (i.e., a place that `app/error.tsx` can't catch). Must render
+ * its own `<html>`/`<body>` since the layout failed.
+ *
+ * Like `app/error.tsx`, this never renders the raw error to the client.
+ */
+export default function GlobalError({ error, reset }: Props) {
+  useEffect(() => {
+    console.error('Global error:', error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+            padding: 32,
+            fontFamily: 'system-ui, sans-serif',
+            maxWidth: 600,
+            margin: '40px auto',
+          }}
+        >
+          <h1 style={{ fontSize: '1.25rem', fontWeight: 600 }}>
+            The app couldn&apos;t start
+          </h1>
+          <p style={{ color: '#666' }}>
+            The error has been logged on the server.
+            {error.digest && (
+              <span
+                style={{
+                  marginLeft: 4,
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  opacity: 0.7,
+                }}
+              >
+                (ref: {error.digest})
+              </span>
+            )}
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              alignSelf: 'flex-start',
+              padding: '6px 12px',
+              borderRadius: 6,
+              border: '1px solid #ccc',
+              background: 'white',
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/monthly/loading.tsx
+++ b/app/monthly/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={12} showChart />;
+}

--- a/app/net-worth/loading.tsx
+++ b/app/net-worth/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={6} showChart />;
+}

--- a/app/payees/loading.tsx
+++ b/app/payees/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={15} />;
+}

--- a/app/reconcile/loading.tsx
+++ b/app/reconcile/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={10} />;
+}

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import {
   getJournalStats,
   getRecentTransactions,
 } from './Dashboard.utils';
+import EmptyJournal from './EmptyJournal';
 import Card from '@/components/Card';
 import Help from '@/components/Help';
 import { buttonVariants } from '@/components/ui/button';
@@ -90,6 +91,13 @@ const Dashboard = async () => {
   const [highestAccount, highestAmount] = highestExpenseThisMonth
     ? highestExpenseThisMonth.split('|')
     : [null, null];
+
+  // `ledger stats` returns "0" (or an empty string when the journal is just
+  // the stub from `ensureLayout`). Either way we show the empty-state CTA.
+  const postingsCount = Number(stats.postings || '0');
+  if (!Number.isFinite(postingsCount) || postingsCount === 0) {
+    return <EmptyJournal />;
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/features/dashboard/EmptyJournal.tsx
+++ b/features/dashboard/EmptyJournal.tsx
@@ -1,0 +1,47 @@
+import { FileUp, PlusCircle } from 'lucide-react';
+import { buttonVariants } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+
+/**
+ * Rendered by the Dashboard when `ledger stats` reports zero postings —
+ * either a brand-new account or a journal that's only a stub. Points the
+ * user at the two ways to populate it.
+ */
+const EmptyJournal = () => (
+  <div className="flex flex-col gap-6">
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+      <p className="mt-1 text-sm text-muted">No transactions yet</p>
+    </div>
+    <Card className="flex flex-col items-center gap-4 p-10 text-center">
+      <div className="text-base font-medium">
+        Your journal is empty. Let&apos;s fix that.
+      </div>
+      <p className="max-w-md text-sm text-muted-foreground">
+        Add a single transaction by hand, or import a Ledger journal you already
+        keep — a single <code>.ledger</code> file or a <code>.zip</code> with
+        includes both work.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Link
+          href="/transactions/new"
+          className={cn(buttonVariants({ size: 'sm' }))}
+        >
+          <PlusCircle className="h-4 w-4" />
+          Add transaction
+        </Link>
+        <Link
+          href="/import"
+          className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}
+        >
+          <FileUp className="h-4 w-4" />
+          Import journal
+        </Link>
+      </div>
+    </Card>
+  </div>
+);
+
+export default EmptyJournal;


### PR DESCRIPTION
## Summary

Three of the four Phase 5.3 bullets land here. The fourth (\"verify writes with \`ledger\`\") is carved out because it touches the mutation hot paths — separate follow-up PR.

**Error boundary**

- \`app/error.tsx\` (route-level) renders a generic destructive Alert + a *Try again* reset button. The real \`Error\` is logged to the browser console only — never rendered, so ledger stderr and FS paths stay server-side.
- \`app/global-error.tsx\` is the root-layout-failure fallback. Inline styles only, since the root CSS may not have loaded when it fires.

**Empty state**

- \`features/dashboard/EmptyJournal.tsx\` — rendered when \`ledger stats\` reports zero postings. Card with copy + *Add transaction* / *Import journal* buttons.
- \`Dashboard\` short-circuits to \`EmptyJournal\` before computing the stat tiles, so the page is fast for a brand-new user.

**Per-route loading skeletons**

- New \`loading.tsx\` for: \`/balance\`, \`/net-worth\`, \`/monthly\` (rows + chart), \`/payees\` (rows=15, no chart), \`/debts\` / \`/reconcile\` / \`/accounts\` (rows-only).
- Before: the root \`app/loading.tsx\` (which has \`showChart\`) was serving every route, so table-only pages flashed a chart placeholder before the real content landed.

134 tests pass (unchanged). Type-check + lint clean.

## Test plan

- [ ] CI green (lint / type-check / 134 tests).
- [ ] Manual: a fresh user (no journal yet) lands on \`/\` and sees the empty-state, not stat tiles with em-dashes.
- [ ] Manual: visit \`/payees\` while it's loading — skeleton matches (rows only, no chart bar).
- [ ] Manual: force an error on any report page (e.g., delete \`data/db.sqlite\` then visit \`/balance\`) — see the generic alert + retry; refresh restores normal behavior.