### PR TITLE
feat(storage): Garage object storage as source of truth for ledger files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,15 @@ DEFAULT_CURRENCY=USD
 
 # Root directory for persistent journals (one subdir per user). Defaults to ./data
 DATA_DIR=./data
+
+# ---- Object storage (ledger files) ----
+# Garage holds the canonical journal files; DATA_DIR is an ephemeral local cache.
+# STORAGE_BACKEND=memory (default) keeps everything in-process — for local dev/tests.
+# Set STORAGE_BACKEND=s3 in production and fill the S3_* vars below.
+STORAGE_BACKEND=memory
+# S3_ENDPOINT=http://garage:3900
+# S3_REGION=garage
+# S3_BUCKET=ledger
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
+# S3_FORCE_PATH_STYLE=true

--- a/PLAN.md
+++ b/PLAN.md
@@ -206,10 +206,14 @@ The Tier-2/3 items from `TODO.md` that need more than a weekend.
 
 ---
 
-## Phase 7 — Multi-user hardening
+## Phase 7 — Multi-user hardening / backups
 
 Only relevant if this gets deployed to anyone other than you.
 
+- [ ] **Object storage (Garage):** journal files are stored in Garage (S3-compatible)
+  as the source of truth; local disk is an ephemeral cache synced via
+  ListObjectsV2 + ETags. See `docs/deployment/garage.md` and
+  `docs/superpowers/specs/2026-06-24-garage-object-storage-design.md`.
 - [ ] **Encrypted user journals at rest** — envelope encryption with **session-scoped** decryption (zero-knowledge at rest, not full E2E). One per-user DEK encrypts the journal; wrapped by passphrase + one-time recovery code, with optional passkey-PRF convenience wrap. DEK reaches the server in RAM only, for the session; server-side `ledger` preserved. Unlock once per login session + a manual Lock button. Design: `docs/superpowers/specs/2026-06-22-encrypted-journals-design.md`. (Supersedes the earlier `.env.example` "server master key" idea — that was not zero-knowledge.)
 - [ ] Rate limit `/api/upload` and any future write endpoint
 - [ ] Audit log of journal mutations (who, when, how many bytes)

--- a/deploy/garage/garage.toml
+++ b/deploy/garage/garage.toml
@@ -1,0 +1,18 @@
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "lmdb"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "<RPC_SECRET>"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.local"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "<ADMIN_TOKEN>"

--- a/docs/deployment/garage.md
+++ b/docs/deployment/garage.md
@@ -1,0 +1,52 @@
+# Garage object storage (new-raxel)
+
+Garage holds the canonical ledger journal files. The app treats local disk
+(`DATA_DIR`) as an ephemeral cache.
+
+## Deploy (Coolify, single node)
+
+1. New Coolify service from image `dxflrs/garage:v1.0.1` (pin a tag).
+2. Persistent volumes:
+   - `/var/lib/garage/data`
+   - `/var/lib/garage/meta`
+3. Mount `deploy/garage/garage.toml` at `/etc/garage.toml` (fill secrets first:
+   `openssl rand -hex 32` for `rpc_secret` and `admin_token`).
+4. Expose **only** the S3 API port `3900` on Coolify's internal network to the
+   app container. Do NOT publish it publicly (consistent with the locked-down
+   admin-ports posture on this box).
+
+## One-time provisioning (run in the Garage container)
+
+```bash
+# Assign the single node to the layout (replication factor 1).
+NODE_ID=$(garage node id -q | cut -d@ -f1)
+garage layout assign "$NODE_ID" -z dc1 -c 50G
+garage layout apply --version 1
+
+# Bucket + application key.
+garage bucket create ledger
+garage key create ledger-app           # prints Key ID + Secret — copy them
+garage bucket allow --read --write ledger --key ledger-app
+```
+
+## App configuration
+
+Set on the app (Coolify env):
+
+```
+STORAGE_BACKEND=s3
+S3_ENDPOINT=http://<garage-internal-host>:3900
+S3_REGION=garage
+S3_BUCKET=ledger
+S3_ACCESS_KEY_ID=<Key ID from `garage key create`>
+S3_SECRET_ACCESS_KEY=<Secret from `garage key create`>
+S3_FORCE_PATH_STYLE=true
+```
+
+## Smoke test
+
+After deploy, sign in and add a transaction. Verify the object exists:
+
+```bash
+garage bucket info ledger        # object count > 0
+```

--- a/docs/superpowers/plans/2026-06-24-garage-object-storage.md
+++ b/docs/superpowers/plans/2026-06-24-garage-object-storage.md
@@ -619,8 +619,8 @@ describe('fingerprint', () => {
     expect(a).not.toBe(c);
   });
 
