### PR TITLE
feat(auth): send magic-link mail via self-hosted Postal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,11 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/ledger_dev
 BETTER_AUTH_SECRET=replace-with-32-plus-chars-of-random-data
 BETTER_AUTH_URL=http://localhost:3000
 
-# Email (magic link) — optional in dev (link logs to stdout when RESEND_API_KEY unset)
+# Email (magic link) — delivered via the self-hosted Postal server.
+# Both Postal vars are required: a missing/empty value fails fast at startup.
 EMAIL_FROM=auth@example.com
-RESEND_API_KEY=
+POSTAL_API_URL=https://postal.raxel.studio
+POSTAL_API_KEY=
 
 # Optional: Google sign-in. Set NEXT_PUBLIC_ENABLE_GOOGLE=1 in lockstep.
 # GOOGLE_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # claude code
 .claude/
+.codegraph/
 
 # local app data (sqlite + user journals)
 /data/

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { APP_NAME } from '@/lib/app';
+import { postalTransport } from '@/lib/email-transport';
 import { createAuth } from '@naeemba/next-starter/auth';
 
 const googleConfigured =
@@ -8,5 +9,6 @@ const googleConfigured =
 export const auth = await createAuth({
   singleAdmin: 'sharp.fk@gmail.com',
   passkey: { rpName: APP_NAME },
+  transport: postalTransport,
   ...(googleConfigured && { google: {} }),
 });

--- a/lib/email-transport.ts
+++ b/lib/email-transport.ts
@@ -1,0 +1,54 @@
+import 'server-only';
+import type { EmailTransport } from '@naeemba/next-starter/email';
+
+/**
+ * Magic-link delivery via the self-hosted Postal server (postal.raxel.studio)
+ * over its HTTPS API. When passed to `createAuth({ transport })`, the starter
+ * skips its built-in Resend dispatch entirely (no RESEND_API_KEY needed).
+ *
+ * Env:
+ *   POSTAL_API_URL  e.g. https://postal.raxel.studio
+ *   POSTAL_API_KEY  a Postal "API" credential key for the mail server
+ */
+export const postalTransport: EmailTransport = async ({
+  to,
+  from,
+  subject,
+  html,
+  text,
+}) => {
+  const baseUrl = process.env.POSTAL_API_URL;
+  const apiKey = process.env.POSTAL_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      '[email] POSTAL_API_URL and POSTAL_API_KEY must be set to send mail.'
+    );
+  }
+
+  const res = await fetch(`${baseUrl}/api/v1/send/message`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Server-API-Key': apiKey,
+    },
+    body: JSON.stringify({
+      to: [to],
+      from,
+      subject,
+      html_body: html,
+      plain_body: text,
+    }),
+  });
+
+  // Postal returns 200 with { status: 'success' | 'error' | 'parameter-error' }
+  const body = (await res.json().catch(() => null)) as {
+    status?: string;
+    data?: unknown;
+  } | null;
+
+  if (!res.ok || body?.status !== 'success') {
+    throw new Error(
+      `[email] Postal send failed (HTTP ${res.status}): ${JSON.stringify(body)}`
+    );
+  }
+};

--- a/lib/email-transport.ts
+++ b/lib/email-transport.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { env } from '@/lib/env';
 import type { EmailTransport } from '@naeemba/next-starter/email';
 
 /**
@@ -17,19 +18,11 @@ export const postalTransport: EmailTransport = async ({
   html,
   text,
 }) => {
-  const baseUrl = process.env.POSTAL_API_URL;
-  const apiKey = process.env.POSTAL_API_KEY;
-  if (!baseUrl || !apiKey) {
-    throw new Error(
-      '[email] POSTAL_API_URL and POSTAL_API_KEY must be set to send mail.'
-    );
-  }
-
-  const res = await fetch(`${baseUrl}/api/v1/send/message`, {
+  const res = await fetch(`${env.POSTAL_API_URL}/api/v1/send/message`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-Server-API-Key': apiKey,
+      'X-Server-API-Key': env.POSTAL_API_KEY,
     },
     body: JSON.stringify({
       to: [to],

--- a/lib/email-transport.ts
+++ b/lib/email-transport.ts
@@ -36,7 +36,6 @@ export const postalTransport: EmailTransport = async ({
   // Postal returns 200 with { status: 'success' | 'error' | 'parameter-error' }
   const body = (await res.json().catch(() => null)) as {
     status?: string;
-    data?: unknown;
   } | null;
 
   if (!res.ok || body?.status !== 'success') {

--- a/lib/env/index.ts
+++ b/lib/env/index.ts
@@ -21,10 +21,12 @@ const envSchema = clientEnvSchema.extend({
   // lib/journal/layout.ts (so tests can override it per-case).
   DATA_DIR: z.string().min(1).default('./data'),
 
-  // Email (magic link). Required for Resend delivery in production; in dev the
-  // link is logged to stdout when RESEND_API_KEY is unset.
+  // Email (magic link). Delivered via the self-hosted Postal server (see
+  // lib/email-transport.ts). Both Postal vars are required so a missing/empty
+  // value fails fast at startup rather than the first time someone signs in.
   EMAIL_FROM: z.string().default('auth@example.com'),
-  RESEND_API_KEY: z.string().optional(),
+  POSTAL_API_URL: z.string().url(),
+  POSTAL_API_KEY: z.string().min(1),
 
   // Google OAuth (optional)
   GOOGLE_CLIENT_ID: z.string().optional(),

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -13,3 +13,8 @@ process.env.DATABASE_URL =
 process.env.DATA_DIR = process.env.DATA_DIR ?? '/tmp/ledger-cli-ui-tests';
 process.env.BETTER_AUTH_URL =
   process.env.BETTER_AUTH_URL ?? 'http://localhost:3000';
+// Magic-link delivery (lib/email-transport.ts) reads these via the validated
+// env schema; placeholders satisfy the validators without contacting Postal.
+process.env.POSTAL_API_URL =
+  process.env.POSTAL_API_URL ?? 'https://postal.test';
+process.env.POSTAL_API_KEY = process.env.POSTAL_API_KEY ?? 'test-key';


### PR DESCRIPTION
## What

Routes magic-link auth emails through the self-hosted **Postal** server (`postal.raxel.studio`) instead of Resend.

- `lib/email-transport.ts` — `postalTransport`: POSTs the rendered email to Postal's HTTPS API (`/api/v1/send/message`) with an `X-Server-API-Key`.
- `lib/auth.ts` — passes `transport: postalTransport` to `createAuth`, so the starter skips its built-in Resend dispatch (no `RESEND_API_KEY` needed).

## Why

Self-hosting all transactional mail (3 domains) on Postal instead of paying Resend. SPF/DKIM/DMARC verified, delivering to inbox.

## Required env (set in Coolify before/with deploy)

```
POSTAL_API_URL = https://postal.raxel.studio
POSTAL_API_KEY = <Postal "API" credential key>
EMAIL_FROM     = Ledgeria <login@ledgeria.app>
```

⚠️ The transport throws if `POSTAL_API_KEY` is unset — set these env vars **before** the deploy serves sign-in, or magic-link sends will error.

## Test plan

- [ ] Set env vars on the ledgeria.app Coolify app
- [ ] Deploy
- [ ] Trigger a real sign-in → magic link arrives via Postal, lands in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)