### PR TITLE
feat(portfolio): commodity/portfolio view

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -196,7 +196,7 @@ The Tier-2/3 items from `TODO.md` that need more than a weekend.
 
 - [ ] **Budget actual-vs-target** — `ledger budget`; depends on 4.2 (templates / periodic transactions)
 - [~] **CSV export** for any report (`ledger csv`) — `/transactions` ships with an Export CSV button that downloads the currently-filtered list as RFC 4180 CSV via `/api/transactions/export`. One row per posting (long format) for spreadsheet/pandas compatibility. Other report pages (balance / monthly / payees) don't have export buttons yet; revisit if asked.
-- [ ] **Commodity / portfolio view** (`bal Assets:Investments -X CCY`)
+- [x] **Commodity / portfolio view** (`bal Assets:Investments -X CCY`) — `/portfolio` lists holdings under the configurable `PORTFOLIO_ACCOUNT_PREFIX` (default `Assets:Investments`) in their native commodity plus the value converted to your default currency. Empty-state when the prefix matches nothing; account names drill into the existing register page.
 - [ ] **Forecasting** (`ledger --forecast`)
 - [ ] **Saved views** — pin a filtered Payees/Register query and reach it from the Dashboard
 

--- a/app/portfolio/loading.tsx
+++ b/app/portfolio/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={8} />;
+}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,0 +1,7 @@
+import Portfolio from '@/features/portfolio/Portfolio';
+
+export const dynamic = 'force-dynamic';
+
+export default async function PortfolioPage() {
+  return <Portfolio />;
+}