-  it('is stable for the empty set', () => {
-    expect(fingerprint([])).toBe(fingerprint([]));
+  it('is a deterministic 64-char hex string for the empty set', () => {
+    expect(fingerprint([])).toMatch(/^[a-f0-9]{64}$/);
   });
 });
 ```

--- a/docs/superpowers/plans/2026-06-24-garage-object-storage.md
+++ b/docs/superpowers/plans/2026-06-24-garage-object-storage.md
@@ -1,0 +1,1648 @@
+# Garage Object Storage for Ledger Files — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Garage (S3-compatible object storage) the source of truth for ledger journal files, with the local filesystem acting as an ephemeral cache that is synced down before every `ledger` invocation and pushed up after every successful write.
+
+**Architecture:** A single `lib/storage/` directory owns all Garage actions. An `ObjectStore` interface has two backends: `S3ObjectStore` (Garage, prod) and `MemoryObjectStore` (tests + no-infra dev). A sync layer mirrors each user's `journals/<userId>/` prefix to/from a local working dir using `ListObjectsV2` + ETags, producing a content **fingerprint** that replaces the current mtime-based query cache key. `JournalService` pulls before reads, and mutates → verifies → pushes on writes; `runLedger` pulls and keys its cache on the fingerprint.
+
+**Tech Stack:** Next.js (App Router), TypeScript, Drizzle/Postgres, Zod, Vitest, `@aws-sdk/client-s3`, the `ledger` CLI (invoked via `execFile`).
+
+## Global Constraints
+
+- **Single source of truth:** Garage holds canonical journal files; local disk under `DATA_DIR` is an ephemeral cache only.
+- **`ledger` CLI reads local paths only** — every read must ensure local files are present/fresh first; every write must verify locally before pushing.
+- **Backend selected by env:** `STORAGE_BACKEND` ∈ `{s3, memory}`, default `memory`. S3 vars required only when `STORAGE_BACKEND=s3`.
+- **Object key layout:** `journals/<userId>/<relPath>` mirrors the local layout `${DATA_DIR}/journals/<userId>/<relPath>`.
+- **ETag is opaque per backend.** The manifest and fingerprint store/compare whatever string the store returns; never assume MD5.
+- **Conflict detection lives in the sync layer** (compare remote ETags to the pulled manifest), not via `If-Match` (Garage support is not assumed).
+- **Failure policy:** reads serve stale local cache + warn when Garage is unreachable but a manifest exists, else fail loudly; writes roll back the local mutation and throw on any pull/verify/push failure.
+- **Patterns:** follow existing repo/service split; tests colocated as `*.test.ts`; use `setupTestDb`/`teardownTestDb` from `@/lib/test-utils/db` where a DB is needed. DRY, YAGNI, TDD, frequent commits.
+- **Commands:** test `pnpm test`, single file `pnpm vitest run <path>`, type-check `pnpm type-check`, lint `pnpm lint`.
+- **Commit trailer:** end each commit message with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Config foundation — dependency + env vars
+
+**Files:**
+- Modify: `package.json` (add `@aws-sdk/client-s3`)
+- Modify: `lib/env/index.ts`
+- Modify: `.env.example`
+- Test: `lib/env/storage-env.test.ts` (Create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `env.STORAGE_BACKEND` (`'s3' | 'memory'`), `env.S3_ENDPOINT`, `env.S3_REGION` (string, default `'garage'`), `env.S3_BUCKET`, `env.S3_ACCESS_KEY_ID`, `env.S3_SECRET_ACCESS_KEY`, `env.S3_FORCE_PATH_STYLE` (boolean, default `true`). When `STORAGE_BACKEND==='s3'`, the four `S3_ENDPOINT/S3_BUCKET/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY` are required non-empty.
+
+- [ ] **Step 1: Install the AWS S3 client**
+
+Run: `pnpm add @aws-sdk/client-s3`
+Expected: `package.json` gains `"@aws-sdk/client-s3"` under dependencies; lockfile updates.
+
+- [ ] **Step 2: Write the failing env test**
+
+Create `lib/env/storage-env.test.ts`. The env module parses `process.env` at import time and throws on invalid config, so each case imports it in isolation via `vitest.resetModules()` + dynamic import.
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// A minimal valid baseline so the rest of the schema passes; we only vary the
+// storage-related vars per test.
+const BASE_ENV: Record<string, string> = {
+  BETTER_AUTH_SECRET: 'x'.repeat(32),
+  DATABASE_URL: 'postgres://u:p@localhost:5432/db',
+  POSTAL_API_URL: 'https://postal.example.com',
+  POSTAL_API_KEY: 'k',
+};
+
+const loadEnv = async (overrides: Record<string, string | undefined>) => {
+  vi.resetModules();
+  const prev = process.env;
+  process.env = { ...BASE_ENV, ...overrides } as NodeJS.ProcessEnv;
+  try {
+    const mod = await import('./index');
+    return mod.env;
+  } finally {
+    process.env = prev;
+  }
+};
+
+describe('storage env', () => {
+  it('defaults STORAGE_BACKEND to memory and needs no S3 vars', async () => {
+    const env = await loadEnv({});
+    expect(env.STORAGE_BACKEND).toBe('memory');
+  });
+
+  it('defaults S3_REGION to garage and S3_FORCE_PATH_STYLE to true', async () => {
+    const env = await loadEnv({
+      STORAGE_BACKEND: 's3',
+      S3_ENDPOINT: 'http://garage:3900',
+      S3_BUCKET: 'ledger',
+      S3_ACCESS_KEY_ID: 'id',
+      S3_SECRET_ACCESS_KEY: 'secret',
+    });
+    expect(env.S3_REGION).toBe('garage');
+    expect(env.S3_FORCE_PATH_STYLE).toBe(true);
+  });
+
+  it('throws when STORAGE_BACKEND=s3 but S3 vars are missing', async () => {
+    await expect(loadEnv({ STORAGE_BACKEND: 's3' })).rejects.toThrow(
+      /S3_ENDPOINT/
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/env/storage-env.test.ts`
+Expected: FAIL — `env.STORAGE_BACKEND` is `undefined` (schema not extended yet).
+
+- [ ] **Step 4: Extend the env schema**
+
+In `lib/env/index.ts`, add inside the `clientEnvSchema.extend({ ... })` object (after the `Prices` block, before the closing `})`):
+
+```ts
+  // Object storage (Garage / S3-compatible). DATA_DIR is the local cache;
+  // these point at the canonical store. S3_* are required only when
+  // STORAGE_BACKEND === 's3' (enforced by the superRefine below).
+  STORAGE_BACKEND: z.enum(['s3', 'memory']).default('memory'),
+  S3_ENDPOINT: z.string().url().optional(),
+  S3_REGION: z.string().default('garage'),
+  S3_BUCKET: z.string().optional(),
+  S3_ACCESS_KEY_ID: z.string().optional(),
+  S3_SECRET_ACCESS_KEY: z.string().optional(),
+  S3_FORCE_PATH_STYLE: z
+    .union([z.literal('true'), z.literal('false')])
+    .default('true')
+    .transform((v) => v === 'true'),
+```
+
+Then change the schema construction so the conditional check runs. Replace:
+
+```ts
+const envSchema = clientEnvSchema.extend({
+```
+
+…keep the `.extend({...})` block exactly, and immediately after the closing `})` of `.extend`, append a `.superRefine`:
+
+```ts
+}).superRefine((val, ctx) => {
+  if (val.STORAGE_BACKEND !== 's3') return;
+  const required = [
+    'S3_ENDPOINT',
+    'S3_BUCKET',
+    'S3_ACCESS_KEY_ID',
+    'S3_SECRET_ACCESS_KEY',
+  ] as const;
+  for (const key of required) {
+    if (!val[key]) {
+      ctx.addIssue({
+        code: 'custom',
+        path: [key],
+        message: `${key} is required when STORAGE_BACKEND=s3`,
+      });
+    }
+  }
+});
+```
+
+Note: `z.infer` still works on a `ZodEffects` (the result of `.superRefine`); `Env` type and `parsed.data` are unaffected.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/env/storage-env.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Document the vars in `.env.example`**
+
+Add a section to `.env.example`:
+
+```bash
+# ---- Object storage (ledger files) ----
+# Garage holds the canonical journal files; DATA_DIR is an ephemeral local cache.
+# STORAGE_BACKEND=memory (default) keeps everything in-process — for local dev/tests.
+# Set STORAGE_BACKEND=s3 in production and fill the S3_* vars below.
+STORAGE_BACKEND=memory
+# S3_ENDPOINT=http://garage:3900
+# S3_REGION=garage
+# S3_BUCKET=ledger
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
+# S3_FORCE_PATH_STYLE=true
+```
+
+- [ ] **Step 7: Type-check and commit**
+
+Run: `pnpm type-check` → Expected: clean.
+
+```bash
+git add package.json pnpm-lock.yaml lib/env/index.ts lib/env/storage-env.test.ts .env.example
+git commit -m "feat(storage): add S3/Garage env vars and aws-sdk dependency"
+```
+
+---
+
+### Task 2: ObjectStore interface + MemoryObjectStore
+
+**Files:**
+- Create: `lib/storage/objectStore.ts`
+- Create: `lib/storage/memoryObjectStore.ts`
+- Test: `lib/storage/memoryObjectStore.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type ObjectMeta = { key: string; etag: string; size: number }`
+  - `type GetResult = { body: Buffer; etag: string }`
+  - `interface ObjectStore { list(prefix: string): Promise<ObjectMeta[]>; get(key: string): Promise<GetResult>; put(key: string, body: Buffer): Promise<{ etag: string }>; delete(key: string): Promise<void>; deletePrefix(prefix: string): Promise<void> }`
+  - `class MemoryObjectStore implements ObjectStore` — ETag is `sha256` hex of the body.
+
+- [ ] **Step 1: Write the interface file (no test — pure types)**
+
+Create `lib/storage/objectStore.ts`:
+
+```ts
+/** Metadata for one stored object. `etag` is opaque and backend-specific. */
+export type ObjectMeta = { key: string; etag: string; size: number };
+
+/** Result of fetching an object's bytes. */
+export type GetResult = { body: Buffer; etag: string };
+
+/**
+ * Minimal S3-shaped object store. Implementations: S3ObjectStore (Garage) and
+ * MemoryObjectStore (tests/dev). Keys are full paths like
+ * `journals/<userId>/main.ledger`. Conflict detection is done by the sync layer
+ * (comparing ETags), not here.
+ */
+export interface ObjectStore {
+  /** Lists every object whose key starts with `prefix`. */
+  list(prefix: string): Promise<ObjectMeta[]>;
+  /** Fetches one object. Rejects if the key does not exist. */
+  get(key: string): Promise<GetResult>;
+  /** Writes one object, returning its new ETag. */
+  put(key: string, body: Buffer): Promise<{ etag: string }>;
+  /** Deletes one object. No-op if it does not exist. */
+  delete(key: string): Promise<void>;
+  /** Deletes every object under `prefix`. */
+  deletePrefix(prefix: string): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Write the failing MemoryObjectStore test**
+
+Create `lib/storage/memoryObjectStore.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryObjectStore } from './memoryObjectStore';
+
+describe('MemoryObjectStore', () => {
+  let store: MemoryObjectStore;
+  beforeEach(() => {
+    store = new MemoryObjectStore();
+  });
+
+  it('put then get round-trips the body and returns a stable etag', async () => {
+    const { etag } = await store.put('a/x.ledger', Buffer.from('hello'));
+    const got = await store.get('a/x.ledger');
+    expect(got.body.toString()).toBe('hello');
+    expect(got.etag).toBe(etag);
+  });
+
+  it('etag changes when content changes', async () => {
+    const first = await store.put('a/x.ledger', Buffer.from('one'));
+    const second = await store.put('a/x.ledger', Buffer.from('two'));
+    expect(second.etag).not.toBe(first.etag);
+  });
+
+  it('list returns only keys under the prefix with meta', async () => {
+    await store.put('a/x.ledger', Buffer.from('1'));
+    await store.put('a/sub/y.ledger', Buffer.from('22'));
+    await store.put('b/z.ledger', Buffer.from('333'));
+    const entries = await store.list('a/');
+    expect(entries.map((e) => e.key).sort()).toEqual([
+      'a/sub/y.ledger',
+      'a/x.ledger',
+    ]);
+    const x = entries.find((e) => e.key === 'a/x.ledger')!;
+    expect(x.size).toBe(1);
+    expect(x.etag).toHaveLength(64); // sha256 hex
+  });
+
+  it('get rejects for a missing key', async () => {
+    await expect(store.get('nope')).rejects.toThrow();
+  });
+
+  it('delete removes one key; deletePrefix removes the subtree', async () => {
+    await store.put('a/x.ledger', Buffer.from('1'));
+    await store.put('a/y.ledger', Buffer.from('2'));
+    await store.delete('a/x.ledger');
+    expect((await store.list('a/')).map((e) => e.key)).toEqual(['a/y.ledger']);
+    await store.deletePrefix('a/');
+    expect(await store.list('a/')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/storage/memoryObjectStore.test.ts`
+Expected: FAIL — module `./memoryObjectStore` not found.
+
+- [ ] **Step 4: Implement MemoryObjectStore**
+
+Create `lib/storage/memoryObjectStore.ts`:
+
+```ts
+import { createHash } from 'crypto';
+import type { GetResult, ObjectMeta, ObjectStore } from './objectStore';
+
+const sha256 = (body: Buffer): string =>
+  createHash('sha256').update(body).digest('hex');
+
+/** In-memory ObjectStore for tests and no-infra dev. ETag = sha256(body). */
+export class MemoryObjectStore implements ObjectStore {
+  private readonly objects = new Map<string, Buffer>();
+
+  async list(prefix: string): Promise<ObjectMeta[]> {
+    const out: ObjectMeta[] = [];
+    for (const [key, body] of this.objects) {
+      if (key.startsWith(prefix)) {
+        out.push({ key, etag: sha256(body), size: body.length });
+      }
+    }
+    return out;
+  }
+
+  async get(key: string): Promise<GetResult> {
+    const body = this.objects.get(key);
+    if (!body) throw new Error(`MemoryObjectStore: missing key ${key}`);
+    return { body, etag: sha256(body) };
+  }
+
+  async put(key: string, body: Buffer): Promise<{ etag: string }> {
+    this.objects.set(key, Buffer.from(body));
+    return { etag: sha256(body) };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    for (const key of [...this.objects.keys()]) {
+      if (key.startsWith(prefix)) this.objects.delete(key);
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/storage/memoryObjectStore.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/storage/objectStore.ts lib/storage/memoryObjectStore.ts lib/storage/memoryObjectStore.test.ts
+git commit -m "feat(storage): ObjectStore interface + in-memory backend"
+```
+
+---
+
+### Task 3: S3ObjectStore (Garage backend) + factory
+
+**Files:**
+- Create: `lib/storage/s3ObjectStore.ts`
+- Create: `lib/storage/client.ts`
+- Test: `lib/storage/client.test.ts`
+
+**Interfaces:**
+- Consumes: `ObjectStore`, `MemoryObjectStore`, `env`.
+- Produces:
+  - `class S3ObjectStore implements ObjectStore` — ctor `({ client: S3Client, bucket: string })`.
+  - `getObjectStore(): ObjectStore` — memoized; `s3` → S3ObjectStore from env, else MemoryObjectStore.
+  - `resetObjectStore(): void` — clears the memo (tests only).
+
+- [ ] **Step 1: Implement S3ObjectStore (thin wrapper; verified via integration, not unit)**
+
+Create `lib/storage/s3ObjectStore.ts`:
+
+```ts
+import {
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
+import type { GetResult, ObjectMeta, ObjectStore } from './objectStore';
+
+const stripQuotes = (etag: string | undefined): string =>
+  (etag ?? '').replace(/^"|"$/g, '');
+
+/** Garage / S3-compatible ObjectStore. ETag is the server's (md5-based) header. */
+export class S3ObjectStore implements ObjectStore {
+  constructor(
+    private readonly client: S3Client,
+    private readonly bucket: string
+  ) {}
+
+  async list(prefix: string): Promise<ObjectMeta[]> {
+    const out: ObjectMeta[] = [];
+    let token: string | undefined;
+    do {
+      const res = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: token,
+        })
+      );
+      for (const obj of res.Contents ?? []) {
+        out.push({
+          key: obj.Key!,
+          etag: stripQuotes(obj.ETag),
+          size: obj.Size ?? 0,
+        });
+      }
+      token = res.IsTruncated ? res.NextContinuationToken : undefined;
+    } while (token);
+    return out;
+  }
+
+  async get(key: string): Promise<GetResult> {
+    const res = await this.client.send(
+      new GetObjectCommand({ Bucket: this.bucket, Key: key })
+    );
+    const body = Buffer.from(await res.Body!.transformToByteArray());
+    return { body, etag: stripQuotes(res.ETag) };
+  }
+
+  async put(key: string, body: Buffer): Promise<{ etag: string }> {
+    const res = await this.client.send(
+      new PutObjectCommand({ Bucket: this.bucket, Key: key, Body: body })
+    );
+    return { etag: stripQuotes(res.ETag) };
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(
+      new DeleteObjectCommand({ Bucket: this.bucket, Key: key })
+    );
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    const entries = await this.list(prefix);
+    if (entries.length === 0) return;
+    await this.client.send(
+      new DeleteObjectsCommand({
+        Bucket: this.bucket,
+        Delete: { Objects: entries.map((e) => ({ Key: e.key })) },
+      })
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing factory test**
+
+Create `lib/storage/client.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { getObjectStore, resetObjectStore } from './client';
+import { MemoryObjectStore } from './memoryObjectStore';
+
+afterEach(() => resetObjectStore());
+
+describe('getObjectStore', () => {
+  it('returns a MemoryObjectStore when STORAGE_BACKEND is memory (default)', () => {
+    // Test env has STORAGE_BACKEND unset → defaults to 'memory'.
+    expect(getObjectStore()).toBeInstanceOf(MemoryObjectStore);
+  });
+
+  it('memoizes the instance', () => {
+    expect(getObjectStore()).toBe(getObjectStore());
+  });
+
+  it('resetObjectStore clears the memo', () => {
+    const first = getObjectStore();
+    resetObjectStore();
+    expect(getObjectStore()).not.toBe(first);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/storage/client.test.ts`
+Expected: FAIL — module `./client` not found.
+
+- [ ] **Step 4: Implement the factory**
+
+Create `lib/storage/client.ts`:
+
+```ts
+import { S3Client } from '@aws-sdk/client-s3';
+import { env } from '@/lib/env';
+import { MemoryObjectStore } from './memoryObjectStore';
+import type { ObjectStore } from './objectStore';
+import { S3ObjectStore } from './s3ObjectStore';
+
+let cached: ObjectStore | null = null;
+
+const buildS3Store = (): ObjectStore => {
+  const client = new S3Client({
+    endpoint: env.S3_ENDPOINT,
+    region: env.S3_REGION,
+    forcePathStyle: env.S3_FORCE_PATH_STYLE,
+    credentials: {
+      accessKeyId: env.S3_ACCESS_KEY_ID!,
+      secretAccessKey: env.S3_SECRET_ACCESS_KEY!,
+    },
+  });
+  return new S3ObjectStore(client, env.S3_BUCKET!);
+};
+
+/** Returns the process-wide ObjectStore, building it from env on first call. */
+export const getObjectStore = (): ObjectStore => {
+  if (cached) return cached;
+  cached = env.STORAGE_BACKEND === 's3' ? buildS3Store() : new MemoryObjectStore();
+  return cached;
+};
+
+/** Test-only: drop the memoized store so the next getObjectStore() rebuilds. */
+export const resetObjectStore = (): void => {
+  cached = null;
+};
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/storage/client.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/storage/s3ObjectStore.ts lib/storage/client.ts lib/storage/client.test.ts
+git commit -m "feat(storage): Garage S3 backend + env-driven store factory"
+```
+
+---
+
+### Task 4: Manifest + key helpers + fingerprint
+
+**Files:**
+- Create: `lib/storage/manifest.ts`
+- Test: `lib/storage/manifest.test.ts`
+
+**Interfaces:**
+- Consumes: `getJournalDir` from `@/lib/journal/layout`.
+- Produces:
+  - `type Manifest = Record<string, string>` (relPath → etag)
+  - `userPrefix(userId: string): string` → `journals/<userId>/`
+  - `keyFor(userId: string, relPath: string): string`
+  - `relPathFromKey(userId: string, key: string): string`
+  - `localPathFor(userId: string, relPath: string): string`
+  - `readManifest(userId: string): Promise<Manifest>` (`{}` if absent)
+  - `writeManifest(userId: string, m: Manifest): Promise<void>`
+  - `manifestRelName` constant `'.manifest.json'`
+  - `fingerprint(entries: { key: string; etag: string }[]): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/storage/manifest.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { getJournalDir } from '@/lib/journal/layout';
+import {
+  fingerprint,
+  keyFor,
+  localPathFor,
+  readManifest,
+  relPathFromKey,
+  userPrefix,
+  writeManifest,
+} from './manifest';
+
+const USER = 'manifest-user';
+afterEach(() => fs.rm(getJournalDir(USER), { recursive: true, force: true }));
+
+describe('key helpers', () => {
+  it('builds and reverses keys', () => {
+    expect(userPrefix(USER)).toBe(`journals/${USER}/`);
+    expect(keyFor(USER, 'sub/a.ledger')).toBe(`journals/${USER}/sub/a.ledger`);
+    expect(relPathFromKey(USER, `journals/${USER}/sub/a.ledger`)).toBe(
+      'sub/a.ledger'
+    );
+    expect(localPathFor(USER, 'a.ledger')).toBe(
+      path.join(getJournalDir(USER), 'a.ledger')
+    );
+  });
+});
+
+describe('manifest io', () => {
+  it('returns {} when no manifest exists', async () => {
+    expect(await readManifest(USER)).toEqual({});
+  });
+
+  it('round-trips a manifest', async () => {
+    await writeManifest(USER, { 'main.ledger': 'etag1' });
+    expect(await readManifest(USER)).toEqual({ 'main.ledger': 'etag1' });
+  });
+});
+
+describe('fingerprint', () => {
+  it('is order-independent and changes with content', () => {
+    const a = fingerprint([
+      { key: 'k1', etag: 'e1' },
+      { key: 'k2', etag: 'e2' },
+    ]);
+    const b = fingerprint([
+      { key: 'k2', etag: 'e2' },
+      { key: 'k1', etag: 'e1' },
+    ]);
+    const c = fingerprint([
+      { key: 'k1', etag: 'eX' },
+      { key: 'k2', etag: 'e2' },
+    ]);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it('is stable for the empty set', () => {
+    expect(fingerprint([])).toBe(fingerprint([]));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/storage/manifest.test.ts`
+Expected: FAIL — module `./manifest` not found.
+
+- [ ] **Step 3: Implement manifest.ts**
+
+Create `lib/storage/manifest.ts`:
+
+```ts
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getJournalDir } from '@/lib/journal/layout';
+
+/** relPath (within the user's journal dir) → last-seen ETag. */
+export type Manifest = Record<string, string>;
+
+export const manifestRelName = '.manifest.json';
+
+/** Garage key prefix for a user, e.g. `journals/<userId>/`. */
+export const userPrefix = (userId: string): string => `journals/${userId}/`;
+
+/** Full object key for a file inside the user's journal. POSIX separators. */
+export const keyFor = (userId: string, relPath: string): string =>
+  userPrefix(userId) + relPath.split(path.sep).join('/');
+
+/** Inverse of keyFor: the relPath (OS separators) for a full key. */
+export const relPathFromKey = (userId: string, key: string): string =>
+  key.slice(userPrefix(userId).length).split('/').join(path.sep);
+
+/** Absolute local cache path for a relPath inside the user's journal dir. */
+export const localPathFor = (userId: string, relPath: string): string =>
+  path.join(getJournalDir(userId), relPath);
+
+const manifestPath = (userId: string): string =>
+  path.join(getJournalDir(userId), manifestRelName);
+
+export const readManifest = async (userId: string): Promise<Manifest> => {
+  try {
+    const raw = await fs.readFile(manifestPath(userId), 'utf-8');
+    return JSON.parse(raw) as Manifest;
+  } catch {
+    return {};
+  }
+};
+
+export const writeManifest = async (
+  userId: string,
+  m: Manifest
+): Promise<void> => {
+  await fs.mkdir(getJournalDir(userId), { recursive: true });
+  await fs.writeFile(manifestPath(userId), JSON.stringify(m, null, 2), 'utf-8');
+};
+
+/** Order-independent content fingerprint of a set of (key, etag) pairs. */
+export const fingerprint = (
+  entries: { key: string; etag: string }[]
+): string => {
+  const body = [...entries]
+    .map((e) => `${e.key}:${e.etag}`)
+    .sort()
+    .join('\n');
+  return createHash('sha256').update(body).digest('hex');
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/storage/manifest.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/storage/manifest.ts lib/storage/manifest.test.ts
+git commit -m "feat(storage): manifest io, key helpers, and content fingerprint"
+```
+
+---
+
+### Task 5: download.ts — pull (remote → local mirror)
+
+**Files:**
+- Create: `lib/storage/download.ts`
+- Test: `lib/storage/download.test.ts`
+
+**Interfaces:**
+- Consumes: `ObjectStore`, `MemoryObjectStore`, manifest helpers, `getJournalDir`.
+- Produces: `pullToLocal(store: ObjectStore, userId: string): Promise<{ fingerprint: string }>` — mirrors the remote prefix into the local journal dir (downloading only ETag-changed objects, deleting locally-stale files, skipping `.manifest.json`), rewrites the manifest, and returns the fingerprint. On a store error: if a manifest exists, logs a warning and returns the fingerprint computed from the manifest (serve-stale); otherwise rethrows.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/storage/download.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { getJournalDir } from '@/lib/journal/layout';
+import { MemoryObjectStore } from './memoryObjectStore';
+import { keyFor, readManifest } from './manifest';
+import { pullToLocal } from './download';
+
+const USER = 'pull-user';
+const dir = () => getJournalDir(USER);
+const read = (rel: string) => fs.readFile(path.join(dir(), rel), 'utf-8');
+afterEach(() => fs.rm(dir(), { recursive: true, force: true }));
+
+const seed = async (store: MemoryObjectStore, files: Record<string, string>) => {
+  for (const [rel, content] of Object.entries(files)) {
+    await store.put(keyFor(USER, rel), Buffer.from(content));
+  }
+};
+
+describe('pullToLocal', () => {
+  it('downloads all remote files and writes a manifest', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, { 'main.ledger': 'include ./sub.ledger\n', 'sub.ledger': 'x' });
+    const { fingerprint } = await pullToLocal(store, USER);
+    expect(await read('main.ledger')).toBe('include ./sub.ledger\n');
+    expect(await read('sub.ledger')).toBe('x');
+    expect(Object.keys(await readManifest(USER)).sort()).toEqual([
+      'main.ledger',
+      'sub.ledger',
+    ]);
+    expect(fingerprint).toHaveLength(64);
+  });
+
+  it('removes local files no longer present remotely', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, { 'main.ledger': 'a', 'gone.ledger': 'b' });
+    await pullToLocal(store, USER);
+    await store.delete(keyFor(USER, 'gone.ledger'));
+    await pullToLocal(store, USER);
+    await expect(read('gone.ledger')).rejects.toThrow();
+    expect(await read('main.ledger')).toBe('a');
+  });
+
+  it('changes the fingerprint when remote content changes', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, { 'main.ledger': 'a' });
+    const first = (await pullToLocal(store, USER)).fingerprint;
+    await store.put(keyFor(USER, 'main.ledger'), Buffer.from('b'));
+    const second = (await pullToLocal(store, USER)).fingerprint;
+    expect(second).not.toBe(first);
+    expect(await read('main.ledger')).toBe('b');
+  });
+
+  it('returns a stable fingerprint for an empty remote (new user)', async () => {
+    const store = new MemoryObjectStore();
+    const { fingerprint } = await pullToLocal(store, USER);
+    expect(fingerprint).toHaveLength(64);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/storage/download.test.ts`
+Expected: FAIL — module `./download` not found.
+
+- [ ] **Step 3: Implement download.ts**
+
+Create `lib/storage/download.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getJournalDir } from '@/lib/journal/layout';
+import {
+  fingerprint,
+  manifestRelName,
+  readManifest,
+  relPathFromKey,
+  userPrefix,
+  writeManifest,
+  type Manifest,
+} from './manifest';
+import type { ObjectStore } from './objectStore';
+
+/** Lists the local journal dir recursively, returning relPaths (excludes the
+ * manifest file and any *.tmp scratch files from atomic writes). */
+const listLocalRelPaths = async (dir: string): Promise<string[]> => {
+  const out: string[] = [];
+  const walk = async (abs: string, rel: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      return; // dir does not exist yet
+    }
+    for (const e of entries) {
+      const childRel = rel ? path.join(rel, e.name) : e.name;
+      if (e.isDirectory()) {
+        await walk(path.join(abs, e.name), childRel);
+      } else if (e.name !== manifestRelName && !e.name.endsWith('.tmp')) {
+        out.push(childRel);
+      }
+    }
+  };
+  await walk(dir, '');
+  return out;
+};
+
+/**
+ * Mirrors the user's remote prefix into the local journal dir. Downloads only
+ * objects whose ETag differs from the local manifest, deletes local files no
+ * longer present remotely, rewrites the manifest, and returns the fingerprint.
+ *
+ * If the store is unreachable but a manifest exists, serves the stale local
+ * cache (warn + fingerprint from manifest). With no manifest, the error
+ * propagates.
+ */
+export const pullToLocal = async (
+  store: ObjectStore,
+  userId: string
+): Promise<{ fingerprint: string }> => {
+  const dir = getJournalDir(userId);
+  const prefix = userPrefix(userId);
+  const prevManifest = await readManifest(userId);
+
+  let remote;
+  try {
+    remote = await store.list(prefix);
+  } catch (err) {
+    if (Object.keys(prevManifest).length > 0) {
+      console.warn(
+        `[storage] Garage unreachable for ${userId}; serving stale local cache`,
+        err
+      );
+      return {
+        fingerprint: fingerprint(
+          Object.entries(prevManifest).map(([rel, etag]) => ({
+            key: prefix + rel.split(path.sep).join('/'),
+            etag,
+          }))
+        ),
+      };
+    }
+    throw err;
+  }
+
+  const nextManifest: Manifest = {};
+  const remoteRelSet = new Set<string>();
+
+  for (const obj of remote) {
+    const rel = relPathFromKey(userId, obj.key);
+    remoteRelSet.add(rel);
+    nextManifest[rel] = obj.etag;
+    const localAbs = path.join(dir, rel);
+    if (prevManifest[rel] === obj.etag) {
+      // Unchanged — only download if the local file is missing.
+      try {
+        await fs.access(localAbs);
+        continue;
+      } catch {
+        // fall through to download
+      }
+    }
+    const { body } = await store.get(obj.key);
+    await fs.mkdir(path.dirname(localAbs), { recursive: true });
+    await fs.writeFile(localAbs, body);
+  }
+
+  // Delete local files that are no longer in the remote set.
+  for (const rel of await listLocalRelPaths(dir)) {
+    if (!remoteRelSet.has(rel)) {
+      await fs.rm(path.join(dir, rel), { force: true });
+    }
+  }
+
+  await writeManifest(userId, nextManifest);
+  return { fingerprint: fingerprint(remote) };
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/storage/download.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/storage/download.ts lib/storage/download.test.ts
+git commit -m "feat(storage): pull remote prefix into local cache with fingerprint"
+```
+
+---
+
+### Task 6: save.ts — push (local → remote mirror) with conflict detection
+
+**Files:**
+- Create: `lib/storage/save.ts`
+- Test: `lib/storage/save.test.ts`
+
+**Interfaces:**
+- Consumes: `ObjectStore`, manifest helpers, `getJournalDir`, `pullToLocal` (tests only).
+- Produces:
+  - `class StorageConflictError extends Error`
+  - `pushFromLocal(store: ObjectStore, userId: string): Promise<void>` — verifies the remote still matches the pulled manifest (else throws `StorageConflictError`), uploads every local file, deletes remote objects with no local counterpart, and rewrites the manifest with the new ETags.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/storage/save.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { getJournalDir } from '@/lib/journal/layout';
+import { MemoryObjectStore } from './memoryObjectStore';
+import { pullToLocal } from './download';
+import { keyFor, readManifest } from './manifest';
+import { StorageConflictError, pushFromLocal } from './save';
+
+const USER = 'push-user';
+const dir = () => getJournalDir(USER);
+const writeLocal = async (rel: string, content: string) => {
+  const abs = path.join(dir(), rel);
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, content);
+};
+afterEach(() => fs.rm(dir(), { recursive: true, force: true }));
+
+describe('pushFromLocal', () => {
+  it('uploads new local files and records their etags in the manifest', async () => {
+    const store = new MemoryObjectStore();
+    await pullToLocal(store, USER); // empty remote → empty manifest
+    await writeLocal('main.ledger', 'hello');
+    await pushFromLocal(store, USER);
+    const remote = await store.get(keyFor(USER, 'main.ledger'));
+    expect(remote.body.toString()).toBe('hello');
+    expect((await readManifest(USER))['main.ledger']).toBe(remote.etag);
+  });
+
+  it('deletes remote objects with no local counterpart', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(keyFor(USER, 'old.ledger'), Buffer.from('x'));
+    await pullToLocal(store, USER); // brings old.ledger local
+    await fs.rm(path.join(dir(), 'old.ledger'));
+    await writeLocal('main.ledger', 'new');
+    await pushFromLocal(store, USER);
+    expect((await store.list(keyFor(USER, ''))).map((e) => e.key)).toEqual([
+      keyFor(USER, 'main.ledger'),
+    ]);
+  });
+
+  it('throws StorageConflictError when remote changed since the pull', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(keyFor(USER, 'main.ledger'), Buffer.from('v1'));
+    await pullToLocal(store, USER);
+    // Another writer changes the remote out from under us.
+    await store.put(keyFor(USER, 'main.ledger'), Buffer.from('v2-elsewhere'));
+    await writeLocal('main.ledger', 'v2-mine');
+    await expect(pushFromLocal(store, USER)).rejects.toBeInstanceOf(
+      StorageConflictError
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/storage/save.test.ts`
+Expected: FAIL — module `./save` not found.
+
+- [ ] **Step 3: Implement save.ts**
+
+Create `lib/storage/save.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getJournalDir } from '@/lib/journal/layout';
+import {
+  keyFor,
+  manifestRelName,
+  readManifest,
+  relPathFromKey,
+  userPrefix,
+  writeManifest,
+  type Manifest,
+} from './manifest';
+import type { ObjectStore } from './objectStore';
+
+/** Thrown when the remote changed between pull and push (lost-update guard). */
+export class StorageConflictError extends Error {
+  constructor(message = 'Journal was modified elsewhere; reload and retry.') {
+    super(message);
+    this.name = 'StorageConflictError';
+  }
+}
+
+const listLocalRelPaths = async (dir: string): Promise<string[]> => {
+  const out: string[] = [];
+  const walk = async (abs: string, rel: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const childRel = rel ? path.join(rel, e.name) : e.name;
+      if (e.isDirectory()) await walk(path.join(abs, e.name), childRel);
+      else if (e.name !== manifestRelName && !e.name.endsWith('.tmp'))
+        out.push(childRel);
+    }
+  };
+  await walk(dir, '');
+  return out;
+};
+
+/**
+ * Mirrors the local journal dir up to the remote prefix. First confirms the
+ * remote still matches the manifest we pulled (else throws StorageConflictError
+ * — never blindly overwrite a concurrent change). Then uploads every local
+ * file, deletes remote objects with no local counterpart, and rewrites the
+ * manifest with the freshly-returned ETags.
+ */
+export const pushFromLocal = async (
+  store: ObjectStore,
+  userId: string
+): Promise<void> => {
+  const dir = getJournalDir(userId);
+  const prefix = userPrefix(userId);
+  const manifest = await readManifest(userId);
+
+  // Conflict check: remote must equal the snapshot we last pulled.
+  const remote = await store.list(prefix);
+  const remoteByRel = new Map(
+    remote.map((o) => [relPathFromKey(userId, o.key), o.etag])
+  );
+  const allRels = new Set([
+    ...Object.keys(manifest),
+    ...remoteByRel.keys(),
+  ]);
+  for (const rel of allRels) {
+    if (manifest[rel] !== remoteByRel.get(rel)) {
+      throw new StorageConflictError();
+    }
+  }
+
+  // Upload every local file; collect new etags.
+  const localRels = await listLocalRelPaths(dir);
+  const next: Manifest = {};
+  for (const rel of localRels) {
+    const body = await fs.readFile(path.join(dir, rel));
+    const { etag } = await store.put(keyFor(userId, rel), body);
+    next[rel] = etag;
+  }
+
+  // Delete remote objects that no longer exist locally.
+  const localSet = new Set(localRels);
+  for (const rel of remoteByRel.keys()) {
+    if (!localSet.has(rel)) await store.delete(keyFor(userId, rel));
+  }
+
+  await writeManifest(userId, next);
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/storage/save.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/storage/save.ts lib/storage/save.test.ts
+git commit -m "feat(storage): push local cache to remote with lost-update guard"
+```
+
+---
+
+### Task 7: sync.ts public API + index.ts barrel
+
+**Files:**
+- Create: `lib/storage/sync.ts`
+- Create: `lib/storage/index.ts`
+- Test: `lib/storage/sync.test.ts`
+
+**Interfaces:**
+- Consumes: `getObjectStore`/`resetObjectStore`, `pullToLocal`, `pushFromLocal`, `userPrefix`, manifest helpers.
+- Produces (bound to the env-configured store):
+  - `pull(userId: string): Promise<{ fingerprint: string }>`
+  - `push(userId: string): Promise<void>`
+  - `clearRemote(userId: string): Promise<void>`
+  - `index.ts` re-exports `pull`, `push`, `clearRemote`, `StorageConflictError`, `getObjectStore`, `resetObjectStore`, and the `ObjectStore`/`ObjectMeta` types.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/storage/sync.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { getJournalDir } from '@/lib/journal/layout';
+import { resetObjectStore } from './client';
+import { pull, push, clearRemote } from './sync';
+
+const USER = 'sync-user';
+afterEach(async () => {
+  resetObjectStore();
+  await fs.rm(getJournalDir(USER), { recursive: true, force: true });
+});
+
+describe('sync (memory backend via env default)', () => {
+  it('push then pull round-trips through the configured store', async () => {
+    await pull(USER); // empty
+    const abs = path.join(getJournalDir(USER), 'main.ledger');
+    await fs.writeFile(abs, 'data');
+    await push(USER);
+    await fs.rm(abs); // blow away local cache
+    await pull(USER); // should restore from the store
+    expect(await fs.readFile(abs, 'utf-8')).toBe('data');
+  });
+
+  it('clearRemote empties the user prefix', async () => {
+    await pull(USER);
+    await fs.writeFile(path.join(getJournalDir(USER), 'main.ledger'), 'd');
+    await push(USER);
+    await clearRemote(USER);
+    await fs.rm(path.join(getJournalDir(USER), 'main.ledger'));
+    const after = await pull(USER);
+    // Empty remote → only the stable empty-set fingerprint, no restored file.
+    await expect(
+      fs.access(path.join(getJournalDir(USER), 'main.ledger'))
+    ).rejects.toThrow();
+    expect(after.fingerprint).toHaveLength(64);
+  });
+});
+```
+
+Note: `pull`/`push` resolve the store via `getObjectStore()`, which memoizes a single `MemoryObjectStore` across calls in one test, so the round-trip works. `resetObjectStore()` in `afterEach` isolates tests.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/storage/sync.test.ts`
+Expected: FAIL — module `./sync` not found.
+
+- [ ] **Step 3: Implement sync.ts and index.ts**
+
+Create `lib/storage/sync.ts`:
+
+```ts
+import { getObjectStore } from './client';
+import { pullToLocal } from './download';
+import { userPrefix } from './manifest';
+import { pushFromLocal } from './save';
+
+/** Mirror the user's canonical journal down to the local cache. */
+export const pull = (userId: string): Promise<{ fingerprint: string }> =>
+  pullToLocal(getObjectStore(), userId);
+
+/** Mirror the user's local cache up to the canonical store. */
+export const push = (userId: string): Promise<void> =>
+  pushFromLocal(getObjectStore(), userId);
+
+/** Delete every canonical object for the user (used before a full import). */
+export const clearRemote = (userId: string): Promise<void> =>
+  getObjectStore().deletePrefix(userPrefix(userId));
+```
+
+Create `lib/storage/index.ts`:
+
+```ts
+export { pull, push, clearRemote } from './sync';
+export { getObjectStore, resetObjectStore } from './client';
+export { StorageConflictError } from './save';
+export type { ObjectStore, ObjectMeta, GetResult } from './objectStore';
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run lib/storage/sync.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Type-check the whole storage module and commit**
+
+Run: `pnpm type-check` → Expected: clean.
+
+```bash
+git add lib/storage/sync.ts lib/storage/index.ts lib/storage/sync.test.ts
+git commit -m "feat(storage): public pull/push/clearRemote sync API + barrel"
+```
+
+---
+
+### Task 8: Wire sync into the read path (runLedger + getMaxMtime call sites)
+
+**Files:**
+- Modify: `utils/runLedger.ts`
+- Modify: `lib/journal/repository.ts` (replace `getMaxMtime` with `getFingerprint`)
+- Investigate/Modify: any other `getMaxMtime` caller (e.g. `features/.../Transactions.tsx`)
+- Test: `lib/journal/repository.test.ts` (update the `getMaxMtime` describe block to `getFingerprint`)
+
+**Interfaces:**
+- Consumes: `pull` from `@/lib/storage`.
+- Produces: `JournalRepository.getFingerprint(userId: string): Promise<string>` (pulls from the store, ensures the layout stub exists locally, returns the fingerprint). `getMaxMtime` is removed.
+
+- [ ] **Step 1: Find every getMaxMtime caller**
+
+Run: `grep -rn "getMaxMtime" --include=*.ts --include=*.tsx .`
+Expected: at least `utils/runLedger.ts`, `lib/journal/repository.ts`, `lib/journal/repository.test.ts`, and possibly a `Transactions` component. Record the list — every one is updated in this task.
+
+- [ ] **Step 2: Update the repository test (red)**
+
+In `lib/journal/repository.test.ts`, replace the entire `describe('JournalRepository.getMaxMtime', ...)` block with a `getFingerprint` block. Mtime-specific cases no longer apply; assert fingerprint behavior instead:
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+import { resetObjectStore } from '@/lib/storage';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('JournalRepository.getFingerprint', () => {
+  let ctx: TestDbContext;
+  let repo: JournalRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('repo-fp-');
+    await ctx.insertUser('test-user', 'Test', 'test@example.com');
+    repo = new JournalRepository(ctx.db);
+    resetObjectStore();
+    await fs.rm(getJournalDir('test-user'), { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    resetObjectStore();
+    await fs.rm(getJournalDir('test-user'), { recursive: true, force: true });
+  });
+
+  it('returns a 64-char hex fingerprint for a brand-new user', async () => {
+    const fp = await repo.getFingerprint('test-user');
+    expect(fp).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('changes the fingerprint after a file is added and pushed', async () => {
+    const { pull, push } = await import('@/lib/storage');
+    const before = await repo.getFingerprint('test-user');
+    await pull('test-user');
+    await fs.writeFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      '2024-01-01 x\n    A  1\n    B\n'
+    );
+    await push('test-user');
+    const after = await repo.getFingerprint('test-user');
+    expect(after).not.toBe(before);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run lib/journal/repository.test.ts`
+Expected: FAIL — `repo.getFingerprint` is not a function.
+
+- [ ] **Step 4: Replace getMaxMtime in the repository**
+
+In `lib/journal/repository.ts`:
+
+1. Add the import near the top (after the existing imports):
+
+```ts
+import { pull } from '@/lib/storage';
+```
+
+2. Replace the entire `getMaxMtime` method (lines ~111-119) with:
+
+```ts
+  /** Pulls the canonical journal into the local cache and returns the content
+   * fingerprint. Used as the query cache-key input so any change (local or in
+   * Garage) invalidates `unstable_cache`. Also guarantees the local stub exists. */
+  async getFingerprint(userId: string): Promise<string> {
+    const { fingerprint } = await pull(userId);
+    await this.ensureLayout(userId);
+    return fingerprint;
+  }
+```
+
+(`resolveIncludes` import in this file is still used elsewhere? It is not — remove `resolveIncludes` from the parser import if it becomes unused; keep `parseJournal`, `ParsedJournal`, `Transaction`.)
+
+- [ ] **Step 5: Update runLedger**
+
+In `utils/runLedger.ts`:
+
+1. Change the cache-key builder signature from `mtimeMs: number` to `fingerprint: string`:
+
+```ts
+const buildExecLedger = (tag: string, fingerprint: string) =>
+  unstable_cache(
+    async (allArgs: string[]): Promise<string> => {
+      const { stdout } = await execFilePromise('ledger', allArgs);
+      return stdout;
+    },
+    ['ledger-cli-exec', tag, fingerprint],
+    { revalidate: LEDGER_CACHE_TTL_SECONDS, tags: [tag] }
+  );
+```
+
+2. In `runLedger`, replace the mtime line and the buildExecLedger call:
+
+```ts
+  // getFingerprint pulls the canonical journal into the local cache (so the
+  // ledger CLI can read it) and returns the content fingerprint for the key.
+  const fingerprint = await journalRepository.getFingerprint(user.id);
+  const { mainPath, priceDbPath } = await journalRepository.getLayout(user.id);
+```
+
+and
+
+```ts
+  const execLedger = buildExecLedger(getJournalCacheTag(user.id), fingerprint);
+```
+
+- [ ] **Step 6: Update any remaining getMaxMtime caller**
+
+For each non-test file from Step 1 (e.g. a `Transactions` server component), replace `journalRepository.getMaxMtime(userId)` with `journalRepository.getFingerprint(userId)` and use the returned string wherever the number was used in the cache key. Show the concrete edit for the file(s) found (the cache-key array element changes from `String(mtime)` to the fingerprint string).
+
+- [ ] **Step 7: Run tests + type-check**
+
+Run: `pnpm vitest run lib/journal/repository.test.ts` → Expected: PASS.
+Run: `pnpm type-check` → Expected: clean (no remaining `getMaxMtime` references).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add utils/runLedger.ts lib/journal/repository.ts lib/journal/repository.test.ts
+# plus any Transactions component touched
+git commit -m "feat(storage): pull-before-read and fingerprint-keyed ledger cache"
+```
+
+---
+
+### Task 9: Wire sync into the write path (service mutations + imports)
+
+**Files:**
+- Modify: `lib/journal/service.ts`
+- Modify: `lib/journal/repository.ts` (`emptyJournalDir` also clears remote)
+- Test: `lib/journal/service.test.ts` and `lib/journal/integration.test.ts` (add sync isolation; assert push happens)
+
+**Interfaces:**
+- Consumes: `pull`, `push`, `clearRemote`, `StorageConflictError` from `@/lib/storage`.
+- Produces: mutations and imports keep canonical Garage state in sync — pull at the start, push after a successful local verify, and roll back + throw on conflict/failure.
+
+- [ ] **Step 1: Update emptyJournalDir to clear remote too (red via service tests later)**
+
+In `lib/journal/repository.ts`, add to the top imports:
+
+```ts
+import { clearRemote } from '@/lib/storage';
+```
+
+Replace `emptyJournalDir` so it clears both the local cache and the canonical store:
+
+```ts
+  /** Wipes the user's journal locally AND in canonical storage, then recreates
+   * the local dir empty. Used by the import flow. */
+  async emptyJournalDir(userId: string): Promise<void> {
+    const dir = getJournalDir(userId);
+    await clearRemote(userId);
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    await fs.mkdir(dir, { recursive: true });
+  }
+```
+
+- [ ] **Step 2: Add pull-before-read in service read passthroughs**
+
+In `lib/journal/service.ts`, add to imports:
+
+```ts
+import { pull, push, StorageConflictError } from '@/lib/storage';
+```
+
+Update the read passthroughs so the local cache is fresh before the parser runs:
+
+```ts
+  async listTransactions(userId: string): Promise<ParsedJournal> {
+    await pull(userId);
+    return this.repo.list(userId);
+  }
+
+  async findTransaction(
+    userId: string,
+    uid: string
+  ): Promise<Transaction | null> {
+    await pull(userId);
+    return this.repo.find(userId, uid);
+  }
+```
+
+- [ ] **Step 3: Add pull + push to addTransaction**
+
+In `addTransaction`, add `await pull(userId);` immediately before `const { mainPath } = await this.repo.ensureLayout(userId);`. Then, after the successful verify (replace the `invalidateCache(userId); return { ok: true };` tail) with a push that rolls back local on failure:
+
+```ts
+    try {
+      await push(userId);
+    } catch (e) {
+      // Local is ahead of canonical — roll back so we never diverge.
+      await this.repo.writeFileAtomic(mainPath, snapshot);
+      const formError =
+        e instanceof StorageConflictError
+          ? e.message
+          : 'Failed to save journal to storage.';
+      return { ok: false, fieldErrors: {}, formError };
+    }
+    invalidateCache(userId);
+    return { ok: true };
+```
+
+- [ ] **Step 4: Add pull (start) + push (after verify) to performEdit**
+
+In `performEdit`, add `await pull(userId);` as the first line of the method body (before the `input.uid !== input.draft.uid` check). After the successful verify, replace `invalidateCache(userId); return { ok: true };` with:
+
+```ts
+    try {
+      await push(userId);
+    } catch (e) {
+      await this.repo.writeFileAtomic(tx.file, text); // restore pre-edit content
+      return {
+        ok: false,
+        reason: 'stale',
+        message:
+          e instanceof StorageConflictError
+            ? e.message
+            : 'Failed to save journal to storage.',
+      };
+    }
+    invalidateCache(userId);
+    return { ok: true };
+```
+
+- [ ] **Step 5: Add pull (start) + push (after verify) to performDelete**
+
+Mirror Step 4 in `performDelete`: `await pull(userId);` as the first line, and after the successful verify replace `invalidateCache(userId); return { ok: true };` with the same push-with-rollback block (restoring `text` to `tx.file`).
+
+- [ ] **Step 6: Push after imports**
+
+In `replaceFromSingleFile` and `replaceFromZip`, after `invalidateCache(userId);` (and after the verify) add `await push(userId);` so the imported files reach canonical storage. `emptyJournalDir` already cleared the remote in Step 1, so the push reflects exactly the imported set.
+
+- [ ] **Step 7: Write a failing test asserting canonical sync on add**
+
+Add to `lib/journal/service.test.ts` (follow the file's existing setup; add `resetObjectStore()` to its `beforeEach`/`afterEach` and import `getObjectStore, resetObjectStore` from `@/lib/storage`):
+
+```ts
+it('persists an added transaction to canonical storage', async () => {
+  // service + repo wired to ctx.db as the existing tests do
+  const res = await service.addTransaction(userId, {
+    date: '2024-03-01',
+    payee: 'Coffee',
+    postings: [
+      { account: 'Expenses:Food', amount: 'USD 3' },
+      { account: 'Assets:Cash', amount: '' },
+    ],
+  });
+  expect(res.ok).toBe(true);
+  const store = getObjectStore();
+  const remote = await store.list(`journals/${userId}/`);
+  expect(remote.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 8: Run the failing test, then the full suite**
+
+Run: `pnpm vitest run lib/journal/service.test.ts`
+Expected after wiring: PASS. Then run the full suite to catch fallout in `integration.test.ts`/`service-zip.test.ts` (these need `resetObjectStore()` isolation if they assert on storage):
+
+Run: `pnpm test`
+Expected: all green (~345+ existing tests still pass; new ones added).
+
+- [ ] **Step 9: Type-check, lint, commit**
+
+Run: `pnpm type-check` → clean. `pnpm lint` → clean.
+
+```bash
+git add lib/journal/service.ts lib/journal/repository.ts lib/journal/service.test.ts lib/journal/integration.test.ts
+git commit -m "feat(storage): sync journals to Garage on write and import"
+```
+
+---
+
+### Task 10: Garage deployment runbook, config, and docs
+
+**Files:**
+- Create: `docs/deployment/garage.md`
+- Create: `deploy/garage/garage.toml`
+- Modify: `PLAN.md`
+
+**Interfaces:**
+- Consumes: nothing (docs/config only).
+- Produces: a reproducible runbook for standing Garage up on new-raxel and the app env it expects.
+
+- [ ] **Step 1: Write `deploy/garage/garage.toml`**
+
+Create `deploy/garage/garage.toml` (single-node; replace `<RPC_SECRET>` and `<ADMIN_TOKEN>` with `openssl rand -hex 32` values at deploy time — do not commit real secrets):
+
+```toml
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "lmdb"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "<RPC_SECRET>"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.local"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "<ADMIN_TOKEN>"
+```
+
+- [ ] **Step 2: Write the runbook `docs/deployment/garage.md`**
+
+Create `docs/deployment/garage.md` documenting, with exact commands:
+
+```markdown
+# Garage object storage (new-raxel)
+
+Garage holds the canonical ledger journal files. The app treats local disk
+(`DATA_DIR`) as an ephemeral cache.
+
+## Deploy (Coolify, single node)
+
+1. New Coolify service from image `dxflrs/garage:v1.0.1` (pin a tag).
+2. Persistent volumes:
+   - `/var/lib/garage/data`
+   - `/var/lib/garage/meta`
+3. Mount `deploy/garage/garage.toml` at `/etc/garage.toml` (fill secrets first:
+   `openssl rand -hex 32` for `rpc_secret` and `admin_token`).
+4. Expose **only** the S3 API port `3900` on Coolify's internal network to the
+   app container. Do NOT publish it publicly (consistent with the locked-down
+   admin-ports posture on this box).
+
+## One-time provisioning (run in the Garage container)
+
+```bash
+# Assign the single node to the layout (replication factor 1).
+NODE_ID=$(garage node id -q | cut -d@ -f1)
+garage layout assign "$NODE_ID" -z dc1 -c 50G
+garage layout apply --version 1
+
+# Bucket + application key.
+garage bucket create ledger
+garage key create ledger-app           # prints Key ID + Secret — copy them
+garage bucket allow --read --write ledger --key ledger-app
+```
+
+## App configuration
+
+Set on the app (Coolify env):
+
+```
+STORAGE_BACKEND=s3
+S3_ENDPOINT=http://<garage-internal-host>:3900
+S3_REGION=garage
+S3_BUCKET=ledger
+S3_ACCESS_KEY_ID=<Key ID from `garage key create`>
+S3_SECRET_ACCESS_KEY=<Secret from `garage key create`>
+S3_FORCE_PATH_STYLE=true
+```
+
+## Smoke test
+
+After deploy, sign in and add a transaction. Verify the object exists:
+
+```bash
+garage bucket info ledger        # object count > 0
+```
+```
+
+- [ ] **Step 3: Add a PLAN.md entry**
+
+In `PLAN.md`, under Phase 7 (multi-user hardening / backups), add a bullet:
+
+```markdown
+- **Object storage (Garage):** journal files are stored in Garage (S3-compatible)
+  as the source of truth; local disk is an ephemeral cache synced via
+  ListObjectsV2 + ETags. See `docs/deployment/garage.md` and
+  `docs/superpowers/specs/2026-06-24-garage-object-storage-design.md`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/deployment/garage.md deploy/garage/garage.toml PLAN.md
+git commit -m "docs(storage): Garage deployment runbook, config, and PLAN entry"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full suite: `pnpm test` → all green.
+- [ ] `pnpm type-check` → clean.
+- [ ] `pnpm lint` → clean.
+- [ ] `pnpm build` → succeeds (env defaults to `STORAGE_BACKEND=memory`, so build needs no live Garage).
+- [ ] Manual smoke against a real Garage is the deploy step in `docs/deployment/garage.md` (host not reachable from this environment).

--- a/docs/superpowers/plans/2026-06-24-garage-object-storage.md
+++ b/docs/superpowers/plans/2026-06-24-garage-object-storage.md
@@ -16,6 +16,7 @@
 - **Object key layout:** `journals/<userId>/<relPath>` mirrors the local layout `${DATA_DIR}/journals/<userId>/<relPath>`.
 - **ETag is opaque per backend.** The manifest and fingerprint store/compare whatever string the store returns; never assume MD5.
 - **Conflict detection lives in the sync layer** (compare remote ETags to the pulled manifest), not via `If-Match` (Garage support is not assumed).
+- **Path-traversal safety (security):** a relPath derived from an object key must never escape the user's journal dir. `relPathFromKey` rejects any `rel` that is absolute or contains a `..` segment (mirror `service.ts`'s `PATH_TRAVERSAL = /(^|[/\\])\.\.([/\\]|$)/` + `path.isAbsolute`), and every filesystem write/delete in the storage layer verifies `path.resolve(abs).startsWith(path.resolve(dir) + path.sep)` before touching disk.
 - **Failure policy:** reads serve stale local cache + warn when Garage is unreachable but a manifest exists, else fail loudly; writes roll back the local mutation and throw on any pull/verify/push failure.
 - **Patterns:** follow existing repo/service split; tests colocated as `*.test.ts`; use `setupTestDb`/`teardownTestDb` from `@/lib/test-utils/db` where a DB is needed. DRY, YAGNI, TDD, frequent commits.
 - **Commands:** test `pnpm test`, single file `pnpm vitest run <path>`, type-check `pnpm type-check`, lint `pnpm lint`.

--- a/docs/superpowers/specs/2026-06-24-garage-object-storage-design.md
+++ b/docs/superpowers/specs/2026-06-24-garage-object-storage-design.md
@@ -1,0 +1,235 @@
+# Garage Object Storage for Ledger Files — Design
+
+**Date:** 2026-06-24
+**Status:** Approved (brainstorming) — pending implementation plan
+**Branch:** TBD (off `main`)
+
+## Problem
+
+Ledger journal files are the source of truth for all financial data. They
+currently live on the local filesystem at `${DATA_DIR}/journals/<userId>/`
+(`main.ledger` + any `include`d files), accessed through `JournalRepository`
+(`lib/journal/repository.ts`) and read by the `ledger` CLI via
+`execFile('ledger', ['-f', mainPath, ...])`.
+
+Now that the app is moving to Postgres + Coolify containers, local disk is
+ephemeral — journal files have no durable home in a container. We want
+**Garage** (self-hosted, S3-compatible object storage by Deuxfleurs) to hold
+the canonical journal files so containers can stay stateless.
+
+The hard constraint: the `ledger` CLI reads files **only from a real local
+filesystem path** — it cannot read from S3. So the design must bridge object
+storage and the local filesystem around every `ledger` invocation.
+
+## Decisions (locked)
+
+- **Garage is the source of truth; local disk is an ephemeral cache.** On read,
+  sync canonical files down to a local working dir (skipping unchanged objects
+  by ETag), then run `ledger`. On write, mutate locally, verify, then upload to
+  Garage.
+- **Host:** Garage runs on the existing `new-raxel` Coolify host
+  (`45.92.156.98`), not yet deployed — this work stands it up.
+- **Data:** fresh start, no migration of existing files (consistent with the
+  Postgres migration decision). A simple upload/import path for new files is
+  enough.
+- **Bridge mechanism:** prefix-mirror via `ListObjectsV2` + ETags (Approach A
+  below).
+
+## Approach (chosen): prefix-mirror via ListObjectsV2 + ETags
+
+Treat each user's `journals/<userId>/` prefix as a directory.
+
+- **Read:** one `ListObjectsV2` returns every object's key + ETag; download only
+  objects whose ETag differs from the local copy; delete locally-stale files;
+  run `ledger` on the local `main.ledger`. The sorted list of `(key, ETag)`
+  pairs hashes into a **fingerprint** that becomes the query cache key,
+  replacing the current mtime-based key.
+- **Write:** mutate the local file, verify with the `ledger` CLI, then
+  `PutObject` conditionally (`If-Match` on the known ETag), then update the local
+  manifest.
+
+Mirroring the whole prefix gets `main.ledger` + every `include`d file in one
+shot, so the sync layer never has to parse the include graph. ETags give exact,
+cheap change detection and map cleanly onto the existing `JournalRepository`
+and `unstable_cache` seams.
+
+**Rejected alternatives:**
+- *Include-graph-follow sync* — reintroduces a chicken-and-egg (must read a file
+  to know what to read next) and duplicates parser logic, with no benefit at
+  this scale.
+- *FUSE / s3fs mount* — adds an opaque kernel/daemon dependency in the container
+  with weak consistency semantics and hard-to-debug failures. Overkill.
+
+## Architecture
+
+### Single storage directory: `lib/storage/`
+
+All Garage actions live in one directory, split by action. `lib/journal/` holds
+no storage code; `JournalRepository` imports from `lib/storage`.
+
+```
+lib/storage/
+  objectStore.ts        # ObjectStore interface (list/get/put/delete + ETags)
+  client.ts             # Garage S3 client config + backend factory (STORAGE_BACKEND)
+  s3ObjectStore.ts      # S3ObjectStore — real Garage backend (@aws-sdk/client-s3)
+  memoryObjectStore.ts  # in-memory fake (content-hash ETags) for tests / no-infra dev
+  save.ts               # save/upload a file to Garage (conditional PutObject)
+  download.ts           # download/pull object(s) from Garage to the local working dir
+  sync.ts               # ensureLocal(userId): list + diff + download + manifest + fingerprint
+  manifest.ts           # read/write local .manifest.json (relPath -> etag)
+  index.ts              # public surface re-exported for the journal layer
+```
+
+### ObjectStore interface
+
+```
+list(prefix): Promise<{ key, etag, size }[]>
+get(key): Promise<{ body: Buffer, etag }>
+put(key, body, { ifMatch? }): Promise<{ etag }>
+delete(key): Promise<void>
+deletePrefix(prefix): Promise<void>
+```
+
+- **`S3ObjectStore`** — `@aws-sdk/client-s3`, path-style addressing, region
+  `garage`, configured from env. The prod backend; works against Garage.
+- **`MemoryObjectStore`** — in-memory map with content-hash ETags. Used by the
+  test suite and `STORAGE_BACKEND=memory` local dev, so neither needs a real
+  Garage.
+- **`client.ts`** factory selects the backend from `STORAGE_BACKEND`.
+
+### Sync layer (`sync.ts`, `save.ts`, `download.ts`, `manifest.ts`)
+
+- **`ensureLocal(userId): Promise<Fingerprint>`** — `ListObjectsV2` on
+  `journals/<userId>/`, diff remote ETags against the local manifest
+  (`${DATA_DIR}/journals/<userId>/.manifest.json`), download only changed
+  objects, delete locally-stale ones, rewrite the manifest. Returns the
+  fingerprint = hash of sorted `key:etag` pairs.
+- **`save(userId, relPath, content)`** — conditional `PutObject`
+  (`If-Match` on known ETag), then manifest update.
+- **`download`** — fetch one or many objects into the local working dir.
+- **`manifest`** — read/write the local `.manifest.json` (relPath → etag).
+
+### Wiring into existing seams (minimal change)
+
+- `JournalRepository` (`lib/journal/repository.ts`) gains a dependency on the
+  storage layer. Reads (`readFile`, `list`) call `ensureLocal` first; writes
+  (`appendFile`, `writeFileAtomic`) write local then `save`. `emptyJournalDir`
+  clears both store (`deletePrefix`) and local.
+- `getMaxMtime()` is **replaced** by the sync fingerprint.
+- `utils/runLedger.ts` — `unstable_cache` key becomes `(userId, fingerprint,
+  args)` instead of `(userId, mtime, args)`. `ledger` still runs on the local
+  `main.ledger`, unchanged.
+- `lib/journal/verify.ts` stays put — it's a ledger-CLI concern, not storage.
+
+## Data flow
+
+**Read (every report page):**
+1. service → repo → `ensureLocal(userId)`: `ListObjectsV2` → diff → download
+   changed → write manifest → fingerprint.
+2. `runLedger` keyed on `(userId, fingerprint, args)` via `unstable_cache` →
+   `execFile('ledger', ['-f', localMain, ...])`.
+
+**Write (add/edit/delete tx):**
+1. Acquire per-user mutex (already exists).
+2. `ensureLocal` — so we don't clobber a newer canonical version.
+3. Mutate local file (`appendFile` / `writeFileAtomic`).
+4. **Verify** via the `ledger` CLI locally.
+5. On success → `save` (conditional `PutObject`) → manifest update. Cache
+   invalidates naturally because the fingerprint changes.
+6. On verify failure **or** a `412` conditional-put conflict → **rollback the
+   local mutation** and throw.
+
+The ordering change vs today (append-then-verify): the new order is
+**mutate → verify → push**, so a bad or conflicting write never reaches Garage,
+and a failed push never leaves local ahead of canonical.
+
+**Import (single file / ZIP):** write all entries locally, verify, then `save`
+each (or `deletePrefix` then upload for a full replace).
+
+## Config / env
+
+In `lib/env/index.ts` (+ `.env.example`):
+
+- `STORAGE_BACKEND`: `s3 | memory`, default `memory` (tests + local dev need no
+  infra; prod sets `s3`).
+- S3 group — **required only when `STORAGE_BACKEND=s3`** via a Zod `superRefine`
+  conditional, matching the existing fail-fast pattern:
+  - `S3_ENDPOINT`
+  - `S3_REGION` (default `garage`)
+  - `S3_BUCKET` (e.g. `ledger`)
+  - `S3_ACCESS_KEY_ID`
+  - `S3_SECRET_ACCESS_KEY`
+  - `S3_FORCE_PATH_STYLE` (default `true`)
+- `DATA_DIR` keeps its name but is now an **ephemeral cache**, not the source of
+  truth — noted in `.env.example`.
+
+## Garage deployment on new-raxel
+
+Deliverables here are a `docs/` runbook + `garage.toml`. Actually clicking
+deploy in Coolify is the user's step (the host isn't reachable from this agent).
+
+- Run `dxflrs/garage` as a Coolify service with two persistent volumes
+  (`/var/lib/garage/data`, `/var/lib/garage/meta`).
+- `garage.toml`: `rpc_secret`, S3 API bound on an internal port,
+  `s3_region = "garage"`, path-style.
+- One-time provisioning (documented commands):
+  - `garage layout assign` (single node, replication factor 1)
+  - `garage bucket create ledger`
+  - `garage key create ledger-app`
+  - `garage bucket allow --read --write ledger --key ledger-app`
+- Expose the S3 endpoint **only on Coolify's internal network** to the app
+  container (not public). App env points `S3_ENDPOINT` at it. Consistent with
+  the locked-down admin-ports posture on that box (see new-raxel server notes).
+
+## Failure behavior when Garage is unreachable
+
+- **Reads:** if `ListObjectsV2` fails but a local cache + manifest exist → serve
+  from cache and log a warning (availability wins for a single-user app). If the
+  cache is cold → fail loudly with a clear error. (Strictness can be made
+  configurable later.)
+- **Writes:** `ensureLocal` failure or push failure → **rollback the local
+  mutation and throw**; never leave local ahead of canonical. A `412` surfaces
+  as "modified elsewhere — reload and retry."
+
+## Concurrency / consistency
+
+Single-admin app (locked to `sharp.fk@gmail.com`), so contention is low. The
+per-user mutex already serializes writes within an instance. Conditional
+`PutObject` (`If-Match`) guards the rare two-instance race; on `412`, re-sync and
+surface a retry error.
+
+## Testing
+
+- Unit-test `sync.ts` / `save.ts` / `download.ts` against `MemoryObjectStore`:
+  list → diff → download, manifest correctness, fingerprint stability/change,
+  conditional-put conflict, rollback-on-verify-failure.
+- The existing ~345 tests run with `STORAGE_BACKEND=memory`; the journal
+  repo/service suites get the memory backend injected and keep passing with no
+  real Garage.
+- One optional integration test against a real S3 endpoint, gated behind an env
+  flag (skipped in CI unless configured).
+
+## Files
+
+**New:**
+- `lib/storage/objectStore.ts`, `client.ts`, `s3ObjectStore.ts`,
+  `memoryObjectStore.ts`, `save.ts`, `download.ts`, `sync.ts`, `manifest.ts`,
+  `index.ts`
+- `docs/<runbook>.md`, `garage.toml`
+- Sync test files + fixtures
+
+**Modified:**
+- `lib/journal/repository.ts` (inject storage; `ensureLocal` on read, `save` on
+  write; `emptyJournalDir` clears store + local; replace `getMaxMtime` with
+  fingerprint)
+- `lib/journal/service.ts` (write ordering: mutate → verify → push; rollback)
+- `utils/runLedger.ts` (fingerprint cache key)
+- `lib/env/index.ts`, `.env.example`
+- `PLAN.md` (entry under Phase 7 — multi-user hardening / backups)
+
+## Out of scope
+
+- Data migration of existing journal files (fresh start).
+- Multi-node Garage / replication beyond factor 1.
+- Public exposure of the Garage endpoint.
+- Encrypted-at-rest journals (separate Phase 7 item).

--- a/features/transactions/Transactions.tsx
+++ b/features/transactions/Transactions.tsx
@@ -7,7 +7,7 @@ import {
 } from './applyTransactionFilters';
 import Help from '@/components/Help';
 import { requireUser } from '@/lib/auth/require-user';
-import { journalRepository, journalService } from '@/lib/journal';
+import { journalRepository } from '@/lib/journal';
 import { getJournalCacheTag } from '@/lib/journal/layout';
 import { type Transaction } from '@/lib/journal/parser';
 import { savedViewService } from '@/lib/savedViews';
@@ -16,7 +16,10 @@ import { unstable_cache } from 'next/cache';
 const buildLoader = (tag: string, fingerprint: string) =>
   unstable_cache(
     async (userId: string): Promise<Transaction[]> => {
-      const journal = await journalService.listTransactions(userId);
+      // getFingerprint (below) already pulled the canonical journal into the
+      // local cache, so read straight from the repository — going through
+      // journalService.listTransactions would pull a second time.
+      const journal = await journalRepository.list(userId);
       return journal.transactions;
     },
     ['journal-transactions', tag, fingerprint],

--- a/features/transactions/Transactions.tsx
+++ b/features/transactions/Transactions.tsx
@@ -13,19 +13,19 @@ import { type Transaction } from '@/lib/journal/parser';
 import { savedViewService } from '@/lib/savedViews';
 import { unstable_cache } from 'next/cache';
 
-const buildLoader = (tag: string, mtimeMs: number) =>
+const buildLoader = (tag: string, fingerprint: string) =>
   unstable_cache(
     async (userId: string): Promise<Transaction[]> => {
       const journal = await journalService.listTransactions(userId);
       return journal.transactions;
     },
-    ['journal-transactions', tag, String(mtimeMs)],
+    ['journal-transactions', tag, fingerprint],
     { revalidate: 60, tags: [tag] }
   );
 
 const loadTransactions = async (userId: string) => {
-  const mtimeMs = await journalRepository.getMaxMtime(userId);
-  return buildLoader(getJournalCacheTag(userId), mtimeMs)(userId);
+  const fingerprint = await journalRepository.getFingerprint(userId);
+  return buildLoader(getJournalCacheTag(userId), fingerprint)(userId);
 };
 
 const Transactions = async ({

--- a/lib/env/index.ts
+++ b/lib/env/index.ts
@@ -2,49 +2,82 @@ import { z } from 'zod';
 import 'server-only';
 import { clientEnvSchema } from './client';
 
-const envSchema = clientEnvSchema.extend({
-  // Auth — required
-  BETTER_AUTH_SECRET: z
-    .string()
-    .min(
-      32,
-      'BETTER_AUTH_SECRET must be at least 32 characters (generate one: `openssl rand -base64 32`)'
-    ),
-  BETTER_AUTH_URL: z.string().url().default('http://localhost:3000'),
+const envSchema = clientEnvSchema
+  .extend({
+    // Auth — required
+    BETTER_AUTH_SECRET: z
+      .string()
+      .min(
+        32,
+        'BETTER_AUTH_SECRET must be at least 32 characters (generate one: `openssl rand -base64 32`)'
+      ),
+    BETTER_AUTH_URL: z.string().url().default('http://localhost:3000'),
 
-  // Storage — Postgres connection string (postgres://user:pass@host:5432/db)
-  DATABASE_URL: z.string().url(),
+    // Storage — Postgres connection string (postgres://user:pass@host:5432/db)
+    DATABASE_URL: z.string().url(),
 
-  // Root directory for persistent journals (one subdir per user). Validated
-  // here so an empty/missing value fails fast at startup rather than silently
-  // writing journals under ./data. Read at runtime via process.env in
-  // lib/journal/layout.ts (so tests can override it per-case).
-  DATA_DIR: z.string().min(1).default('./data'),
+    // Root directory for persistent journals (one subdir per user). Validated
+    // here so an empty/missing value fails fast at startup rather than silently
+    // writing journals under ./data. Read at runtime via process.env in
+    // lib/journal/layout.ts (so tests can override it per-case).
+    DATA_DIR: z.string().min(1).default('./data'),
 
-  // Email (magic link). Delivered via the self-hosted Postal server (see
-  // lib/email-transport.ts). Both Postal vars are required so a missing/empty
-  // value fails fast at startup rather than the first time someone signs in.
-  EMAIL_FROM: z.string().default('auth@example.com'),
-  POSTAL_API_URL: z.string().url(),
-  POSTAL_API_KEY: z.string().min(1),
+    // Email (magic link). Delivered via the self-hosted Postal server (see
+    // lib/email-transport.ts). Both Postal vars are required so a missing/empty
+    // value fails fast at startup rather than the first time someone signs in.
+    EMAIL_FROM: z.string().default('auth@example.com'),
+    POSTAL_API_URL: z.string().url(),
+    POSTAL_API_KEY: z.string().min(1),
 
-  // Google OAuth (optional)
-  GOOGLE_CLIENT_ID: z.string().optional(),
-  GOOGLE_CLIENT_SECRET: z.string().optional(),
+    // Google OAuth (optional)
+    GOOGLE_CLIENT_ID: z.string().optional(),
+    GOOGLE_CLIENT_SECRET: z.string().optional(),
 
-  // Ledger
-  DEFAULT_CURRENCY: z.string().default('USD'),
-  LEDGER_PRICE_DB: z.string().optional(),
-  DATE_LOCALE: z.string().default('en-US'),
-  PORTFOLIO_ACCOUNT_PREFIX: z.string().default('Assets:Investments'),
+    // Ledger
+    DEFAULT_CURRENCY: z.string().default('USD'),
+    LEDGER_PRICE_DB: z.string().optional(),
+    DATE_LOCALE: z.string().default('en-US'),
+    PORTFOLIO_ACCOUNT_PREFIX: z.string().default('Assets:Investments'),
 
-  // Prices
-  PRICE_REFRESH_HOUR: z.coerce.number().int().min(0).max(23).default(6),
-  PRICE_REFRESH_ENABLED: z
-    .union([z.literal('true'), z.literal('false')])
-    .default('true')
-    .transform((v) => v === 'true'),
-});
+    // Prices
+    PRICE_REFRESH_HOUR: z.coerce.number().int().min(0).max(23).default(6),
+    PRICE_REFRESH_ENABLED: z
+      .union([z.literal('true'), z.literal('false')])
+      .default('true')
+      .transform((v) => v === 'true'),
+
+    // Object storage (Garage / S3-compatible). DATA_DIR is the local cache;
+    // these point at the canonical store. S3_* are required only when
+    // STORAGE_BACKEND === 's3' (enforced by the superRefine below).
+    STORAGE_BACKEND: z.enum(['s3', 'memory']).default('memory'),
+    S3_ENDPOINT: z.string().url().optional(),
+    S3_REGION: z.string().default('garage'),
+    S3_BUCKET: z.string().optional(),
+    S3_ACCESS_KEY_ID: z.string().optional(),
+    S3_SECRET_ACCESS_KEY: z.string().optional(),
+    S3_FORCE_PATH_STYLE: z
+      .union([z.literal('true'), z.literal('false')])
+      .default('true')
+      .transform((v) => v === 'true'),
+  })
+  .superRefine((val, ctx) => {
+    if (val.STORAGE_BACKEND !== 's3') return;
+    const required = [
+      'S3_ENDPOINT',
+      'S3_BUCKET',
+      'S3_ACCESS_KEY_ID',
+      'S3_SECRET_ACCESS_KEY',
+    ] as const;
+    for (const key of required) {
+      if (!val[key]) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [key],
+          message: `${key} is required when STORAGE_BACKEND=s3`,
+        });
+      }
+    }
+  });
 
 const parsed = envSchema.safeParse(process.env);
 

--- a/lib/env/storage-env.test.ts
+++ b/lib/env/storage-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// A minimal valid baseline so the rest of the schema passes; we only vary the
+// storage-related vars per test.
+const BASE_ENV: Record<string, string> = {
+  BETTER_AUTH_SECRET: 'x'.repeat(32),
+  DATABASE_URL: 'postgres://u:p@localhost:5432/db',
+  POSTAL_API_URL: 'https://postal.example.com',
+  POSTAL_API_KEY: 'k',
+};
+
+const loadEnv = async (overrides: Record<string, string | undefined>) => {
+  vi.resetModules();
+  const prev = process.env;
+  process.env = { ...BASE_ENV, ...overrides } as NodeJS.ProcessEnv;
+  try {
+    const mod = await import('./index');
+    return mod.env;
+  } finally {
+    process.env = prev;
+  }
+};
+
+describe('storage env', () => {
+  it('defaults STORAGE_BACKEND to memory and needs no S3 vars', async () => {
+    const env = await loadEnv({});
+    expect(env.STORAGE_BACKEND).toBe('memory');
+  });
+
+  it('defaults S3_REGION to garage and S3_FORCE_PATH_STYLE to true', async () => {
+    const env = await loadEnv({
+      STORAGE_BACKEND: 's3',
+      S3_ENDPOINT: 'http://garage:3900',
+      S3_BUCKET: 'ledger',
+      S3_ACCESS_KEY_ID: 'id',
+      S3_SECRET_ACCESS_KEY: 'secret',
+    });
+    expect(env.S3_REGION).toBe('garage');
+    expect(env.S3_FORCE_PATH_STYLE).toBe(true);
+  });
+
+  it('throws when STORAGE_BACKEND=s3 but S3 vars are missing', async () => {
+    await expect(loadEnv({ STORAGE_BACKEND: 's3' })).rejects.toThrow(
+      /S3_ENDPOINT/
+    );
+  });
+});

--- a/lib/journal/integration.test.ts
+++ b/lib/journal/integration.test.ts
@@ -1,13 +1,22 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getJournalDir } from './layout';
 import { parseJournal } from './parser';
 import { JournalRepository } from './repository';
 import { JournalService } from './service';
+import { resetObjectStore, push } from '@/lib/storage';
 import { setupTestDb, teardownTestDb } from '@/lib/test-utils/db';
 
 describe('Phase 4.1 integration', () => {
+  beforeEach(() => {
+    resetObjectStore();
+  });
+
+  afterEach(() => {
+    resetObjectStore();
+  });
+
   it('parses → backfills → edits → deletes a real fixture', async () => {
     const src = path.resolve(__dirname, '__fixtures__/integration');
     const ctx = await setupTestDb('integration-');
@@ -27,6 +36,9 @@ describe('Phase 4.1 integration', () => {
       for (const name of ['main.ledger', 'q1.ledger']) {
         await fs.copyFile(path.join(src, name), path.join(dir, name));
       }
+      // Seed canonical storage so pull() in edit/delete does not wipe the
+      // locally-copied fixtures.
+      await push(userId);
 
       const q1Content = await fs.readFile(path.join(dir, 'q1.ledger'));
       expect(Buffer.from(q1Content).includes(0x09)).toBe(true);

--- a/lib/journal/repository.test.ts
+++ b/lib/journal/repository.test.ts
@@ -3,99 +3,47 @@ import path from 'path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getJournalDir } from './layout';
 import { JournalRepository } from './repository';
+import { resetObjectStore } from '@/lib/storage';
 import {
   setupTestDb,
   teardownTestDb,
   type TestDbContext,
 } from '@/lib/test-utils/db';
 
-describe('JournalRepository.getMaxMtime', () => {
+describe('JournalRepository.getFingerprint', () => {
   let ctx: TestDbContext;
   let repo: JournalRepository;
 
   beforeEach(async () => {
-    ctx = await setupTestDb('repo-mtime-');
+    ctx = await setupTestDb('repo-fp-');
     await ctx.insertUser('test-user', 'Test', 'test@example.com');
     repo = new JournalRepository(ctx.db);
-    // Wipe journal dir so each test starts with a clean filesystem state.
+    resetObjectStore();
     await fs.rm(getJournalDir('test-user'), { recursive: true, force: true });
   });
 
   afterEach(async () => {
     await teardownTestDb(ctx);
+    resetObjectStore();
     await fs.rm(getJournalDir('test-user'), { recursive: true, force: true });
   });
 
-  it('returns the stub file mtime for a brand-new user (calls ensureLayout)', async () => {
-    const mtime = await repo.getMaxMtime('test-user');
-    expect(mtime).toBeGreaterThan(0);
+  it('returns a 64-char hex fingerprint for a brand-new user', async () => {
+    const fp = await repo.getFingerprint('test-user');
+    expect(fp).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it('returns the main file mtime when there are no includes', async () => {
-    const userId = 'test-user';
-    await repo.ensureLayout(userId);
-    const mainPath = path.join(getJournalDir(userId), 'main.ledger');
-    const target = 1_700_000_000_000;
-    await fs.utimes(mainPath, new Date(target), new Date(target));
-    const mtime = await repo.getMaxMtime(userId);
-    expect(mtime).toBe(target);
-  });
-
-  it('returns the max mtime across the include graph', async () => {
-    const userId = 'test-user';
-    const dir = getJournalDir(userId);
-    await fs.mkdir(dir, { recursive: true });
+  it('changes the fingerprint after a file is added and pushed', async () => {
+    const { pull, push } = await import('@/lib/storage');
+    const before = await repo.getFingerprint('test-user');
+    await pull('test-user');
     await fs.writeFile(
-      path.join(dir, 'main.ledger'),
-      'include ./sub.ledger\n\n2024-01-01 main\n    Expenses:Food  USD 1\n    Assets:Cash\n'
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      '2024-01-01 x\n    A  1\n    B\n'
     );
-    await fs.writeFile(
-      path.join(dir, 'sub.ledger'),
-      '2024-01-02 sub\n    Expenses:Food  USD 2\n    Assets:Cash\n'
-    );
-    const older = 1_700_000_000_000;
-    const newer = 1_800_000_000_000;
-    await fs.utimes(
-      path.join(dir, 'main.ledger'),
-      new Date(older),
-      new Date(older)
-    );
-    await fs.utimes(
-      path.join(dir, 'sub.ledger'),
-      new Date(newer),
-      new Date(newer)
-    );
-
-    const mtime = await repo.getMaxMtime(userId);
-    expect(mtime).toBe(newer);
-  });
-
-  it('reflects a sub-file change on the next call', async () => {
-    const userId = 'test-user';
-    const dir = getJournalDir(userId);
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(path.join(dir, 'main.ledger'), 'include ./sub.ledger\n');
-    await fs.writeFile(path.join(dir, 'sub.ledger'), '');
-    const first = 1_700_000_000_000;
-    await fs.utimes(
-      path.join(dir, 'main.ledger'),
-      new Date(first),
-      new Date(first)
-    );
-    await fs.utimes(
-      path.join(dir, 'sub.ledger'),
-      new Date(first),
-      new Date(first)
-    );
-    expect(await repo.getMaxMtime(userId)).toBe(first);
-
-    const later = 1_800_000_000_000;
-    await fs.utimes(
-      path.join(dir, 'sub.ledger'),
-      new Date(later),
-      new Date(later)
-    );
-    expect(await repo.getMaxMtime(userId)).toBe(later);
+    await push('test-user');
+    const after = await repo.getFingerprint('test-user');
+    expect(after).not.toBe(before);
   });
 });
 

--- a/lib/journal/repository.ts
+++ b/lib/journal/repository.ts
@@ -2,14 +2,10 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { eq, sql } from 'drizzle-orm';
 import { DEFAULT_MAIN, PRICE_DB_NAME, getJournalDir } from './layout';
-import {
-  parseJournal,
-  resolveIncludes,
-  type ParsedJournal,
-  type Transaction,
-} from './parser';
+import { parseJournal, type ParsedJournal, type Transaction } from './parser';
 import { userSetting } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
+import { pull } from '@/lib/storage';
 
 export type JournalLayout = {
   dir: string;
@@ -108,14 +104,13 @@ export class JournalRepository {
     return transactions.find((t) => t.uid === uid) ?? null;
   }
 
-  /** Returns max mtimeMs across the user's include graph. Used as a cache-key
-   * input so any file change (internal or external) invalidates `unstable_cache`. */
-  async getMaxMtime(userId: string): Promise<number> {
-    const { mainPath } = await this.ensureLayout(userId);
-    const files = await resolveIncludes(mainPath);
-    if (files.length === 0) return 0;
-    const stats = await Promise.all(files.map((f) => fs.stat(f)));
-    return Math.max(...stats.map((s) => s.mtimeMs));
+  /** Pulls the canonical journal into the local cache and returns the content
+   * fingerprint. Used as the query cache-key input so any change (local or in
+   * Garage) invalidates `unstable_cache`. Also guarantees the local stub exists. */
+  async getFingerprint(userId: string): Promise<string> {
+    const { fingerprint } = await pull(userId);
+    await this.ensureLayout(userId);
+    return fingerprint;
   }
 
   private async findPriceDb(dir: string): Promise<string | null> {

--- a/lib/journal/repository.ts
+++ b/lib/journal/repository.ts
@@ -5,7 +5,7 @@ import { DEFAULT_MAIN, PRICE_DB_NAME, getJournalDir } from './layout';
 import { parseJournal, type ParsedJournal, type Transaction } from './parser';
 import { userSetting } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
-import { pull, manifestRelName } from '@/lib/storage';
+import { pullLocked, manifestRelName } from '@/lib/storage';
 
 export type JournalLayout = {
   dir: string;
@@ -115,7 +115,7 @@ export class JournalRepository {
    * fingerprint. Used as the query cache-key input so any change (local or in
    * Garage) invalidates `unstable_cache`. Also guarantees the local stub exists. */
   async getFingerprint(userId: string): Promise<string> {
-    const { fingerprint } = await pull(userId);
+    const { fingerprint } = await pullLocked(userId);
     await this.ensureLayout(userId);
     return fingerprint;
   }

--- a/lib/journal/repository.ts
+++ b/lib/journal/repository.ts
@@ -5,7 +5,7 @@ import { DEFAULT_MAIN, PRICE_DB_NAME, getJournalDir } from './layout';
 import { parseJournal, type ParsedJournal, type Transaction } from './parser';
 import { userSetting } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
-import { pull } from '@/lib/storage';
+import { pull, clearRemote } from '@/lib/storage';
 
 export type JournalLayout = {
   dir: string;
@@ -64,9 +64,11 @@ export class JournalRepository {
       });
   }
 
-  /** Wipes the journal directory and recreates it empty. Used by the import flow. */
+  /** Wipes the user's journal locally AND in canonical storage, then recreates
+   * the local dir empty. Used by the import flow. */
   async emptyJournalDir(userId: string): Promise<void> {
     const dir = getJournalDir(userId);
+    await clearRemote(userId);
     try {
       await fs.rm(dir, { recursive: true, force: true });
     } catch {

--- a/lib/journal/repository.ts
+++ b/lib/journal/repository.ts
@@ -5,7 +5,7 @@ import { DEFAULT_MAIN, PRICE_DB_NAME, getJournalDir } from './layout';
 import { parseJournal, type ParsedJournal, type Transaction } from './parser';
 import { userSetting } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
-import { pull, clearRemote } from '@/lib/storage';
+import { pull, manifestRelName } from '@/lib/storage';
 
 export type JournalLayout = {
   dir: string;
@@ -64,17 +64,22 @@ export class JournalRepository {
       });
   }
 
-  /** Wipes the user's journal locally AND in canonical storage, then recreates
-   * the local dir empty. Used by the import flow. */
-  async emptyJournalDir(userId: string): Promise<void> {
+  /** Removes the user's journal files locally but PRESERVES the storage manifest
+   * (.manifest.json), so a subsequent push can diff against canonical and replace
+   * it atomically (upload new + delete orphans) without first wiping canonical. */
+  async resetLocalJournal(userId: string): Promise<void> {
     const dir = getJournalDir(userId);
-    await clearRemote(userId);
-    try {
-      await fs.rm(dir, { recursive: true, force: true });
-    } catch {
-      // ignore
-    }
     await fs.mkdir(dir, { recursive: true });
+    const entries = await fs
+      .readdir(dir, { withFileTypes: true })
+      .catch(() => []);
+    await Promise.all(
+      entries
+        .filter((e) => e.name !== manifestRelName)
+        .map((e) =>
+          fs.rm(path.join(dir, e.name), { recursive: true, force: true })
+        )
+    );
   }
 
   /** Reads a file by absolute path. */

--- a/lib/journal/repository.ts
+++ b/lib/journal/repository.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { eq, sql } from 'drizzle-orm';
@@ -6,6 +7,18 @@ import { parseJournal, type ParsedJournal, type Transaction } from './parser';
 import { userSetting } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
 import { pullLocked, manifestRelName } from '@/lib/storage';
+
+/**
+ * Request-scoped dedup of the read-path pull. A single render fires ~8
+ * concurrent reads (7× runLedger + recent-tx/stats), each of which needs the
+ * canonical journal pulled into the local cache. Without this, the read-path
+ * lock serializes them into N back-to-back ListObjectsV2 round-trips that all
+ * return identical data. React's `cache()` coalesces same-userId callers in one
+ * request to a single pull. Keyed by userId so distinct users don't collide.
+ */
+const cachedPull = cache(
+  (userId: string): Promise<{ fingerprint: string }> => pullLocked(userId)
+);
 
 export type JournalLayout = {
   dir: string;
@@ -115,7 +128,7 @@ export class JournalRepository {
    * fingerprint. Used as the query cache-key input so any change (local or in
    * Garage) invalidates `unstable_cache`. Also guarantees the local stub exists. */
   async getFingerprint(userId: string): Promise<string> {
-    const { fingerprint } = await pullLocked(userId);
+    const { fingerprint } = await cachedPull(userId);
     await this.ensureLayout(userId);
     return fingerprint;
   }

--- a/lib/journal/service-zip.test.ts
+++ b/lib/journal/service-zip.test.ts
@@ -5,7 +5,7 @@ import AdmZip from 'adm-zip';
 import { getJournalDir } from './layout';
 import { JournalRepository } from './repository';
 import { JournalService } from './service';
-import { resetObjectStore } from '@/lib/storage';
+import { resetObjectStore, getObjectStore } from '@/lib/storage';
 import {
   setupTestDb,
   teardownTestDb,
@@ -114,6 +114,43 @@ describe('JournalService.replaceFromZip', () => {
       expect(
         await fs.readFile(path.join(dir, 'sub', 'sub.ledger'), 'utf-8')
       ).toContain('2024-01-01 a');
+    });
+  });
+
+  describe('atomic canonical replace (orphan removal)', () => {
+    it('single-file import after zip-import removes orphan files from canonical', async () => {
+      const userId = 'test-user';
+
+      // 1. Zip-import: two ledger files land in canonical.
+      const zip = buildZip([
+        { name: 'main.ledger', content: '2024-01-01 a\n    A  USD 1\n    B\n' },
+        {
+          name: 'extra.ledger',
+          content: '2024-01-02 b\n    A  USD 2\n    B\n',
+        },
+      ]);
+      await service.replaceFromZip(userId, zip);
+
+      const store = getObjectStore();
+      const afterZip = await store.list(`journals/${userId}/`);
+      const afterZipKeys = afterZip.map((o) => o.key);
+      expect(afterZipKeys.some((k) => k.includes('main.ledger'))).toBe(true);
+      expect(afterZipKeys.some((k) => k.includes('extra.ledger'))).toBe(true);
+
+      // 2. Single-file import: only main.ledger should survive in canonical.
+      const singleContent = Buffer.from(
+        '2024-03-01 c\n    A  USD 3\n    B\n',
+        'utf-8'
+      );
+      await service.replaceFromSingleFile(userId, singleContent);
+
+      const afterSingle = await store.list(`journals/${userId}/`);
+      const afterSingleKeys = afterSingle.map((o) => o.key);
+      expect(afterSingleKeys.some((k) => k.includes('main.ledger'))).toBe(true);
+      // extra.ledger must be gone — the push replaced canonical atomically.
+      expect(afterSingleKeys.some((k) => k.includes('extra.ledger'))).toBe(
+        false
+      );
     });
   });
 });

--- a/lib/journal/service-zip.test.ts
+++ b/lib/journal/service-zip.test.ts
@@ -5,6 +5,7 @@ import AdmZip from 'adm-zip';
 import { getJournalDir } from './layout';
 import { JournalRepository } from './repository';
 import { JournalService } from './service';
+import { resetObjectStore } from '@/lib/storage';
 import {
   setupTestDb,
   teardownTestDb,
@@ -26,6 +27,7 @@ describe('JournalService.replaceFromZip', () => {
   let service: JournalService;
 
   beforeEach(async () => {
+    resetObjectStore();
     ctx = await setupTestDb('zip-');
     await ctx.insertUser('test-user', 'Test', 'test@example.com');
     service = new JournalService(new JournalRepository(ctx.db));
@@ -33,6 +35,7 @@ describe('JournalService.replaceFromZip', () => {
 
   afterEach(async () => {
     await teardownTestDb(ctx);
+    resetObjectStore();
   });
 
   describe('detectMain', () => {

--- a/lib/journal/service.test.ts
+++ b/lib/journal/service.test.ts
@@ -6,6 +6,7 @@ import { getJournalDir } from './layout';
 import { JournalRepository } from './repository';
 import { JournalService } from './service';
 import { findUidInBlock } from '@/lib/journal/uid';
+import { getObjectStore, resetObjectStore, push } from '@/lib/storage';
 import {
   setupTestDb,
   teardownTestDb,
@@ -21,6 +22,7 @@ describe('JournalService.addTransaction', () => {
   let service: JournalService;
 
   beforeEach(async () => {
+    resetObjectStore();
     ctx = await setupTestDb('journal-add-');
     await insertTestUser(ctx);
     service = new JournalService(new JournalRepository(ctx.db));
@@ -28,6 +30,7 @@ describe('JournalService.addTransaction', () => {
 
   afterEach(async () => {
     await teardownTestDb(ctx);
+    resetObjectStore();
   });
 
   it('stamps a ULID on the new block', async () => {
@@ -63,6 +66,23 @@ describe('JournalService.addTransaction', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.fieldErrors.date).toBeDefined();
   });
+
+  it('persists an added transaction to canonical storage', async () => {
+    const userId = 'test-user';
+    await fs.mkdir(getJournalDir(userId), { recursive: true });
+    const res = await service.addTransaction(userId, {
+      date: '2024-03-01',
+      payee: 'Coffee',
+      postings: [
+        { account: 'Expenses:Food', amount: '3', currency: 'USD' },
+        { account: 'Assets:Cash', amount: '-3', currency: 'USD' },
+      ],
+    });
+    expect(res.ok).toBe(true);
+    const store = getObjectStore();
+    const remote = await store.list(`journals/${userId}/`);
+    expect(remote.length).toBeGreaterThan(0);
+  });
 });
 
 describe('JournalService.editTransaction', () => {
@@ -70,6 +90,7 @@ describe('JournalService.editTransaction', () => {
   let service: JournalService;
 
   beforeEach(async () => {
+    resetObjectStore();
     ctx = await setupTestDb('journal-edit-');
     await insertTestUser(ctx);
     service = new JournalService(new JournalRepository(ctx.db));
@@ -77,6 +98,7 @@ describe('JournalService.editTransaction', () => {
 
   afterEach(async () => {
     await teardownTestDb(ctx);
+    resetObjectStore();
   });
 
   it('rewrites only the target block; rest byte-exact', async () => {
@@ -95,6 +117,7 @@ describe('JournalService.editTransaction', () => {
       '    Expenses:Coffee                          USD 4\n' +
       '    Assets:Cash                              USD -4\n';
     await fs.writeFile(path.join(dir, 'main.ledger'), before);
+    await push(userId);
 
     const draftBefore = {
       date: '2024-09-01',
@@ -138,6 +161,7 @@ describe('JournalService.editTransaction', () => {
       path.join(dir, 'main.ledger'),
       '2024-09-01 lunch\n    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DJC\n    Expenses:Food  USD 10\n    Assets:Cash\n'
     );
+    await push(userId);
 
     const result = await service.editTransaction(userId, {
       kind: 'edit',
@@ -165,6 +189,7 @@ describe('JournalService.editTransaction', () => {
       path.join(getJournalDir(userId), 'main.ledger'),
       '2024-09-01 lunch\n    Expenses:Food  USD 10\n    Assets:Cash\n'
     );
+    await push(userId);
 
     const result = await service.editTransaction(userId, {
       kind: 'edit',
@@ -191,6 +216,7 @@ describe('JournalService.deleteTransaction', () => {
   let service: JournalService;
 
   beforeEach(async () => {
+    resetObjectStore();
     ctx = await setupTestDb('journal-del-');
     await insertTestUser(ctx);
     service = new JournalService(new JournalRepository(ctx.db));
@@ -198,6 +224,7 @@ describe('JournalService.deleteTransaction', () => {
 
   afterEach(async () => {
     await teardownTestDb(ctx);
+    resetObjectStore();
   });
 
   it('removes the block plus the trailing blank line', async () => {
@@ -214,6 +241,7 @@ describe('JournalService.deleteTransaction', () => {
       '    Expenses:Coffee  USD 4\n' +
       '    Assets:Cash\n';
     await fs.writeFile(path.join(dir, 'main.ledger'), before);
+    await push(userId);
 
     const draft = {
       date: '2024-09-01',
@@ -254,6 +282,7 @@ describe('JournalService.deleteTransaction', () => {
       '    Expenses:Food  USD 10\n' +
       '    Assets:Cash\n';
     await fs.writeFile(path.join(dir, 'main.ledger'), before);
+    await push(userId);
 
     const draft = {
       date: '2024-09-01',
@@ -286,6 +315,7 @@ describe('JournalService.backfillUids', () => {
   let service: JournalService;
 
   beforeEach(async () => {
+    resetObjectStore();
     ctx = await setupTestDb('journal-bf-');
     await insertTestUser(ctx);
     service = new JournalService(new JournalRepository(ctx.db));
@@ -293,6 +323,7 @@ describe('JournalService.backfillUids', () => {
 
   afterEach(async () => {
     await teardownTestDb(ctx);
+    resetObjectStore();
   });
 
   it('inserts UID into every block lacking one', async () => {

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -144,45 +144,47 @@ export class JournalService {
       return { ok: false, fieldErrors };
     }
 
-    const draft: TransactionDraft = { ...parsed.data, uid: generateUid() };
-    await pull(userId);
-    const { mainPath } = await this.repo.ensureLayout(userId);
-    // Snapshot the file so we can roll back if ledger rejects the result.
-    const snapshot = await this.repo.readFile(mainPath);
-    // Leading "\n\n" guards against imported files that lack a trailing newline.
-    const block = `\n\n${formatTransaction(draft)}\n`;
-    try {
-      await this.repo.appendFile(mainPath, block);
-    } catch (e) {
-      return {
-        ok: false,
-        fieldErrors: {},
-        formError: e instanceof Error ? e.message : 'Failed to write journal',
-      };
-    }
-    const verify = await verifyJournalParseable(mainPath);
-    if (!verify.ok) {
-      // Roll back so the journal stays parseable.
-      await this.repo.writeFileAtomic(mainPath, snapshot);
-      return {
-        ok: false,
-        fieldErrors: {},
-        formError: `Ledger rejected the new transaction: ${verify.firstLine}`,
-      };
-    }
-    try {
-      await push(userId);
-    } catch (e) {
-      // Local is ahead of canonical — roll back so we never diverge.
-      await this.repo.writeFileAtomic(mainPath, snapshot);
-      const formError =
-        e instanceof StorageConflictError
-          ? e.message
-          : 'Failed to save journal to storage.';
-      return { ok: false, fieldErrors: {}, formError };
-    }
-    invalidateCache(userId);
-    return { ok: true };
+    return withUserLock(userId, async () => {
+      const draft: TransactionDraft = { ...parsed.data, uid: generateUid() };
+      await pull(userId);
+      const { mainPath } = await this.repo.ensureLayout(userId);
+      // Snapshot the file so we can roll back if ledger rejects the result.
+      const snapshot = await this.repo.readFile(mainPath);
+      // Leading "\n\n" guards against imported files that lack a trailing newline.
+      const block = `\n\n${formatTransaction(draft)}\n`;
+      try {
+        await this.repo.appendFile(mainPath, block);
+      } catch (e) {
+        return {
+          ok: false,
+          fieldErrors: {},
+          formError: e instanceof Error ? e.message : 'Failed to write journal',
+        };
+      }
+      const verify = await verifyJournalParseable(mainPath);
+      if (!verify.ok) {
+        // Roll back so the journal stays parseable.
+        await this.repo.writeFileAtomic(mainPath, snapshot);
+        return {
+          ok: false,
+          fieldErrors: {},
+          formError: `Ledger rejected the new transaction: ${verify.firstLine}`,
+        };
+      }
+      try {
+        await push(userId);
+      } catch (e) {
+        // Local is ahead of canonical — roll back so we never diverge.
+        await this.repo.writeFileAtomic(mainPath, snapshot);
+        const formError =
+          e instanceof StorageConflictError
+            ? e.message
+            : 'Failed to save journal to storage.';
+        return { ok: false, fieldErrors: {}, formError };
+      }
+      invalidateCache(userId);
+      return { ok: true };
+    });
   }
 
   async editTransaction(
@@ -220,31 +222,34 @@ export class JournalService {
     userId: string,
     content: Buffer
   ): Promise<{ uidsAdded: number; parseFailure?: string }> {
-    await this.repo.emptyJournalDir(userId);
-    const dir = getJournalDir(userId);
-    const mainPath = path.join(dir, DEFAULT_MAIN);
-    await fs.writeFile(mainPath, content);
-    await this.repo.setMainFile(userId, DEFAULT_MAIN);
-    const backfill = await this.backfillUids(userId);
-    invalidateCache(userId);
-    // No rollback on parse failure for imports — too much state to undo.
-    // Surface the error so the user can re-upload a clean journal.
-    const verify = await verifyJournalParseable(mainPath);
-    try {
-      await push(userId);
-    } catch (e) {
+    return withUserLock(userId, async () => {
+      await pull(userId); // sync local cache + manifest to canonical
+      await this.repo.resetLocalJournal(userId); // wipe local files, keep manifest
+      const dir = getJournalDir(userId);
+      const mainPath = path.join(dir, DEFAULT_MAIN);
+      await fs.writeFile(mainPath, content);
+      await this.repo.setMainFile(userId, DEFAULT_MAIN);
+      const backfill = await this.backfillUids(userId);
+      invalidateCache(userId);
+      // No rollback on parse failure for imports — too much state to undo.
+      // Surface the error so the user can re-upload a clean journal.
+      const verify = await verifyJournalParseable(mainPath);
+      try {
+        await push(userId);
+      } catch (e) {
+        return {
+          uidsAdded: backfill.uidsAdded,
+          parseFailure:
+            e instanceof StorageConflictError
+              ? e.message
+              : 'Failed to save journal to storage.',
+        };
+      }
       return {
         uidsAdded: backfill.uidsAdded,
-        parseFailure:
-          e instanceof StorageConflictError
-            ? e.message
-            : 'Failed to save journal to storage.',
+        ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
       };
-    }
-    return {
-      uidsAdded: backfill.uidsAdded,
-      ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
-    };
+    });
   }
 
   /** Extracts a .zip into the journal dir, picks a main file, backfills UIDs. */
@@ -269,45 +274,48 @@ export class JournalService {
       }
     }
 
-    await this.repo.emptyJournalDir(userId);
-    const dir = getJournalDir(userId);
+    return withUserLock(userId, async () => {
+      await pull(userId); // sync local cache + manifest to canonical
+      await this.repo.resetLocalJournal(userId); // wipe local files, keep manifest
+      const dir = getJournalDir(userId);
 
-    for (const entry of entries) {
-      const target = path.join(dir, entry.entryName);
-      const resolved = path.resolve(target);
-      if (!resolved.startsWith(path.resolve(dir) + path.sep)) {
-        throw new Error(`Unsafe path in archive: ${entry.entryName}`);
+      for (const entry of entries) {
+        const target = path.join(dir, entry.entryName);
+        const resolved = path.resolve(target);
+        if (!resolved.startsWith(path.resolve(dir) + path.sep)) {
+          throw new Error(`Unsafe path in archive: ${entry.entryName}`);
+        }
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, entry.getData());
       }
-      await fs.mkdir(path.dirname(target), { recursive: true });
-      await fs.writeFile(target, entry.getData());
-    }
 
-    const mainFile = detectMain(entries.map((e) => ({ name: e.entryName })));
-    await this.repo.setMainFile(userId, mainFile);
-    const backfill = await this.backfillUids(userId);
-    invalidateCache(userId);
-    // No rollback on parse failure for imports — too much state to undo.
-    // Surface the error so the user can re-upload a clean journal.
-    const verify = await verifyJournalParseable(path.join(dir, mainFile));
-    try {
-      await push(userId);
-    } catch (e) {
+      const mainFile = detectMain(entries.map((e) => ({ name: e.entryName })));
+      await this.repo.setMainFile(userId, mainFile);
+      const backfill = await this.backfillUids(userId);
+      invalidateCache(userId);
+      // No rollback on parse failure for imports — too much state to undo.
+      // Surface the error so the user can re-upload a clean journal.
+      const verify = await verifyJournalParseable(path.join(dir, mainFile));
+      try {
+        await push(userId);
+      } catch (e) {
+        return {
+          mainFile,
+          fileCount: entries.length,
+          uidsAdded: backfill.uidsAdded,
+          parseFailure:
+            e instanceof StorageConflictError
+              ? e.message
+              : 'Failed to save journal to storage.',
+        };
+      }
       return {
         mainFile,
         fileCount: entries.length,
         uidsAdded: backfill.uidsAdded,
-        parseFailure:
-          e instanceof StorageConflictError
-            ? e.message
-            : 'Failed to save journal to storage.',
+        ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
       };
-    }
-    return {
-      mainFile,
-      fileCount: entries.length,
-      uidsAdded: backfill.uidsAdded,
-      ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
-    };
+    });
   }
 
   // ---- internals ------------------------------------------------------------

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -230,7 +230,17 @@ export class JournalService {
     // No rollback on parse failure for imports — too much state to undo.
     // Surface the error so the user can re-upload a clean journal.
     const verify = await verifyJournalParseable(mainPath);
-    await push(userId);
+    try {
+      await push(userId);
+    } catch (e) {
+      return {
+        uidsAdded: backfill.uidsAdded,
+        parseFailure:
+          e instanceof StorageConflictError
+            ? e.message
+            : 'Failed to save journal to storage.',
+      };
+    }
     return {
       uidsAdded: backfill.uidsAdded,
       ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
@@ -279,7 +289,19 @@ export class JournalService {
     // No rollback on parse failure for imports — too much state to undo.
     // Surface the error so the user can re-upload a clean journal.
     const verify = await verifyJournalParseable(path.join(dir, mainFile));
-    await push(userId);
+    try {
+      await push(userId);
+    } catch (e) {
+      return {
+        mainFile,
+        fileCount: entries.length,
+        uidsAdded: backfill.uidsAdded,
+        parseFailure:
+          e instanceof StorageConflictError
+            ? e.message
+            : 'Failed to save journal to storage.',
+      };
+    }
     return {
       mainFile,
       fileCount: entries.length,

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -19,6 +19,7 @@ import {
 import { JournalRepository } from './repository';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
+import { pull, push, StorageConflictError } from '@/lib/storage';
 import {
   formatTransaction,
   transactionDraftSchema,
@@ -115,6 +116,7 @@ export class JournalService {
   // ---- read passthroughs ----------------------------------------------------
 
   async listTransactions(userId: string): Promise<ParsedJournal> {
+    await pull(userId);
     return this.repo.list(userId);
   }
 
@@ -122,6 +124,7 @@ export class JournalService {
     userId: string,
     uid: string
   ): Promise<Transaction | null> {
+    await pull(userId);
     return this.repo.find(userId, uid);
   }
 
@@ -142,6 +145,7 @@ export class JournalService {
     }
 
     const draft: TransactionDraft = { ...parsed.data, uid: generateUid() };
+    await pull(userId);
     const { mainPath } = await this.repo.ensureLayout(userId);
     // Snapshot the file so we can roll back if ledger rejects the result.
     const snapshot = await this.repo.readFile(mainPath);
@@ -165,6 +169,17 @@ export class JournalService {
         fieldErrors: {},
         formError: `Ledger rejected the new transaction: ${verify.firstLine}`,
       };
+    }
+    try {
+      await push(userId);
+    } catch (e) {
+      // Local is ahead of canonical — roll back so we never diverge.
+      await this.repo.writeFileAtomic(mainPath, snapshot);
+      const formError =
+        e instanceof StorageConflictError
+          ? e.message
+          : 'Failed to save journal to storage.';
+      return { ok: false, fieldErrors: {}, formError };
     }
     invalidateCache(userId);
     return { ok: true };
@@ -215,6 +230,7 @@ export class JournalService {
     // No rollback on parse failure for imports — too much state to undo.
     // Surface the error so the user can re-upload a clean journal.
     const verify = await verifyJournalParseable(mainPath);
+    await push(userId);
     return {
       uidsAdded: backfill.uidsAdded,
       ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
@@ -263,6 +279,7 @@ export class JournalService {
     // No rollback on parse failure for imports — too much state to undo.
     // Surface the error so the user can re-upload a clean journal.
     const verify = await verifyJournalParseable(path.join(dir, mainFile));
+    await push(userId);
     return {
       mainFile,
       fileCount: entries.length,
@@ -277,6 +294,7 @@ export class JournalService {
     userId: string,
     input: WriteEditInput
   ): Promise<WriteResult> {
+    await pull(userId);
     if (input.uid !== input.draft.uid) {
       return {
         ok: false,
@@ -354,7 +372,19 @@ export class JournalService {
         message: `Ledger rejected the edit: ${verify.firstLine}`,
       };
     }
-
+    try {
+      await push(userId);
+    } catch (e) {
+      await this.repo.writeFileAtomic(tx.file, text); // restore pre-edit content
+      return {
+        ok: false,
+        reason: 'stale',
+        message:
+          e instanceof StorageConflictError
+            ? e.message
+            : 'Failed to save journal to storage.',
+      };
+    }
     invalidateCache(userId);
     return { ok: true };
   }
@@ -363,6 +393,7 @@ export class JournalService {
     userId: string,
     input: WriteDeleteInput
   ): Promise<WriteResult> {
+    await pull(userId);
     const tx = await this.repo.find(userId, input.uid);
     if (!tx) {
       return {
@@ -424,7 +455,19 @@ export class JournalService {
         message: `Ledger rejected the delete: ${verify.firstLine}`,
       };
     }
-
+    try {
+      await push(userId);
+    } catch (e) {
+      await this.repo.writeFileAtomic(tx.file, text); // restore pre-delete content
+      return {
+        ok: false,
+        reason: 'stale',
+        message:
+          e instanceof StorageConflictError
+            ? e.message
+            : 'Failed to save journal to storage.',
+      };
+    }
     invalidateCache(userId);
     return { ok: true };
   }

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -19,7 +19,7 @@ import {
 import { JournalRepository } from './repository';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
-import { pull, push, StorageConflictError } from '@/lib/storage';
+import { pull, pullLocked, push, StorageConflictError } from '@/lib/storage';
 import {
   formatTransaction,
   transactionDraftSchema,
@@ -116,7 +116,7 @@ export class JournalService {
   // ---- read passthroughs ----------------------------------------------------
 
   async listTransactions(userId: string): Promise<ParsedJournal> {
-    await pull(userId);
+    await pullLocked(userId);
     return this.repo.list(userId);
   }
 
@@ -124,7 +124,7 @@ export class JournalService {
     userId: string,
     uid: string
   ): Promise<Transaction | null> {
-    await pull(userId);
+    await pullLocked(userId);
     return this.repo.find(userId, uid);
   }
 

--- a/lib/storage/client.test.ts
+++ b/lib/storage/client.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getObjectStore, resetObjectStore } from './client';
+import { MemoryObjectStore } from './memoryObjectStore';
+
+afterEach(() => resetObjectStore());
+
+describe('getObjectStore', () => {
+  it('returns a MemoryObjectStore when STORAGE_BACKEND is memory (default)', () => {
+    // Test env has STORAGE_BACKEND unset → defaults to 'memory'.
+    expect(getObjectStore()).toBeInstanceOf(MemoryObjectStore);
+  });
+
+  it('memoizes the instance', () => {
+    expect(getObjectStore()).toBe(getObjectStore());
+  });
+
+  it('resetObjectStore clears the memo', () => {
+    const first = getObjectStore();
+    resetObjectStore();
+    expect(getObjectStore()).not.toBe(first);
+  });
+});

--- a/lib/storage/client.ts
+++ b/lib/storage/client.ts
@@ -1,0 +1,33 @@
+import { MemoryObjectStore } from './memoryObjectStore';
+import type { ObjectStore } from './objectStore';
+import { S3ObjectStore } from './s3ObjectStore';
+import { env } from '@/lib/env';
+import { S3Client } from '@aws-sdk/client-s3';
+
+let cached: ObjectStore | null = null;
+
+const buildS3Store = (): ObjectStore => {
+  const client = new S3Client({
+    endpoint: env.S3_ENDPOINT,
+    region: env.S3_REGION,
+    forcePathStyle: env.S3_FORCE_PATH_STYLE,
+    credentials: {
+      accessKeyId: env.S3_ACCESS_KEY_ID!,
+      secretAccessKey: env.S3_SECRET_ACCESS_KEY!,
+    },
+  });
+  return new S3ObjectStore(client, env.S3_BUCKET!);
+};
+
+/** Returns the process-wide ObjectStore, building it from env on first call. */
+export const getObjectStore = (): ObjectStore => {
+  if (cached) return cached;
+  cached =
+    env.STORAGE_BACKEND === 's3' ? buildS3Store() : new MemoryObjectStore();
+  return cached;
+};
+
+/** Test-only: drop the memoized store so the next getObjectStore() rebuilds. */
+export const resetObjectStore = (): void => {
+  cached = null;
+};

--- a/lib/storage/download.test.ts
+++ b/lib/storage/download.test.ts
@@ -76,7 +76,7 @@ describe('pullToLocal', () => {
   it('serves the stale local cache when the store is unreachable but a manifest exists', async () => {
     const store = new MemoryObjectStore();
     await seed(store, { 'main.ledger': 'a' });
-    await pullToLocal(store, USER); // populates local + manifest
+    const live = await pullToLocal(store, USER); // populates local + manifest
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const downStore: ObjectStore = {
       list: async () => {
@@ -88,7 +88,7 @@ describe('pullToLocal', () => {
       deletePrefix: store.deletePrefix.bind(store),
     };
     const { fingerprint } = await pullToLocal(downStore, USER);
-    expect(fingerprint).toHaveLength(64);
+    expect(fingerprint).toBe(live.fingerprint);
     expect(await read('main.ledger')).toBe('a'); // local cache intact
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();

--- a/lib/storage/download.test.ts
+++ b/lib/storage/download.test.ts
@@ -1,9 +1,10 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { pullToLocal } from './download';
 import { keyFor, readManifest } from './manifest';
 import { MemoryObjectStore } from './memoryObjectStore';
+import type { ObjectStore } from './objectStore';
 import { getJournalDir } from '@/lib/journal/layout';
 
 const USER = 'pull-user';
@@ -61,5 +62,50 @@ describe('pullToLocal', () => {
     const store = new MemoryObjectStore();
     const { fingerprint } = await pullToLocal(store, USER);
     expect(fingerprint).toHaveLength(64);
+  });
+
+  it('rejects a remote key that escapes the journal dir and writes nothing outside', async () => {
+    const store = new MemoryObjectStore();
+    // Raw key with traversal — bypasses keyFor on purpose.
+    await store.put(`journals/${USER}/../evil.ledger`, Buffer.from('x'));
+    await expect(pullToLocal(store, USER)).rejects.toThrow(
+      /Unsafe journal object key/
+    );
+  });
+
+  it('serves the stale local cache when the store is unreachable but a manifest exists', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, { 'main.ledger': 'a' });
+    await pullToLocal(store, USER); // populates local + manifest
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const downStore: ObjectStore = {
+      list: async () => {
+        throw new Error('garage down');
+      },
+      get: store.get.bind(store),
+      put: store.put.bind(store),
+      delete: store.delete.bind(store),
+      deletePrefix: store.deletePrefix.bind(store),
+    };
+    const { fingerprint } = await pullToLocal(downStore, USER);
+    expect(fingerprint).toHaveLength(64);
+    expect(await read('main.ledger')).toBe('a'); // local cache intact
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('rethrows when the store is unreachable and no manifest exists', async () => {
+    const downStore: ObjectStore = {
+      list: async () => {
+        throw new Error('garage down');
+      },
+      get: async () => {
+        throw new Error('n/a');
+      },
+      put: async () => ({ etag: '' }),
+      delete: async () => {},
+      deletePrefix: async () => {},
+    };
+    await expect(pullToLocal(downStore, USER)).rejects.toThrow(/garage down/);
   });
 });

--- a/lib/storage/download.test.ts
+++ b/lib/storage/download.test.ts
@@ -1,0 +1,65 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { pullToLocal } from './download';
+import { keyFor, readManifest } from './manifest';
+import { MemoryObjectStore } from './memoryObjectStore';
+import { getJournalDir } from '@/lib/journal/layout';
+
+const USER = 'pull-user';
+const dir = () => getJournalDir(USER);
+const read = (rel: string) => fs.readFile(path.join(dir(), rel), 'utf-8');
+afterEach(() => fs.rm(dir(), { recursive: true, force: true }));
+
+const seed = async (
+  store: MemoryObjectStore,
+  files: Record<string, string>
+) => {
+  for (const [rel, content] of Object.entries(files)) {
+    await store.put(keyFor(USER, rel), Buffer.from(content));
+  }
+};
+
+describe('pullToLocal', () => {
+  it('downloads all remote files and writes a manifest', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, {
+      'main.ledger': 'include ./sub.ledger\n',
+      'sub.ledger': 'x',
+    });
+    const { fingerprint } = await pullToLocal(store, USER);
+    expect(await read('main.ledger')).toBe('include ./sub.ledger\n');
+    expect(await read('sub.ledger')).toBe('x');
+    expect(Object.keys(await readManifest(USER)).sort()).toEqual([
+      'main.ledger',
+      'sub.ledger',
+    ]);
+    expect(fingerprint).toHaveLength(64);
+  });
+
+  it('removes local files no longer present remotely', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, { 'main.ledger': 'a', 'gone.ledger': 'b' });
+    await pullToLocal(store, USER);
+    await store.delete(keyFor(USER, 'gone.ledger'));
+    await pullToLocal(store, USER);
+    await expect(read('gone.ledger')).rejects.toThrow();
+    expect(await read('main.ledger')).toBe('a');
+  });
+
+  it('changes the fingerprint when remote content changes', async () => {
+    const store = new MemoryObjectStore();
+    await seed(store, { 'main.ledger': 'a' });
+    const first = (await pullToLocal(store, USER)).fingerprint;
+    await store.put(keyFor(USER, 'main.ledger'), Buffer.from('b'));
+    const second = (await pullToLocal(store, USER)).fingerprint;
+    expect(second).not.toBe(first);
+    expect(await read('main.ledger')).toBe('b');
+  });
+
+  it('returns a stable fingerprint for an empty remote (new user)', async () => {
+    const store = new MemoryObjectStore();
+    const { fingerprint } = await pullToLocal(store, USER);
+    expect(fingerprint).toHaveLength(64);
+  });
+});

--- a/lib/storage/download.ts
+++ b/lib/storage/download.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import {
   fingerprint,
-  manifestRelName,
+  listLocalRelPaths,
   readManifest,
   relPathFromKey,
   userPrefix,
@@ -11,30 +11,6 @@ import {
 } from './manifest';
 import type { ObjectStore } from './objectStore';
 import { getJournalDir } from '@/lib/journal/layout';
-
-/** Lists the local journal dir recursively, returning relPaths (excludes the
- * manifest file and any *.tmp scratch files from atomic writes). */
-const listLocalRelPaths = async (dir: string): Promise<string[]> => {
-  const out: string[] = [];
-  const walk = async (abs: string, rel: string): Promise<void> => {
-    let entries: import('fs').Dirent[];
-    try {
-      entries = await fs.readdir(abs, { withFileTypes: true });
-    } catch {
-      return; // dir does not exist yet
-    }
-    for (const e of entries) {
-      const childRel = rel ? path.join(rel, e.name) : e.name;
-      if (e.isDirectory()) {
-        await walk(path.join(abs, e.name), childRel);
-      } else if (e.name !== manifestRelName && !e.name.endsWith('.tmp')) {
-        out.push(childRel);
-      }
-    }
-  };
-  await walk(dir, '');
-  return out;
-};
 
 /**
  * Mirrors the user's remote prefix into the local journal dir. Downloads only

--- a/lib/storage/download.ts
+++ b/lib/storage/download.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  fingerprint,
+  manifestRelName,
+  readManifest,
+  relPathFromKey,
+  userPrefix,
+  writeManifest,
+  type Manifest,
+} from './manifest';
+import type { ObjectStore } from './objectStore';
+import { getJournalDir } from '@/lib/journal/layout';
+
+/** Lists the local journal dir recursively, returning relPaths (excludes the
+ * manifest file and any *.tmp scratch files from atomic writes). */
+const listLocalRelPaths = async (dir: string): Promise<string[]> => {
+  const out: string[] = [];
+  const walk = async (abs: string, rel: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      return; // dir does not exist yet
+    }
+    for (const e of entries) {
+      const childRel = rel ? path.join(rel, e.name) : e.name;
+      if (e.isDirectory()) {
+        await walk(path.join(abs, e.name), childRel);
+      } else if (e.name !== manifestRelName && !e.name.endsWith('.tmp')) {
+        out.push(childRel);
+      }
+    }
+  };
+  await walk(dir, '');
+  return out;
+};
+
+/**
+ * Mirrors the user's remote prefix into the local journal dir. Downloads only
+ * objects whose ETag differs from the local manifest, deletes local files no
+ * longer present remotely, rewrites the manifest, and returns the fingerprint.
+ *
+ * If the store is unreachable but a manifest exists, serves the stale local
+ * cache (warn + fingerprint from manifest). With no manifest, the error
+ * propagates.
+ */
+export const pullToLocal = async (
+  store: ObjectStore,
+  userId: string
+): Promise<{ fingerprint: string }> => {
+  const dir = getJournalDir(userId);
+  const prefix = userPrefix(userId);
+  const prevManifest = await readManifest(userId);
+
+  let remote;
+  try {
+    remote = await store.list(prefix);
+  } catch (err) {
+    if (Object.keys(prevManifest).length > 0) {
+      console.warn(
+        `[storage] Garage unreachable for ${userId}; serving stale local cache`,
+        err
+      );
+      return {
+        fingerprint: fingerprint(
+          Object.entries(prevManifest).map(([rel, etag]) => ({
+            key: prefix + rel.split(path.sep).join('/'),
+            etag,
+          }))
+        ),
+      };
+    }
+    throw err;
+  }
+
+  const nextManifest: Manifest = {};
+  const remoteRelSet = new Set<string>();
+
+  for (const obj of remote) {
+    const rel = relPathFromKey(userId, obj.key);
+    remoteRelSet.add(rel);
+    nextManifest[rel] = obj.etag;
+    const localAbs = path.join(dir, rel);
+    if (prevManifest[rel] === obj.etag) {
+      // Unchanged — only download if the local file is missing.
+      try {
+        await fs.access(localAbs);
+        continue;
+      } catch {
+        // fall through to download
+      }
+    }
+    const { body } = await store.get(obj.key);
+    await fs.mkdir(path.dirname(localAbs), { recursive: true });
+    await fs.writeFile(localAbs, body);
+  }
+
+  // Delete local files that are no longer in the remote set.
+  for (const rel of await listLocalRelPaths(dir)) {
+    if (!remoteRelSet.has(rel)) {
+      await fs.rm(path.join(dir, rel), { force: true });
+    }
+  }
+
+  await writeManifest(userId, nextManifest);
+  return { fingerprint: fingerprint(remote) };
+};

--- a/lib/storage/download.ts
+++ b/lib/storage/download.ts
@@ -82,6 +82,10 @@ export const pullToLocal = async (
     remoteRelSet.add(rel);
     nextManifest[rel] = obj.etag;
     const localAbs = path.join(dir, rel);
+    const resolvedRoot = path.resolve(dir) + path.sep;
+    if (!path.resolve(localAbs).startsWith(resolvedRoot)) {
+      throw new Error(`Refusing to write outside journal dir: ${obj.key}`);
+    }
     if (prevManifest[rel] === obj.etag) {
       // Unchanged — only download if the local file is missing.
       try {

--- a/lib/storage/download.ts
+++ b/lib/storage/download.ts
@@ -76,13 +76,14 @@ export const pullToLocal = async (
 
   const nextManifest: Manifest = {};
   const remoteRelSet = new Set<string>();
+  const resolvedRoot = path.resolve(dir) + path.sep;
 
   for (const obj of remote) {
     const rel = relPathFromKey(userId, obj.key);
     remoteRelSet.add(rel);
     nextManifest[rel] = obj.etag;
     const localAbs = path.join(dir, rel);
-    const resolvedRoot = path.resolve(dir) + path.sep;
+    // Defense in depth: relPathFromKey already rejects `..`; re-check containment before writing.
     if (!path.resolve(localAbs).startsWith(resolvedRoot)) {
       throw new Error(`Refusing to write outside journal dir: ${obj.key}`);
     }

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,4 +1,4 @@
-export { pull, push, clearRemote } from './sync';
+export { pull, pullLocked, push, clearRemote } from './sync';
 export { getObjectStore, resetObjectStore } from './client';
 export { StorageConflictError } from './save';
 export type { ObjectStore, ObjectMeta, GetResult } from './objectStore';

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -2,3 +2,4 @@ export { pull, push, clearRemote } from './sync';
 export { getObjectStore, resetObjectStore } from './client';
 export { StorageConflictError } from './save';
 export type { ObjectStore, ObjectMeta, GetResult } from './objectStore';
+export { manifestRelName } from './manifest';

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,0 +1,4 @@
+export { pull, push, clearRemote } from './sync';
+export { getObjectStore, resetObjectStore } from './client';
+export { StorageConflictError } from './save';
+export type { ObjectStore, ObjectMeta, GetResult } from './objectStore';

--- a/lib/storage/manifest.test.ts
+++ b/lib/storage/manifest.test.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  fingerprint,
+  keyFor,
+  localPathFor,
+  readManifest,
+  relPathFromKey,
+  userPrefix,
+  writeManifest,
+} from './manifest';
+import { getJournalDir } from '@/lib/journal/layout';
+
+const USER = 'manifest-user';
+afterEach(() => fs.rm(getJournalDir(USER), { recursive: true, force: true }));
+
+describe('key helpers', () => {
+  it('builds and reverses keys', () => {
+    expect(userPrefix(USER)).toBe(`journals/${USER}/`);
+    expect(keyFor(USER, 'sub/a.ledger')).toBe(`journals/${USER}/sub/a.ledger`);
+    expect(relPathFromKey(USER, `journals/${USER}/sub/a.ledger`)).toBe(
+      'sub/a.ledger'
+    );
+    expect(localPathFor(USER, 'a.ledger')).toBe(
+      path.join(getJournalDir(USER), 'a.ledger')
+    );
+  });
+});
+
+describe('manifest io', () => {
+  it('returns {} when no manifest exists', async () => {
+    expect(await readManifest(USER)).toEqual({});
+  });
+
+  it('round-trips a manifest', async () => {
+    await writeManifest(USER, { 'main.ledger': 'etag1' });
+    expect(await readManifest(USER)).toEqual({ 'main.ledger': 'etag1' });
+  });
+});
+
+describe('fingerprint', () => {
+  it('is order-independent and changes with content', () => {
+    const a = fingerprint([
+      { key: 'k1', etag: 'e1' },
+      { key: 'k2', etag: 'e2' },
+    ]);
+    const b = fingerprint([
+      { key: 'k2', etag: 'e2' },
+      { key: 'k1', etag: 'e1' },
+    ]);
+    const c = fingerprint([
+      { key: 'k1', etag: 'eX' },
+      { key: 'k2', etag: 'e2' },
+    ]);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it('is a deterministic 64-char hex string for the empty set', () => {
+    expect(fingerprint([])).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/lib/storage/manifest.test.ts
+++ b/lib/storage/manifest.test.ts
@@ -30,7 +30,7 @@ describe('key helpers', () => {
   it('rejects keys that escape the journal dir', () => {
     expect(() =>
       relPathFromKey(USER, `journals/${USER}/../../etc/passwd`)
-    ).toThrow();
+    ).toThrow(/Unsafe journal object key/);
   });
 });
 

--- a/lib/storage/manifest.test.ts
+++ b/lib/storage/manifest.test.ts
@@ -26,6 +26,12 @@ describe('key helpers', () => {
       path.join(getJournalDir(USER), 'a.ledger')
     );
   });
+
+  it('rejects keys that escape the journal dir', () => {
+    expect(() =>
+      relPathFromKey(USER, `journals/${USER}/../../etc/passwd`)
+    ).toThrow();
+  });
 });
 
 describe('manifest io', () => {

--- a/lib/storage/manifest.ts
+++ b/lib/storage/manifest.ts
@@ -15,9 +15,15 @@ export const userPrefix = (userId: string): string => `journals/${userId}/`;
 export const keyFor = (userId: string, relPath: string): string =>
   userPrefix(userId) + relPath.split(path.sep).join('/');
 
-/** Inverse of keyFor: the relPath (OS separators) for a full key. */
-export const relPathFromKey = (userId: string, key: string): string =>
-  key.slice(userPrefix(userId).length).split('/').join(path.sep);
+/** Inverse of keyFor: the relPath (OS separators) for a full key. Rejects keys
+ * that would escape the user's journal dir (absolute or containing `..`). */
+export const relPathFromKey = (userId: string, key: string): string => {
+  const rel = key.slice(userPrefix(userId).length).split('/').join(path.sep);
+  if (path.isAbsolute(rel) || /(^|[/\\])\.\.([/\\]|$)/.test(rel)) {
+    throw new Error(`Unsafe journal object key: ${key}`);
+  }
+  return rel;
+};
 
 /** Absolute local cache path for a relPath inside the user's journal dir. */
 export const localPathFor = (userId: string, relPath: string): string =>

--- a/lib/storage/manifest.ts
+++ b/lib/storage/manifest.ts
@@ -46,7 +46,38 @@ export const writeManifest = async (
   m: Manifest
 ): Promise<void> => {
   await fs.mkdir(getJournalDir(userId), { recursive: true });
-  await fs.writeFile(manifestPath(userId), JSON.stringify(m, null, 2), 'utf-8');
+  // Atomic write (tmp + rename on the same filesystem) so a crash or a
+  // concurrent reader never sees a half-written manifest — a torn manifest
+  // would fail JSON.parse, reset to {}, and silently disable the conflict guard.
+  const dest = manifestPath(userId);
+  const tmp = dest + '.tmp';
+  await fs.writeFile(tmp, JSON.stringify(m, null, 2), 'utf-8');
+  await fs.rename(tmp, dest);
+};
+
+/** Lists the local journal dir recursively, returning relPaths (excludes the
+ * manifest file and any *.tmp scratch files from atomic writes). Returns an
+ * empty list if the dir does not exist yet. */
+export const listLocalRelPaths = async (dir: string): Promise<string[]> => {
+  const out: string[] = [];
+  const walk = async (abs: string, rel: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      return; // dir does not exist yet
+    }
+    for (const e of entries) {
+      const childRel = rel ? path.join(rel, e.name) : e.name;
+      if (e.isDirectory()) {
+        await walk(path.join(abs, e.name), childRel);
+      } else if (e.name !== manifestRelName && !e.name.endsWith('.tmp')) {
+        out.push(childRel);
+      }
+    }
+  };
+  await walk(dir, '');
+  return out;
 };
 
 /** Order-independent content fingerprint of a set of (key, etag) pairs. */

--- a/lib/storage/manifest.ts
+++ b/lib/storage/manifest.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getJournalDir } from '@/lib/journal/layout';
+
+/** relPath (within the user's journal dir) → last-seen ETag. */
+export type Manifest = Record<string, string>;
+
+export const manifestRelName = '.manifest.json';
+
+/** Garage key prefix for a user, e.g. `journals/<userId>/`. */
+export const userPrefix = (userId: string): string => `journals/${userId}/`;
+
+/** Full object key for a file inside the user's journal. POSIX separators. */
+export const keyFor = (userId: string, relPath: string): string =>
+  userPrefix(userId) + relPath.split(path.sep).join('/');
+
+/** Inverse of keyFor: the relPath (OS separators) for a full key. */
+export const relPathFromKey = (userId: string, key: string): string =>
+  key.slice(userPrefix(userId).length).split('/').join(path.sep);
+
+/** Absolute local cache path for a relPath inside the user's journal dir. */
+export const localPathFor = (userId: string, relPath: string): string =>
+  path.join(getJournalDir(userId), relPath);
+
+const manifestPath = (userId: string): string =>
+  path.join(getJournalDir(userId), manifestRelName);
+
+export const readManifest = async (userId: string): Promise<Manifest> => {
+  try {
+    const raw = await fs.readFile(manifestPath(userId), 'utf-8');
+    return JSON.parse(raw) as Manifest;
+  } catch {
+    return {};
+  }
+};
+
+export const writeManifest = async (
+  userId: string,
+  m: Manifest
+): Promise<void> => {
+  await fs.mkdir(getJournalDir(userId), { recursive: true });
+  await fs.writeFile(manifestPath(userId), JSON.stringify(m, null, 2), 'utf-8');
+};
+
+/** Order-independent content fingerprint of a set of (key, etag) pairs. */
+export const fingerprint = (
+  entries: { key: string; etag: string }[]
+): string => {
+  const body = [...entries]
+    .map((e) => `${e.key}:${e.etag}`)
+    .sort()
+    .join('\n');
+  return createHash('sha256').update(body).digest('hex');
+};

--- a/lib/storage/memoryObjectStore.test.ts
+++ b/lib/storage/memoryObjectStore.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryObjectStore } from './memoryObjectStore';
+
+describe('MemoryObjectStore', () => {
+  let store: MemoryObjectStore;
+  beforeEach(() => {
+    store = new MemoryObjectStore();
+  });
+
+  it('put then get round-trips the body and returns a stable etag', async () => {
+    const { etag } = await store.put('a/x.ledger', Buffer.from('hello'));
+    const got = await store.get('a/x.ledger');
+    expect(got.body.toString()).toBe('hello');
+    expect(got.etag).toBe(etag);
+  });
+
+  it('etag changes when content changes', async () => {
+    const first = await store.put('a/x.ledger', Buffer.from('one'));
+    const second = await store.put('a/x.ledger', Buffer.from('two'));
+    expect(second.etag).not.toBe(first.etag);
+  });
+
+  it('list returns only keys under the prefix with meta', async () => {
+    await store.put('a/x.ledger', Buffer.from('1'));
+    await store.put('a/sub/y.ledger', Buffer.from('22'));
+    await store.put('b/z.ledger', Buffer.from('333'));
+    const entries = await store.list('a/');
+    expect(entries.map((e) => e.key).sort()).toEqual([
+      'a/sub/y.ledger',
+      'a/x.ledger',
+    ]);
+    const x = entries.find((e) => e.key === 'a/x.ledger')!;
+    expect(x.size).toBe(1);
+    expect(x.etag).toHaveLength(64); // sha256 hex
+  });
+
+  it('get rejects for a missing key', async () => {
+    await expect(store.get('nope')).rejects.toThrow();
+  });
+
+  it('delete removes one key; deletePrefix removes the subtree', async () => {
+    await store.put('a/x.ledger', Buffer.from('1'));
+    await store.put('a/y.ledger', Buffer.from('2'));
+    await store.delete('a/x.ledger');
+    expect((await store.list('a/')).map((e) => e.key)).toEqual(['a/y.ledger']);
+    await store.deletePrefix('a/');
+    expect(await store.list('a/')).toEqual([]);
+  });
+});

--- a/lib/storage/memoryObjectStore.ts
+++ b/lib/storage/memoryObjectStore.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'crypto';
+import type { GetResult, ObjectMeta, ObjectStore } from './objectStore';
+
+const sha256 = (body: Buffer): string =>
+  createHash('sha256').update(body).digest('hex');
+
+/** In-memory ObjectStore for tests and no-infra dev. ETag = sha256(body). */
+export class MemoryObjectStore implements ObjectStore {
+  private readonly objects = new Map<string, Buffer>();
+
+  async list(prefix: string): Promise<ObjectMeta[]> {
+    const out: ObjectMeta[] = [];
+    for (const [key, body] of this.objects) {
+      if (key.startsWith(prefix)) {
+        out.push({ key, etag: sha256(body), size: body.length });
+      }
+    }
+    return out;
+  }
+
+  async get(key: string): Promise<GetResult> {
+    const body = this.objects.get(key);
+    if (!body) throw new Error(`MemoryObjectStore: missing key ${key}`);
+    return { body, etag: sha256(body) };
+  }
+
+  async put(key: string, body: Buffer): Promise<{ etag: string }> {
+    this.objects.set(key, Buffer.from(body));
+    return { etag: sha256(body) };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    for (const key of [...this.objects.keys()]) {
+      if (key.startsWith(prefix)) this.objects.delete(key);
+    }
+  }
+}

--- a/lib/storage/objectStore.ts
+++ b/lib/storage/objectStore.ts
@@ -1,0 +1,24 @@
+/** Metadata for one stored object. `etag` is opaque and backend-specific. */
+export type ObjectMeta = { key: string; etag: string; size: number };
+
+/** Result of fetching an object's bytes. */
+export type GetResult = { body: Buffer; etag: string };
+
+/**
+ * Minimal S3-shaped object store. Implementations: S3ObjectStore (Garage) and
+ * MemoryObjectStore (tests/dev). Keys are full paths like
+ * `journals/<userId>/main.ledger`. Conflict detection is done by the sync layer
+ * (comparing ETags), not here.
+ */
+export interface ObjectStore {
+  /** Lists every object whose key starts with `prefix`. */
+  list(prefix: string): Promise<ObjectMeta[]>;
+  /** Fetches one object. Rejects if the key does not exist. */
+  get(key: string): Promise<GetResult>;
+  /** Writes one object, returning its new ETag. */
+  put(key: string, body: Buffer): Promise<{ etag: string }>;
+  /** Deletes one object. No-op if it does not exist. */
+  delete(key: string): Promise<void>;
+  /** Deletes every object under `prefix`. */
+  deletePrefix(prefix: string): Promise<void>;
+}

--- a/lib/storage/s3ObjectStore.ts
+++ b/lib/storage/s3ObjectStore.ts
@@ -1,0 +1,75 @@
+import type { GetResult, ObjectMeta, ObjectStore } from './objectStore';
+import {
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
+
+const stripQuotes = (etag: string | undefined): string =>
+  (etag ?? '').replace(/^"|"$/g, '');
+
+/** Garage / S3-compatible ObjectStore. ETag is the server's (md5-based) header. */
+export class S3ObjectStore implements ObjectStore {
+  constructor(
+    private readonly client: S3Client,
+    private readonly bucket: string
+  ) {}
+
+  async list(prefix: string): Promise<ObjectMeta[]> {
+    const out: ObjectMeta[] = [];
+    let token: string | undefined;
+    do {
+      const res = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: token,
+        })
+      );
+      for (const obj of res.Contents ?? []) {
+        out.push({
+          key: obj.Key!,
+          etag: stripQuotes(obj.ETag),
+          size: obj.Size ?? 0,
+        });
+      }
+      token = res.IsTruncated ? res.NextContinuationToken : undefined;
+    } while (token);
+    return out;
+  }
+
+  async get(key: string): Promise<GetResult> {
+    const res = await this.client.send(
+      new GetObjectCommand({ Bucket: this.bucket, Key: key })
+    );
+    const body = Buffer.from(await res.Body!.transformToByteArray());
+    return { body, etag: stripQuotes(res.ETag) };
+  }
+
+  async put(key: string, body: Buffer): Promise<{ etag: string }> {
+    const res = await this.client.send(
+      new PutObjectCommand({ Bucket: this.bucket, Key: key, Body: body })
+    );
+    return { etag: stripQuotes(res.ETag) };
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(
+      new DeleteObjectCommand({ Bucket: this.bucket, Key: key })
+    );
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    const entries = await this.list(prefix);
+    if (entries.length === 0) return;
+    await this.client.send(
+      new DeleteObjectsCommand({
+        Bucket: this.bucket,
+        Delete: { Objects: entries.map((e) => ({ Key: e.key })) },
+      })
+    );
+  }
+}

--- a/lib/storage/save.test.ts
+++ b/lib/storage/save.test.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { pullToLocal } from './download';
+import { keyFor, readManifest } from './manifest';
+import { MemoryObjectStore } from './memoryObjectStore';
+import { StorageConflictError, pushFromLocal } from './save';
+import { getJournalDir } from '@/lib/journal/layout';
+
+const USER = 'push-user';
+const dir = () => getJournalDir(USER);
+const writeLocal = async (rel: string, content: string) => {
+  const abs = path.join(dir(), rel);
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, content);
+};
+afterEach(() => fs.rm(dir(), { recursive: true, force: true }));
+
+describe('pushFromLocal', () => {
+  it('uploads new local files and records their etags in the manifest', async () => {
+    const store = new MemoryObjectStore();
+    await pullToLocal(store, USER); // empty remote → empty manifest
+    await writeLocal('main.ledger', 'hello');
+    await pushFromLocal(store, USER);
+    const remote = await store.get(keyFor(USER, 'main.ledger'));
+    expect(remote.body.toString()).toBe('hello');
+    expect((await readManifest(USER))['main.ledger']).toBe(remote.etag);
+  });
+
+  it('deletes remote objects with no local counterpart', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(keyFor(USER, 'old.ledger'), Buffer.from('x'));
+    await pullToLocal(store, USER); // brings old.ledger local
+    await fs.rm(path.join(dir(), 'old.ledger'));
+    await writeLocal('main.ledger', 'new');
+    await pushFromLocal(store, USER);
+    expect((await store.list(keyFor(USER, ''))).map((e) => e.key)).toEqual([
+      keyFor(USER, 'main.ledger'),
+    ]);
+  });
+
+  it('throws StorageConflictError when remote changed since the pull', async () => {
+    const store = new MemoryObjectStore();
+    await store.put(keyFor(USER, 'main.ledger'), Buffer.from('v1'));
+    await pullToLocal(store, USER);
+    // Another writer changes the remote out from under us.
+    await store.put(keyFor(USER, 'main.ledger'), Buffer.from('v2-elsewhere'));
+    await writeLocal('main.ledger', 'v2-mine');
+    await expect(pushFromLocal(store, USER)).rejects.toBeInstanceOf(
+      StorageConflictError
+    );
+  });
+});

--- a/lib/storage/save.ts
+++ b/lib/storage/save.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import {
   keyFor,
-  manifestRelName,
+  listLocalRelPaths,
   readManifest,
   relPathFromKey,
   userPrefix,
@@ -19,26 +19,6 @@ export class StorageConflictError extends Error {
     this.name = 'StorageConflictError';
   }
 }
-
-const listLocalRelPaths = async (dir: string): Promise<string[]> => {
-  const out: string[] = [];
-  const walk = async (abs: string, rel: string): Promise<void> => {
-    let entries: import('fs').Dirent[];
-    try {
-      entries = await fs.readdir(abs, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const e of entries) {
-      const childRel = rel ? path.join(rel, e.name) : e.name;
-      if (e.isDirectory()) await walk(path.join(abs, e.name), childRel);
-      else if (e.name !== manifestRelName && !e.name.endsWith('.tmp'))
-        out.push(childRel);
-    }
-  };
-  await walk(dir, '');
-  return out;
-};
 
 /**
  * Mirrors the local journal dir up to the remote prefix. First confirms the

--- a/lib/storage/save.ts
+++ b/lib/storage/save.ts
@@ -1,0 +1,86 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  keyFor,
+  manifestRelName,
+  readManifest,
+  relPathFromKey,
+  userPrefix,
+  writeManifest,
+  type Manifest,
+} from './manifest';
+import type { ObjectStore } from './objectStore';
+import { getJournalDir } from '@/lib/journal/layout';
+
+/** Thrown when the remote changed between pull and push (lost-update guard). */
+export class StorageConflictError extends Error {
+  constructor(message = 'Journal was modified elsewhere; reload and retry.') {
+    super(message);
+    this.name = 'StorageConflictError';
+  }
+}
+
+const listLocalRelPaths = async (dir: string): Promise<string[]> => {
+  const out: string[] = [];
+  const walk = async (abs: string, rel: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const childRel = rel ? path.join(rel, e.name) : e.name;
+      if (e.isDirectory()) await walk(path.join(abs, e.name), childRel);
+      else if (e.name !== manifestRelName && !e.name.endsWith('.tmp'))
+        out.push(childRel);
+    }
+  };
+  await walk(dir, '');
+  return out;
+};
+
+/**
+ * Mirrors the local journal dir up to the remote prefix. First confirms the
+ * remote still matches the manifest we pulled (else throws StorageConflictError
+ * — never blindly overwrite a concurrent change). Then uploads every local
+ * file, deletes remote objects with no local counterpart, and rewrites the
+ * manifest with the freshly-returned ETags.
+ */
+export const pushFromLocal = async (
+  store: ObjectStore,
+  userId: string
+): Promise<void> => {
+  const dir = getJournalDir(userId);
+  const prefix = userPrefix(userId);
+  const manifest = await readManifest(userId);
+
+  // Conflict check: remote must equal the snapshot we last pulled.
+  const remote = await store.list(prefix);
+  const remoteByRel = new Map(
+    remote.map((o) => [relPathFromKey(userId, o.key), o.etag])
+  );
+  const allRels = new Set([...Object.keys(manifest), ...remoteByRel.keys()]);
+  for (const rel of allRels) {
+    if (manifest[rel] !== remoteByRel.get(rel)) {
+      throw new StorageConflictError();
+    }
+  }
+
+  // Upload every local file; collect new etags.
+  const localRels = await listLocalRelPaths(dir);
+  const next: Manifest = {};
+  for (const rel of localRels) {
+    const body = await fs.readFile(path.join(dir, rel));
+    const { etag } = await store.put(keyFor(userId, rel), body);
+    next[rel] = etag;
+  }
+
+  // Delete remote objects that no longer exist locally.
+  const localSet = new Set(localRels);
+  for (const rel of remoteByRel.keys()) {
+    if (!localSet.has(rel)) await store.delete(keyFor(userId, rel));
+  }
+
+  await writeManifest(userId, next);
+};

--- a/lib/storage/sync.test.ts
+++ b/lib/storage/sync.test.ts
@@ -1,0 +1,38 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { resetObjectStore } from './client';
+import { pull, push, clearRemote } from './sync';
+import { getJournalDir } from '@/lib/journal/layout';
+
+const USER = 'sync-user';
+afterEach(async () => {
+  resetObjectStore();
+  await fs.rm(getJournalDir(USER), { recursive: true, force: true });
+});
+
+describe('sync (memory backend via env default)', () => {
+  it('push then pull round-trips through the configured store', async () => {
+    await pull(USER); // empty
+    const abs = path.join(getJournalDir(USER), 'main.ledger');
+    await fs.writeFile(abs, 'data');
+    await push(USER);
+    await fs.rm(abs); // blow away local cache
+    await pull(USER); // should restore from the store
+    expect(await fs.readFile(abs, 'utf-8')).toBe('data');
+  });
+
+  it('clearRemote empties the user prefix', async () => {
+    await pull(USER);
+    await fs.writeFile(path.join(getJournalDir(USER), 'main.ledger'), 'd');
+    await push(USER);
+    await clearRemote(USER);
+    await fs.rm(path.join(getJournalDir(USER), 'main.ledger'));
+    const after = await pull(USER);
+    // Empty remote → only the stable empty-set fingerprint, no restored file.
+    await expect(
+      fs.access(path.join(getJournalDir(USER), 'main.ledger'))
+    ).rejects.toThrow();
+    expect(after.fingerprint).toHaveLength(64);
+  });
+});

--- a/lib/storage/sync.ts
+++ b/lib/storage/sync.ts
@@ -1,0 +1,16 @@
+import { getObjectStore } from './client';
+import { pullToLocal } from './download';
+import { userPrefix } from './manifest';
+import { pushFromLocal } from './save';
+
+/** Mirror the user's canonical journal down to the local cache. */
+export const pull = (userId: string): Promise<{ fingerprint: string }> =>
+  pullToLocal(getObjectStore(), userId);
+
+/** Mirror the user's local cache up to the canonical store. */
+export const push = (userId: string): Promise<void> =>
+  pushFromLocal(getObjectStore(), userId);
+
+/** Delete every canonical object for the user (used before a full import). */
+export const clearRemote = (userId: string): Promise<void> =>
+  getObjectStore().deletePrefix(userPrefix(userId));

--- a/lib/storage/sync.ts
+++ b/lib/storage/sync.ts
@@ -2,10 +2,28 @@ import { getObjectStore } from './client';
 import { pullToLocal } from './download';
 import { userPrefix } from './manifest';
 import { pushFromLocal } from './save';
+import { withUserLock } from '@/lib/journal/mutex';
 
-/** Mirror the user's canonical journal down to the local cache. */
+/**
+ * Mirror the user's canonical journal down to the local cache.
+ *
+ * WARNING: this mutates the shared per-user local journal dir in place and is
+ * NOT safe to run concurrently against itself or against `push`. Call it ONLY
+ * while already holding the per-user lock (`withUserLock`). Read paths that are
+ * not already under the lock must use `pullLocked` instead.
+ */
 export const pull = (userId: string): Promise<{ fingerprint: string }> =>
   pullToLocal(getObjectStore(), userId);
+
+/**
+ * Lock-acquiring `pull` for read paths. Serializing under the same per-user
+ * lock the write paths use guarantees a read's pull never interleaves with a
+ * write's push, with another read's pull, or with a concurrent manifest write.
+ * Must NOT be called while already holding the lock (the mutex is
+ * non-reentrant) — write paths call the raw `pull` inside their lock instead.
+ */
+export const pullLocked = (userId: string): Promise<{ fingerprint: string }> =>
+  withUserLock(userId, () => pull(userId));
 
 /** Mirror the user's local cache up to the canonical store. */
 export const push = (userId: string): Promise<void> =>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1075.0",
     "@base-ui/react": "^1.4.1",
     "@better-auth/passkey": "^1.6.10",
     "@heroicons/react": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1075.0
+        version: 3.1075.0
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -168,6 +171,109 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.8':
+    resolution: {integrity: sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1075.0':
+    resolution: {integrity: sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    resolution: {integrity: sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    resolution: {integrity: sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
@@ -2001,6 +2107,42 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.26.0':
+    resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.2':
+    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.2':
+    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.8.2':
+    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.2':
+    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -2559,6 +2701,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -5705,6 +5850,235 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/checksums@3.1000.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/middleware-flexible-checksums': 3.974.33
+      '@aws-sdk/middleware-sdk-s3': 3.972.54
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.26.0
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.8
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
@@ -7289,6 +7663,54 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/core@3.26.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -7889,6 +8311,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.11:
     dependencies:

--- a/utils/runLedger.ts
+++ b/utils/runLedger.ts
@@ -10,13 +10,13 @@ const execFilePromise = promisify(execFile);
 
 const LEDGER_CACHE_TTL_SECONDS = 60;
 
-const buildExecLedger = (tag: string, mtimeMs: number) =>
+const buildExecLedger = (tag: string, fingerprint: string) =>
   unstable_cache(
     async (allArgs: string[]): Promise<string> => {
       const { stdout } = await execFilePromise('ledger', allArgs);
       return stdout;
     },
-    ['ledger-cli-exec', tag, String(mtimeMs)],
+    ['ledger-cli-exec', tag, fingerprint],
     { revalidate: LEDGER_CACHE_TTL_SECONDS, tags: [tag] }
   );
 
@@ -30,16 +30,16 @@ const runLedger = async (
 ): Promise<string> => {
   await connection();
   const user = await requireUser();
-  // `getMaxMtime` calls `ensureLayout` internally — we then use the cheaper
-  // `getLayout` for the actual path, avoiding a duplicate mkdir+access.
-  const mtimeMs = await journalRepository.getMaxMtime(user.id);
+  // getFingerprint pulls the canonical journal into the local cache (so the
+  // ledger CLI can read it) and returns the content fingerprint for the key.
+  const fingerprint = await journalRepository.getFingerprint(user.id);
   const { mainPath, priceDbPath } = await journalRepository.getLayout(user.id);
 
   const baseArgs: string[] = ['--file', mainPath];
   if (priceDbPath) baseArgs.push('--price-db', priceDbPath);
   if (options?.sortByDate ?? true) baseArgs.push('--sort', '-date');
 
-  const execLedger = buildExecLedger(getJournalCacheTag(user.id), mtimeMs);
+  const execLedger = buildExecLedger(getJournalCacheTag(user.id), fingerprint);
   return execLedger([...baseArgs, ...args]);
 };
 


### PR DESCRIPTION
## Summary

Makes **Garage** (self-hosted, S3-compatible object storage) the source of truth for ledger journal files. Local disk under `DATA_DIR` becomes an ephemeral cache. This unblocks stateless Coolify containers — journal files (the real financial data) now have a durable home instead of relying on container-local disk.

The `ledger` CLI only reads local filesystem paths, so the design bridges object storage ↔ local disk around every invocation:
- **Reads** pull the canonical journal into the local cache first (mirroring the `journals/<userId>/` prefix via `ListObjectsV2` + ETags, downloading only changed objects), then run `ledger`. The query cache key switches from file mtime to a content **fingerprint**.
- **Writes** do `pull → mutate → verify (ledger CLI) → push`, rolling the local mutation back on any verify/push failure so the cache is never left ahead of canonical. A lost-update guard (`StorageConflictError`) protects against concurrent overwrites.
- **Imports** replace canonical atomically (pull → reset local files keeping the manifest → write → verify → guarded push with orphan-delete) — no window where canonical is empty.

All Garage actions live in a single new `lib/storage/` directory. Backend is env-selected: `STORAGE_BACKEND=s3|memory` (default `memory`, so tests/dev/build need no infra; production sets `s3`).

## What's included
- `lib/storage/`: `ObjectStore` interface + `S3ObjectStore` (Garage) and `MemoryObjectStore` (tests/dev) backends, env-driven factory, manifest + content fingerprint, `download`(pull)/`save`(push)/`sync` public API.
- Read-path wiring: `runLedger` + `Transactions` keyed on the fingerprint; `getMaxMtime` → `getFingerprint`.
- Write-path wiring: `addTransaction`/`performEdit`/`performDelete`/imports sync to Garage, all serialized under the per-user lock.
- Env schema + `.env.example` (`STORAGE_BACKEND`, `S3_*`, conditional validation).
- Deployment runbook (`docs/deployment/garage.md`) + `deploy/garage/garage.toml` for standing Garage up on the new-raxel Coolify host.
- Design spec + implementation plan under `docs/superpowers/`.

## Security
Path-traversal hardening: `relPathFromKey` rejects absolute/`..` keys and `download.ts` re-checks containment before any write, so a malformed/compromised object key can't escape the user's journal dir (mirrors the existing ZIP-import guards).

## Testing
- 73 files / **379 tests** pass; type-check and lint clean.
- New tests cover: ETag-diff pull, lost-update conflict, serve-stale degraded read, path-traversal rejection, fingerprint cache key, and atomic import orphan-removal.
- Existing suite runs on the in-memory backend (`resetObjectStore()` isolation); no live Garage needed for CI.
- `pnpm build` and the live-Garage smoke test (`docs/deployment/garage.md`) are manual/CI gates (build's prebuild migrate needs Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)