### PR TITLE
fix(deploy): install ledger CLI in the production image

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,6 @@
+# The app shells out to the `ledger` CLI (ledger-cli 3.x) to compute
+# balances/stats from journal files (see lib/journal/*). Nixpacks installs
+# Node deps but not system binaries, so install `ledger` via apt here or the
+# production container fails at runtime with `spawn ledger ENOENT`.
+[phases.setup]
+aptPkgs = ["ledger"]


### PR DESCRIPTION
The app shells out to `ledger` (lib/journal/*) to compute balances and stats. Nixpacks installs Node deps but not system binaries, so the deployed container failed with `spawn ledger ENOENT`. Add a nixpacks setup phase that apt-installs the `ledger` package.