### PR TITLE
feat(transactions): csv export

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -195,7 +195,7 @@ Bring in Vitest and cover the pure functions first (no `ledger` shell-out needed
 The Tier-2/3 items from `TODO.md` that need more than a weekend.
 
 - [ ] **Budget actual-vs-target** — `ledger budget`; depends on 4.2 (templates / periodic transactions)
-- [ ] **CSV export** for any report (`ledger csv`)
+- [~] **CSV export** for any report (`ledger csv`) — `/transactions` ships with an Export CSV button that downloads the currently-filtered list as RFC 4180 CSV via `/api/transactions/export`. One row per posting (long format) for spreadsheet/pandas compatibility. Other report pages (balance / monthly / payees) don't have export buttons yet; revisit if asked.
 - [ ] **Commodity / portfolio view** (`bal Assets:Investments -X CCY`)
 - [ ] **Forecasting** (`ledger --forecast`)
 - [ ] **Saved views** — pin a filtered Payees/Register query and reach it from the Dashboard

--- a/app/api/transactions/export/route.ts
+++ b/app/api/transactions/export/route.ts
@@ -1,0 +1,45 @@
+import {
+  applyTransactionFilters,
+  type TransactionFilters,
+} from '@/features/transactions/applyTransactionFilters';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { transactionsToCsv } from '@/lib/transactions/csv';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const user = await requireUser();
+  const sp = req.nextUrl.searchParams;
+  const filters: TransactionFilters = {
+    start: sp.get('start') ?? undefined,
+    end: sp.get('end') ?? undefined,
+    account: sp.get('account') ?? undefined,
+    payee: sp.get('payee') ?? undefined,
+    q: sp.get('q') ?? undefined,
+  };
+
+  try {
+    const { transactions } = await journalService.listTransactions(user.id);
+    const filtered = applyTransactionFilters(transactions, filters).sort(
+      (a, b) => b.date.localeCompare(a.date)
+    );
+    const csv = transactionsToCsv(filtered);
+    const today = new Date().toISOString().slice(0, 10);
+    return new Response(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="transactions-${today}.csv"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (e) {
+    console.error('csv export failed', e);
+    return NextResponse.json(
+      { error: 'Could not export transactions' },
+      { status: 500 }
+    );
+  }
+}

--- a/features/transactions/Filters.tsx
+++ b/features/transactions/Filters.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { Download } from 'lucide-react';
 import { useState } from 'react';
 import Combobox from '@/components/Combobox';
 import DateFilter from '@/components/DateFilter';
-import { Button } from '@/components/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 type Props = {
@@ -40,6 +43,15 @@ const Filters = ({ payees, accounts, start, end }: Props) => {
   })();
 
   const hasFilters = q || account || payee || start || end;
+
+  // The export endpoint reuses the same filter params, so the user downloads
+  // whatever subset the table is currently showing.
+  const exportHref = (() => {
+    const u = new URLSearchParams(params.toString());
+    return (
+      '/api/transactions/export' + (u.toString() ? '?' + u.toString() : '')
+    );
+  })();
 
   return (
     <div className="flex flex-col gap-4">
@@ -94,6 +106,18 @@ const Filters = ({ payees, accounts, start, end }: Props) => {
             Clear
           </Button>
         )}
+        <Link
+          href={exportHref}
+          className={cn(
+            buttonVariants({ variant: 'outline', size: 'default' })
+          )}
+          // download is a same-origin hint; the server also sets
+          // Content-Disposition: attachment so most browsers honor it.
+          download
+        >
+          <Download className="h-4 w-4" />
+          Export CSV
+        </Link>
       </div>
     </div>
   );

--- a/features/transactions/Transactions.tsx
+++ b/features/transactions/Transactions.tsx
@@ -1,20 +1,16 @@
 import 'server-only';
 import Filters from './Filters';
 import TransactionTable from './TransactionTable';
+import {
+  applyTransactionFilters,
+  type TransactionFilters,
+} from './applyTransactionFilters';
 import Help from '@/components/Help';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalRepository, journalService } from '@/lib/journal';
 import { getJournalCacheTag } from '@/lib/journal/layout';
 import { type Transaction } from '@/lib/journal/parser';
 import { unstable_cache } from 'next/cache';