--- a/components/nav/config.ts
+++ b/components/nav/config.ts
@@ -1,6 +1,7 @@
 import {
   ArrowLeftRight,
   Bookmark,
+  Briefcase,
   CalendarRange,
   Coins,
   FileBarChart,
@@ -75,6 +76,15 @@ export const getNavSections = (): NavSection[] => {
           description: 'Assets minus liabilities, over time.',
           icon: PiggyBank,
           keywords: ['wealth', 'equity', 'assets'],
+        },
+        {
+          id: 'portfolio',
+          title: 'Portfolio',
+          href: '/portfolio',
+          match: 'exact',
+          description: 'Holdings in native commodities + converted value.',
+          icon: Briefcase,
+          keywords: ['investments', 'stocks', 'commodities', 'shares'],
         },
         {
           id: 'periodic',

--- a/features/portfolio/Portfolio.tsx
+++ b/features/portfolio/Portfolio.tsx
@@ -1,0 +1,135 @@
+import { Briefcase } from 'lucide-react';
+import 'server-only';
+import {
+  extractTotal,
+  mergePortfolio,
+  type PortfolioRow,
+} from './parsePortfolio';
+import Help from '@/components/Help';
+import { buttonVariants } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { env } from '@/lib/env';
+import { cn } from '@/lib/utils';
+import formatAmount from '@/utils/formatAmount';
+import getDefaultCurrency from '@/utils/getDefaultCurrency';
+import runLedger from '@/utils/runLedger';
+import Link from 'next/link';
+
+const Portfolio = async () => {
+  const defaultCurrency = getDefaultCurrency() ?? 'USD';
+  const prefix = env.PORTFOLIO_ACCOUNT_PREFIX;
+
+  // `--flat` keeps the rollup hierarchy from interleaving sub-account totals
+  // with the leaf rows we want to display.
+  const [nativeStdout, convertedStdout] = await Promise.all([
+    runLedger(['balance', prefix, '--flat', '--format', '%A|%T\n']),
+    runLedger([
+      'balance',
+      prefix,
+      '-X',
+      defaultCurrency,
+      '--flat',
+      '--format',
+      '%A|%T\n',
+    ]),
+  ]);
+
+  const rows: PortfolioRow[] = mergePortfolio(nativeStdout, convertedStdout);
+  const total = extractTotal(convertedStdout);
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col gap-6">
+        <header className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold">Portfolio</h1>
+          <Help label="About portfolio">
+            Per-account holdings under <code>{prefix}</code> in their native
+            commodities, plus the value converted to your default currency.
+          </Help>
+        </header>
+        <Card className="flex flex-col items-center gap-4 p-10 text-center">
+          <Briefcase className="h-6 w-6 opacity-50" />
+          <div className="text-base font-medium">No investments tracked</div>
+          <p className="max-w-md text-sm text-muted-foreground">
+            Nothing found under <code>{prefix}</code>. Set the{' '}
+            <code>PORTFOLIO_ACCOUNT_PREFIX</code> env var if your journal uses a
+            different account tree.
+          </p>
+          <Link
+            href="/transactions/new"
+            className={cn(buttonVariants({ size: 'sm' }))}
+          >
+            Add a transaction
+          </Link>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">Portfolio</h1>
+            <Help label="About portfolio">
+              Per-account holdings under <code>{prefix}</code> in their native
+              commodities, plus the value converted to your default currency.
+              Prices come from your <code>price-db.ledger</code> if you have
+              one; missing prices show a blank converted column.
+            </Help>
+          </div>
+          <p className="mt-1 text-sm text-muted">
+            <code>{prefix}</code>
+          </p>
+        </div>
+        <div className="text-right">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+            Total ({defaultCurrency.toUpperCase()})
+          </div>
+          <div className="text-2xl font-semibold tracking-tight">
+            {formatAmount(total, true)}
+          </div>
+        </div>
+      </div>
+
+      <Card className="gap-0 overflow-hidden p-0">
+        <table>
+          <thead>
+            <tr>
+              <th>Account</th>
+              <th className="text-right">Native</th>
+              <th className="text-right">
+                Value ({defaultCurrency.toUpperCase()})
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.account}>
+                <td>
+                  <Link
+                    className="block text-fg hover:text-accent"
+                    href={`/accounts/${encodeURIComponent(row.account)}`}
+                  >
+                    {row.account}
+                  </Link>
+                </td>
+                <td className="text-right">{formatAmount(row.native, true)}</td>
+                <td className="text-right">
+                  {row.converted ? (
+                    formatAmount(row.converted, true)
+                  ) : (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+};
+
+export default Portfolio;

--- a/features/portfolio/parsePortfolio.test.ts
+++ b/features/portfolio/parsePortfolio.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractTotal,
+  mergePortfolio,
+  parseNativeRows,
+} from './parsePortfolio';
+
+describe('parseNativeRows', () => {
+  it('returns one row per account|amount line', () => {
+    const stdout =
+      'Assets:Investments:AAPL|10 AAPL\nAssets:Investments:BTC|0.5 BTC\n';
+    expect(parseNativeRows(stdout)).toEqual([
+      { account: 'Assets:Investments:AAPL', raw: '10 AAPL' },
+      { account: 'Assets:Investments:BTC', raw: '0.5 BTC' },
+    ]);
+  });
+
+  it('returns empty when stdout is blank', () => {
+    expect(parseNativeRows('')).toEqual([]);
+    expect(parseNativeRows('\n\n')).toEqual([]);
+  });
+
+  it('skips malformed lines', () => {
+    expect(parseNativeRows('|\nAssets:Foo|1 USD\nnopipe\n')).toEqual([
+      { account: 'Assets:Foo', raw: '1 USD' },
+    ]);
+  });
+
+  it('trims surrounding whitespace from columns', () => {
+    expect(parseNativeRows('  Assets:Foo  |  1 USD  ')).toEqual([
+      { account: 'Assets:Foo', raw: '1 USD' },
+    ]);
+  });
+});
+
+describe('mergePortfolio', () => {
+  it('joins native and converted by account', () => {
+    const native =
+      'Assets:Investments:AAPL|10 AAPL\nAssets:Investments:BTC|0.5 BTC\n';
+    const converted =
+      'Assets:Investments:AAPL|USD 2000\nAssets:Investments:BTC|USD 30000\n';
+    expect(mergePortfolio(native, converted)).toEqual([
+      {
+        account: 'Assets:Investments:AAPL',
+        native: '10 AAPL',
+        converted: 'USD 2000',
+      },
+      {
+        account: 'Assets:Investments:BTC',
+        native: '0.5 BTC',
+        converted: 'USD 30000',
+      },
+    ]);
+  });
+
+  it('leaves converted empty when a commodity has no price', () => {
+    const native = 'Assets:Investments:OBSCURE|5 OBSCURE\n';
+    const converted = ''; // no price for OBSCURE → no converted row
+    expect(mergePortfolio(native, converted)).toEqual([
+      {
+        account: 'Assets:Investments:OBSCURE',
+        native: '5 OBSCURE',
+        converted: '',
+      },
+    ]);
+  });
+
+  it('preserves native order, not converted', () => {
+    const native = 'B|1 X\nA|1 Y\n';
+    const converted = 'A|USD 10\nB|USD 20\n';
+    const rows = mergePortfolio(native, converted);
+    expect(rows.map((r) => r.account)).toEqual(['B', 'A']);
+  });
+});
+
+describe('extractTotal', () => {
+  it('returns the last column of the trailing rollup row', () => {
+    // ledger emits the final total with empty account column in --flat mode.
+    const stdout =
+      'Assets:Investments:AAPL|USD 2000\nAssets:Investments:BTC|USD 30000\n|USD 32000\n';
+    expect(extractTotal(stdout)).toBe('USD 32000');
+  });
+
+  it('returns empty for empty stdout', () => {
+    expect(extractTotal('')).toBe('');
+  });
+
+  it('returns the only row when there is just one', () => {
+    expect(extractTotal('Assets:Investments:AAPL|USD 2000\n')).toBe('USD 2000');
+  });
+});

--- a/features/portfolio/parsePortfolio.ts
+++ b/features/portfolio/parsePortfolio.ts
@@ -1,0 +1,72 @@
+// `ledger bal <prefix> [-X CCY] --flat --format '%A|%T\n'` emits one
+// `account|amount` row per leaf account, plus a trailing total. This helper
+// parses that into typed rows and merges native + converted views by account.
+
+export type NativeRow = {
+  account: string;
+  /** Native amount including unit/commodity, exactly as ledger emitted it. */
+  raw: string;
+};
+
+export type PortfolioRow = {
+  account: string;
+  /** e.g. "10 AAPL", "1500 USD", "0.5 BTC" — whatever the source journal uses. */
+  native: string;
+  /** Converted to the user's default currency; empty string if conversion was missing. */
+  converted: string;
+};
+
+const splitRows = (stdout: string): string[] =>
+  stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+export const parseNativeRows = (stdout: string): NativeRow[] => {
+  const rows: NativeRow[] = [];
+  for (const line of splitRows(stdout)) {
+    const [account, raw] = line.split('|');
+    if (!account || !raw) continue;
+    rows.push({ account: account.trim(), raw: raw.trim() });
+  }
+  return rows;
+};
+
+/**
+ * Combine a native-balance ledger dump with a converted-balance one. The
+ * converted output is grouped by the same accounts; rows are joined on the
+ * account key. The final row in each ledger output is the rollup total,
+ * which appears with an empty account column — we skip it.
+ *
+ * Trailing total: ledger emits an empty-account total row at the end of
+ * --flat output when there are 2+ accounts. The caller wants per-account
+ * rows only; the total is computed separately via the converted call.
+ */
+export const mergePortfolio = (
+  nativeStdout: string,
+  convertedStdout: string
+): PortfolioRow[] => {
+  const native = parseNativeRows(nativeStdout);
+  const converted = new Map(
+    parseNativeRows(convertedStdout).map((r) => [r.account, r.raw])
+  );
+  return native.map(({ account, raw }) => ({
+    account,
+    native: raw,
+    converted: converted.get(account) ?? '',
+  }));
+};
+
+/**
+ * Extract the rollup total from `ledger bal` `-X CCY` output. ledger prints
+ * the total as a final indented line; we grab the very last non-empty line
+ * and strip the account column.
+ */
+export const extractTotal = (convertedStdout: string): string => {
+  const lines = splitRows(convertedStdout);
+  if (lines.length === 0) return '';
+  const last = lines[lines.length - 1];
+  const parts = last.split('|');
+  // Final total row in `--flat` mode has an empty account column.
+  return (parts[1] ?? parts[0] ?? '').trim();
+};

--- a/lib/env/index.ts
+++ b/lib/env/index.ts
@@ -20,6 +20,9 @@ const envSchema = clientEnvSchema.extend({
   DEFAULT_CURRENCY: z.string().default('USD'),
   LEDGER_PRICE_DB: z.string().optional(),
   DATE_LOCALE: z.string().default('en-US'),
+  // Account prefix the /portfolio report aggregates. Matches whatever your
+  // journal calls its investment account tree (e.g. "Assets:Brokerage").
+  PORTFOLIO_ACCOUNT_PREFIX: z.string().default('Assets:Investments'),
 });
 
 const parsed = envSchema.safeParse(process.env);


### PR DESCRIPTION
## Summary

Second Phase 6 bullet ships. \`/portfolio\` aggregates holdings under a configurable account prefix and shows them both in their native commodity (\`10 AAPL\`, \`0.5 BTC\`) and converted to the user's default currency via the price db.

- **\`PORTFOLIO_ACCOUNT_PREFIX\` env var** (default \`Assets:Investments\`) so users with a different account tree can override without touching code.
- **\`features/portfolio/parsePortfolio.ts\`** — pure helpers parsing the \`bal --flat --format %A|%T\` shape, merging native + converted views, extracting the rollup total. 10 unit tests cover parsing + join + edge cases (missing prices, malformed lines, native-order preservation).
- **\`features/portfolio/Portfolio.tsx\`** — server component, two parallel \`runLedger\` calls (native + \`-X CCY\`), table of accounts with native amount + converted value, header total. Empty-state when nothing matches the prefix, pointing at the env var.
- **\`app/portfolio/page.tsx\` + \`loading.tsx\`** — thin route shells.
- **Nav** — new \`Portfolio\` entry under Reports, between Net Worth and Periodic Balance.

157 tests pass (147 + 10). Type-check + lint clean.

## Test plan

- [ ] CI green (lint / type-check / 157 tests).
- [ ] Manual: visit \`/portfolio\` with a journal that has commodity holdings — see native amount + converted column populated.
- [ ] Manual: visit with a journal that has no \`Assets:Investments\` accounts — empty-state appears with the env-var hint.
- [ ] Manual: set \`PORTFOLIO_ACCOUNT_PREFIX=Assets:Brokerage\` (or similar) in \`.env\` and verify the page picks up the new prefix.