-
-type SearchParams = {
-  start?: string;
-  end?: string;
-  account?: string;
-  payee?: string;
-  q?: string;
-};
 
 const buildLoader = (tag: string, mtimeMs: number) =>
   unstable_cache(
@@ -31,41 +27,15 @@ const loadTransactions = async (userId: string) => {
   return buildLoader(getJournalCacheTag(userId), mtimeMs)(userId);
 };
 
-const applyFilters = (txs: Transaction[], params: SearchParams) => {
-  const start = params.start ? Date.parse(params.start) : null;
-  const end = params.end ? Date.parse(params.end) : null;
-  const account = params.account?.toLowerCase().trim();
-  const payee = params.payee?.toLowerCase().trim();
-  const q = params.q?.toLowerCase().trim();
-  return txs.filter((t) => {
-    const ts = Date.parse(t.date);
-    if (start !== null && ts < start) return false;
-    if (end !== null && ts > end) return false;
-    if (payee && t.payee.toLowerCase() !== payee) return false;
-    if (
-      account &&
-      !t.postings.some((p) => p.account.toLowerCase().includes(account))
-    )
-      return false;
-    if (q) {
-      const hay = [t.payee, t.note ?? '', ...t.postings.map((p) => p.account)]
-        .join(' ')
-        .toLowerCase();
-      if (!hay.includes(q)) return false;
-    }
-    return true;
-  });
-};
-
 const Transactions = async ({
   searchParams,
 }: {
-  searchParams: Promise<SearchParams>;
+  searchParams: Promise<TransactionFilters>;
 }) => {
   const user = await requireUser();
   const params = await searchParams;
   const all = await loadTransactions(user.id);
-  const filtered = applyFilters(all, params).sort((a, b) =>
+  const filtered = applyTransactionFilters(all, params).sort((a, b) =>
     b.date.localeCompare(a.date)
   );
   const payees = [...new Set(all.map((t) => t.payee))].sort();

--- a/features/transactions/applyTransactionFilters.ts
+++ b/features/transactions/applyTransactionFilters.ts
@@ -1,0 +1,45 @@
+import type { Transaction } from '@/lib/journal/parser';
+
+export type TransactionFilters = {
+  start?: string;
+  end?: string;
+  account?: string;
+  payee?: string;
+  q?: string;
+};
+
+/**
+ * Filter the user's transactions down to a search-params subset. Shared by
+ * the `/transactions` page render and the `/api/transactions/export` route
+ * so both apply identical semantics to the same query string.
+ */
+export const applyTransactionFilters = (
+  txs: Transaction[],
+  params: TransactionFilters
+): Transaction[] => {
+  const start = params.start ? Date.parse(params.start) : null;
+  const end = params.end ? Date.parse(params.end) : null;
+  const account = params.account?.toLowerCase().trim();
+  const payee = params.payee?.toLowerCase().trim();
+  const q = params.q?.toLowerCase().trim();
+
+  return txs.filter((t) => {
+    const ts = Date.parse(t.date);
+    if (start !== null && ts < start) return false;
+    if (end !== null && ts > end) return false;
+    if (payee && t.payee.toLowerCase() !== payee) return false;
+    if (
+      account &&
+      !t.postings.some((p) => p.account.toLowerCase().includes(account))
+    ) {
+      return false;
+    }
+    if (q) {
+      const hay = [t.payee, t.note ?? '', ...t.postings.map((p) => p.account)]
+        .join(' ')
+        .toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+};

--- a/lib/transactions/csv.test.ts
+++ b/lib/transactions/csv.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { transactionsToCsv } from './csv';
+import type { Transaction } from '@/lib/journal/parser';
+
+const tx = (overrides: Partial<Transaction> = {}): Transaction => ({
+  uid: '01HZX5G5KJDS9HQRYK8E5T0DJC',
+  file: '/tmp/main.ledger',
+  startLine: 1,
+  endLine: 3,
+  date: '2024-09-01',
+  payee: "Trader Joe's",
+  status: 'none',
+  note: null,
+  postings: [
+    { account: 'Expenses:Food', amount: '10', currency: 'USD' },
+    { account: 'Assets:Cash', amount: '-10', currency: 'USD' },
+  ],
+  rawBlock: '',
+  fingerprint: 'abc',
+  ...overrides,
+});
+
+describe('transactionsToCsv', () => {
+  it('emits a header row even when there are no transactions', () => {
+    expect(transactionsToCsv([])).toBe(
+      'date,payee,status,note,uid,account,amount,currency\n'
+    );
+  });
+
+  it('emits one row per posting', () => {
+    const csv = transactionsToCsv([tx()]);
+    const lines = csv.trim().split('\n');
+    expect(lines).toHaveLength(3); // header + 2 postings
+    expect(lines[1]).toContain('Expenses:Food');
+    expect(lines[1]).toContain('10');
+    expect(lines[2]).toContain('Assets:Cash');
+    expect(lines[2]).toContain('-10');
+  });
+
+  it('quotes fields containing commas', () => {
+    const csv = transactionsToCsv([tx({ payee: 'Hello, World' })]);
+    expect(csv).toContain('"Hello, World"');
+  });
+
+  it('quotes fields containing double quotes and doubles them', () => {
+    const csv = transactionsToCsv([tx({ payee: 'Say "hi"' })]);
+    expect(csv).toContain('"Say ""hi"""');
+  });
+
+  it('quotes fields containing newlines', () => {
+    const csv = transactionsToCsv([tx({ note: 'line one\nline two' })]);
+    expect(csv).toContain('"line one\nline two"');
+  });
+
+  it('renders null/undefined fields as empty', () => {
+    const csv = transactionsToCsv([
+      tx({
+        note: null,
+        uid: null,
+        postings: [{ account: 'A', amount: '', currency: '' }],
+      }),
+    ]);
+    const lines = csv.trim().split('\n');
+    // header,date,payee,status,(empty note),(empty uid),A,(empty amount),(empty currency)
+    expect(lines[1]).toBe("2024-09-01,Trader Joe's,none,,,A,,");
+  });
+
+  it('preserves apostrophes without quoting (no special CSV meaning)', () => {
+    const csv = transactionsToCsv([tx()]);
+    // Trader Joe's should appear unquoted
+    expect(csv).toContain("Trader Joe's,");
+  });
+});

--- a/lib/transactions/csv.ts
+++ b/lib/transactions/csv.ts
@@ -1,0 +1,53 @@
+import type { Transaction } from '@/lib/journal/parser';
+
+// One row per posting (long format) is the most useful shape for downstream
+// analysis tools — spreadsheet pivots, pandas DataFrames, etc. Transaction-
+// level metadata (date, payee, status, note) is repeated on each row.
+const COLUMNS = [
+  'date',
+  'payee',
+  'status',
+  'note',
+  'uid',
+  'account',
+  'amount',
+  'currency',
+] as const;
+
+const NEEDS_QUOTING = /[",\r\n]/;
+
+/** RFC 4180 quoting: double-quote the field if it contains comma, quote, CR, or LF. */
+const escapeField = (raw: string | null | undefined): string => {
+  const s = raw ?? '';
+  if (!NEEDS_QUOTING.test(s)) return s;
+  return `"${s.replace(/"/g, '""')}"`;
+};
+
+const formatRow = (cells: Array<string | null | undefined>): string =>
+  cells.map(escapeField).join(',');
+
+/**
+ * Serialize transactions to CSV (RFC 4180). One row per posting; header row
+ * first. Rows are emitted in input order — callers sort beforehand if a
+ * particular order is desired.
+ */
+export const transactionsToCsv = (txs: Transaction[]): string => {
+  const lines = [COLUMNS.join(',')];
+  for (const t of txs) {
+    for (const p of t.postings) {
+      lines.push(
+        formatRow([
+          t.date,
+          t.payee,
+          t.status,
+          t.note,
+          t.uid,
+          p.account,
+          p.amount,
+          p.currency,
+        ])
+      );
+    }
+  }
+  return lines.join('\n') + '\n';
+};


### PR DESCRIPTION
## Summary

First Phase 6 (Power features) bullet — download the currently-filtered transactions list as RFC 4180 CSV. Useful for backups, spreadsheet pivots, pandas analysis.

- **\`lib/transactions/csv.ts\`** — \`transactionsToCsv(txs)\`, one row per posting (long format) with columns \`date,payee,status,note,uid,account,amount,currency\`. RFC 4180 quoting: only fields containing comma / double-quote / CR / LF get wrapped. 7 unit tests cover quoting edge cases (commas, doubled quotes, embedded newlines, nulls).
- **\`features/transactions/applyTransactionFilters.ts\`** — extracted from \`Transactions.tsx\` so the API route and the page render apply identical filter semantics to the same query string.
- **\`app/api/transactions/export/route.ts\`** — GET handler, \`requireUser\`, honors \`start\` / \`end\` / \`account\` / \`payee\` / \`q\` filters from the URL. Responds \`text/csv; charset=utf-8\` with a dated \`Content-Disposition: attachment; filename=\"transactions-YYYY-MM-DD.csv\"\`.
- **\`features/transactions/Filters.tsx\`** gains an \"Export CSV\" outline button that preserves current URL params so the download matches what the user is looking at.

PLAN.md ticked partial (\`[~]\`) on the CSV-export bullet — \`/transactions\` covered, other report pages (balance / monthly / payees) can get export buttons in follow-up PRs if asked.

147 tests pass (140 + 7). Type-check + lint clean.

## Test plan

- [ ] CI green (lint / type-check / 147 tests).
- [ ] Manual: \`/transactions\` → click Export CSV → CSV downloads with \`transactions-<today>.csv\` filename.
- [ ] Manual: apply a date filter or payee filter → click Export → downloaded CSV reflects the same filtered set.
- [ ] Manual: open the CSV in a spreadsheet — fields with commas / quotes / newlines render in one cell, not split across columns.