### PR TITLE
feat(auth): coherent auth experience — full-bleed + landing-matched redesign

### DIFF
--- a/components/AppShell/AppShell.tsx
+++ b/components/AppShell/AppShell.tsx
@@ -32,12 +32,14 @@ const AppShell = ({ children, headerSlot, bannerSlot }: Props) => {
     return <>{children}</>;
   }
 
+  // Auth pages own their own full-bleed chrome — AuthScreen renders its own
+  // <main> split layout, so the shell must not wrap it in a width-clamped
+  // container (the old starter centered-card wrapper squished the split into a
+  // narrow column and nested <main> inside <main>).
   if (isAuthPage) {
     return (
       <TooltipProvider>
-        <main className="mx-auto flex min-h-svh w-full max-w-md flex-col justify-center px-4 py-12 sm:px-6">
-          {children}
-        </main>
+        {children}
         <Toaster />
       </TooltipProvider>
     );

--- a/components/AppShell/authPaths.test.ts
+++ b/components/AppShell/authPaths.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { isAuthPath } from './authPaths';
 
 describe('isAuthPath', () => {
-  it('treats the starter sign-in routes as auth pages', () => {
+  it('treats the sign-in and sign-up routes as auth pages', () => {
     expect(isAuthPath('/sign-in')).toBe(true);
     expect(isAuthPath('/sign-in/error')).toBe(true);
+    expect(isAuthPath('/sign-up')).toBe(true);
   });
 
   it('treats app routes as non-auth pages', () => {

--- a/components/AppShell/authPaths.ts
+++ b/components/AppShell/authPaths.ts
@@ -1,9 +1,10 @@
-// Paths that render the chrome-free, centered auth layout instead of the full
-// app shell (sidebar + header). The auth route is owned by the starter and
-// mounted at /sign-in (+ /sign-in/error). Kept in its own tested module so a
-// future route rename can't silently strand the sign-in page inside the app
-// chrome — where AppHeader's useSession/signOut assume an authenticated user.
-export const AUTH_PATHS = new Set(['/sign-in', '/sign-in/error']);
+// Paths that render the chrome-free, full-bleed auth layout instead of the full
+// app shell (sidebar + header). The custom AuthScreen is mounted at /sign-in
+// (+ /sign-in/error) and /sign-up (registration is open to multi-user). Kept in
+// its own tested module so a future route rename can't silently strand an auth
+// page inside the app chrome — where AppHeader's useSession/signOut assume an
+// authenticated user.
+export const AUTH_PATHS = new Set(['/sign-in', '/sign-in/error', '/sign-up']);
 
 export const isAuthPath = (pathname: string): boolean =>
   AUTH_PATHS.has(pathname);

--- a/features/auth/AuthForm.tsx
+++ b/features/auth/AuthForm.tsx
@@ -12,10 +12,6 @@ import {
   type Method,
 } from './authState';
 import { resolveCallbackUrl } from './callbackUrl';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Separator } from '@/components/ui/separator';
 import { authClient } from '@/lib/auth-client';
 import { useWebAuthnSupported } from '@naeemba/next-starter/client';
 import Link from 'next/link';
@@ -139,63 +135,64 @@ export function AuthForm({ mode }: AuthFormProps) {
     state.status.passkey === 'sending';
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="space-y-1.5 text-center lg:text-left">
-        <h1 className="text-2xl font-semibold tracking-tight">
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
           {copy.heading}
         </h1>
-        <p className="text-sm text-muted-foreground">{copy.subheading}</p>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)]">
+          {copy.subheading}
+        </p>
       </div>
 
       {showSocial && (
         <>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2.5">
             {passkeySupported && (
-              <Button
+              <button
                 type="button"
-                variant="outline"
+                className="au-btn au-btn--ghost"
                 onClick={onPasskey}
                 disabled={sending}
               >
                 <Fingerprint className="size-4" aria-hidden />
                 Continue with a passkey
-              </Button>
+              </button>
             )}
             {googleEnabled && (
-              <Button
+              <button
                 type="button"
-                variant="outline"
+                className="au-btn au-btn--ghost"
                 onClick={onGoogle}
                 disabled={sending}
               >
                 Continue with Google
-              </Button>
+              </button>
             )}
             {passkeySupported && state.status.passkey === 'error' && (
-              <p className="text-sm text-destructive" aria-live="polite">
+              <p className="au-error" aria-live="polite">
                 {state.errors.passkey}
               </p>
             )}
             {state.status.google === 'error' && (
-              <p className="text-sm text-destructive" aria-live="polite">
+              <p className="au-error" aria-live="polite">
                 {state.errors.google}
               </p>
             )}
           </div>
 
-          <div className="flex items-center gap-3 text-xs text-muted-foreground">
-            <Separator className="flex-1" />
-            or
-            <Separator className="flex-1" />
-          </div>
+          <div className="au-sep ff-mono">or</div>
         </>
       )}
 
       <form className="flex flex-col gap-4" onSubmit={onSubmit}>
-        <div className="space-y-1.5">
-          <Label htmlFor="email">Email</Label>
-          <Input
+        <div>
+          <label className="au-label" htmlFor="email">
+            Email
+          </label>
+          <input
             id="email"
+            className="au-input"
             type="email"
             required
             autoComplete="email"
@@ -204,22 +201,23 @@ export function AuthForm({ mode }: AuthFormProps) {
             placeholder="you@example.com"
           />
         </div>
-        <Button type="submit" disabled={sending}>
+        <button
+          type="submit"
+          className="au-btn au-btn--primary"
+          disabled={sending}
+        >
           {state.status.magicLink === 'sending' ? 'Sending…' : copy.submitLabel}
-        </Button>
+        </button>
         {state.status.magicLink === 'error' && (
-          <p className="text-sm text-destructive" aria-live="polite">
+          <p className="au-error" aria-live="polite">
             {state.errors.magicLink}
           </p>
         )}
       </form>
 
-      <p className="text-center text-sm text-muted-foreground">
+      <p className="text-sm text-[color:var(--txt-faint)]">
         {copy.altPrompt}{' '}
-        <Link
-          href={copy.altHref}
-          className="font-medium text-foreground underline-offset-4 hover:underline"
-        >
+        <Link href={copy.altHref} className="au-link">
           {copy.altLinkLabel}
         </Link>
       </p>

--- a/features/auth/AuthScreen.tsx
+++ b/features/auth/AuthScreen.tsx
@@ -1,6 +1,24 @@
 import { AuthForm } from './AuthForm';
 import { BrandPanel } from './BrandPanel';
+import './auth.css';
 import type { AuthMode } from './authCopy';
+import { APP_NAME } from '@/lib/app';
+import { Fraunces, JetBrains_Mono } from 'next/font/google';
+import Link from 'next/link';
+
+// Same display + mono pairing as the marketing landing, so the auth screen
+// inherits the home page's editorial voice rather than the app's UI font.
+const display = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+  style: ['normal', 'italic'],
+});
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
 
 interface AuthScreenProps {
   mode: AuthMode;
@@ -8,11 +26,53 @@ interface AuthScreenProps {
 
 export function AuthScreen({ mode }: AuthScreenProps) {
   return (
-    <main className="grid min-h-screen lg:grid-cols-2">
-      <BrandPanel />
-      <div className="flex items-center justify-center px-6 py-12">
-        <div className="w-full max-w-sm">
-          <AuthForm mode={mode} />
+    <main className={`au ${display.variable} ${mono.variable}`}>
+      {/* atmosphere — emerald glow bleeding in from the brand side */}
+      <span
+        className="au-glow"
+        style={{ width: 560, height: 560, top: -180, left: '-6%' }}
+        aria-hidden
+      />
+      <span
+        className="au-glow"
+        style={{
+          width: 420,
+          height: 420,
+          bottom: -200,
+          left: '20%',
+          opacity: 0.3,
+        }}
+        aria-hidden
+      />
+
+      <div className="au-layer grid min-h-svh grid-cols-1 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+        <BrandPanel />
+
+        {/* form side — min-w-0 lets the column shrink below its content's
+            intrinsic width so the form never overflows on narrow viewports */}
+        <div className="flex min-w-0 flex-col px-6 py-8 sm:px-10 lg:px-14">
+          {/* compact wordmark — the only brand cue on mobile, where the
+              editorial panel is hidden */}
+          <Link
+            href="/"
+            className="au-rise flex items-center gap-2.5 lg:invisible"
+            style={{ ['--d' as string]: '0.05s' }}
+            aria-label={`${APP_NAME} home`}
+          >
+            <span className="au-mark ff-mono text-sm">L</span>
+            <span className="text-[0.95rem] font-semibold tracking-tight">
+              {APP_NAME}
+            </span>
+          </Link>
+
+          <div className="flex flex-1 items-center justify-center py-10">
+            <div
+              className="au-rise w-full max-w-sm"
+              style={{ ['--d' as string]: '0.18s' }}
+            >
+              <AuthForm mode={mode} />
+            </div>
+          </div>
         </div>
       </div>
     </main>

--- a/features/auth/BrandPanel.tsx
+++ b/features/auth/BrandPanel.tsx
@@ -1,45 +1,93 @@
 import { Check } from 'lucide-react';
 import { APP_NAME } from '@/lib/app';
+import Link from 'next/link';
 
 const FEATURES = ['Double-entry', 'CLI-powered', 'Self-hosted'] as const;
 
+// Decorative emerald sparkbars — static, not real data (mirrors the home hero).
+const BARS = [10, 16, 13, 22, 19, 28, 25, 34, 30, 38] as const;
+
+// A compact echo of the landing hero's journal mockup, tying the auth screen
+// back to the product's plain-text roots.
+const JOURNAL = [
+  '<span class="c-cmt">; your books, beautifully</span>',
+  '<span class="c-date">2026/06/01</span> <span class="c-payee">Paycheck</span>',
+  '    <span class="c-acct">Assets:Checking</span>   <span class="c-pos">$ 6,200.00</span>',
+  '    <span class="c-acct">Income:Salary</span>',
+].join('\n');
+
 export function BrandPanel() {
   return (
-    <div className="relative hidden flex-col justify-between overflow-hidden bg-primary p-10 text-primary-foreground lg:flex">
-      {/* decorative gradient wash */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-40 [background:radial-gradient(120%_80%_at_0%_0%,var(--color-chart-1)/25,transparent),radial-gradient(120%_80%_at_100%_100%,var(--color-chart-2)/25,transparent)]"
-      />
-      <div className="relative z-10 flex items-center gap-2 text-lg font-semibold tracking-tight">
-        <span className="inline-block size-5 rounded-md bg-primary-foreground/90" />
-        {APP_NAME}
-      </div>
+    <aside className="relative hidden flex-col justify-between overflow-hidden border-r border-[var(--line-soft)] bg-[var(--ink-2)]/40 p-10 lg:flex lg:p-12">
+      {/* wordmark */}
+      <Link
+        href="/"
+        className="au-rise relative z-10 flex items-center gap-2.5"
+        style={{ ['--d' as string]: '0.05s' }}
+        aria-label={`${APP_NAME} home`}
+      >
+        <span className="au-mark ff-mono text-sm">L</span>
+        <span className="text-lg font-semibold tracking-tight">{APP_NAME}</span>
+      </Link>
 
-      <div className="relative z-10 space-y-6">
-        <p className="max-w-xs text-2xl font-semibold leading-snug">
+      {/* editorial center */}
+      <div className="relative z-10 max-w-md space-y-8">
+        <span
+          className="au-rise au-chip ff-mono"
+          style={{ ['--d' as string]: '0.12s' }}
+        >
+          <span className="au-chip__dot" />
+          PLAIN-TEXT ACCOUNTING
+        </span>
+
+        <h2
+          className="au-rise ff-display text-[clamp(2.25rem,3.4vw,3.25rem)] leading-[1.04]"
+          style={{ ['--d' as string]: '0.2s' }}
+        >
           Track every cent. Plain text. Yours.
-        </p>
-        {/* decorative, static sparkline motif — no real data */}
-        <div aria-hidden className="flex h-16 items-end gap-1">
-          {[3, 5, 4, 7, 6, 9, 8, 11, 9, 12].map((h, i) => (
-            <span
-              key={i}
-              className="w-2 rounded-sm bg-primary-foreground/30"
-              style={{ height: `${h * 6}px` }}
-            />
+        </h2>
+
+        <div
+          className="au-rise au-card au-card--lit p-0"
+          style={{ ['--d' as string]: '0.3s' }}
+        >
+          <div className="flex items-center gap-2 border-b border-[var(--line)] px-4 py-2.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--red)]/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--gold)]/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--em)]/70" />
+            <span className="ff-mono ml-2 text-xs text-[color:var(--txt-faint)]">
+              2026.ledger
+            </span>
+          </div>
+          <pre
+            className="au-journal ff-mono overflow-hidden px-5 py-4"
+            dangerouslySetInnerHTML={{ __html: JOURNAL }}
+          />
+        </div>
+
+        <div
+          className="au-rise au-bars"
+          style={{ ['--d' as string]: '0.38s' }}
+          aria-hidden
+        >
+          {BARS.map((h, i) => (
+            <span key={i} style={{ height: `${h}px` }} />
           ))}
         </div>
       </div>
 
-      <ul className="relative z-10 space-y-2 text-sm text-primary-foreground/90">
+      {/* feature ticks */}
+      <ul
+        className="au-rise relative z-10 space-y-2.5"
+        style={{ ['--d' as string]: '0.46s' }}
+      >
         {FEATURES.map((f) => (
-          <li key={f} className="flex items-center gap-2">
+          <li key={f} className="au-tick">
             <Check className="size-4" aria-hidden />
             {f}
           </li>
         ))}
       </ul>
-    </div>
+    </aside>
   );
 }

--- a/features/auth/SentNotice.tsx
+++ b/features/auth/SentNotice.tsx
@@ -2,7 +2,6 @@
 
 import { MailCheck } from 'lucide-react';
 import { sentCopy } from './authCopy';
-import { Button } from '@/components/ui/button';
 
 interface SentNoticeProps {
   email: string;
@@ -19,33 +18,37 @@ export function SentNotice({
 }: SentNoticeProps) {
   const copy = sentCopy();
   return (
-    <div className="flex flex-col gap-4 text-center" aria-live="polite">
-      <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-muted">
-        <MailCheck className="size-6 text-foreground" aria-hidden />
+    <div className="flex flex-col gap-6" aria-live="polite">
+      <div className="au-icon-tile">
+        <MailCheck className="size-5" aria-hidden />
       </div>
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold">{copy.heading}</h2>
-        <p className="text-sm text-muted-foreground">
+      <div className="space-y-2">
+        <h2 className="ff-display text-[clamp(1.75rem,3.5vw,2.4rem)] leading-tight">
+          {copy.heading}
+        </h2>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)]">
           We sent a sign-in link to{' '}
-          <span className="font-medium text-foreground">{email}</span>. It
+          <span className="ff-mono text-[color:var(--txt)]">{email}</span>. It
           expires in 10 minutes.
         </p>
       </div>
-      <p className="rounded-lg bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
-        {copy.spam}
-      </p>
-      <div className="flex flex-col gap-2">
-        <Button
+      <p className="au-note">{copy.spam}</p>
+      <div className="flex flex-col gap-2.5">
+        <button
           type="button"
-          variant="outline"
+          className="au-btn au-btn--ghost"
           onClick={onResend}
           disabled={!canResend}
         >
           Resend link
-        </Button>
-        <Button type="button" variant="ghost" onClick={onUseDifferentEmail}>
+        </button>
+        <button
+          type="button"
+          className="au-btn au-btn--ghost border-0 bg-transparent text-[color:var(--txt-dim)]"
+          onClick={onUseDifferentEmail}
+        >
           Use a different email
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/features/auth/auth.css
+++ b/features/auth/auth.css
@@ -1,0 +1,388 @@
+/*
+ * Auth screen styles — self-contained under `.au`, deliberately mirroring the
+ * marketing landing's `.lp` system (features/landing/landing.css) so the
+ * sign-in / sign-up pages read with the same deep-green editorial voice as the
+ * home page. Scoped and theme-independent (the app chrome never renders here —
+ * AppShell treats auth routes as full-bleed), so these rules own the viewport
+ * regardless of the app's light/dark mode. Token VALUES intentionally match
+ * landing.css; kept as a separate sheet rather than a shared refactor to keep
+ * the conversion-critical landing page low-risk.
+ */
+
+.au {
+  /* ink palette — deep, green-leaning black with emerald accents */
+  --ink: oklch(16% 0.018 165);
+  --ink-2: oklch(20% 0.02 165);
+  --txt: oklch(95% 0.008 150);
+  --txt-dim: oklch(74% 0.018 160);
+  --txt-faint: oklch(60% 0.018 160);
+  --em: oklch(78% 0.15 165);
+  --em-deep: oklch(66% 0.15 165);
+  --gold: oklch(84% 0.12 88);
+  --red: oklch(72% 0.17 25);
+  --line: oklch(100% 0 0 / 0.09);
+  --line-soft: oklch(100% 0 0 / 0.05);
+  --card: oklch(100% 0 0 / 0.035);
+  --card-hi: oklch(100% 0 0 / 0.06);
+
+  position: relative;
+  min-height: 100svh;
+  background: var(--ink);
+  color: var(--txt);
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.au .ff-display {
+  font-family: var(--font-display), Georgia, 'Times New Roman', serif;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+}
+.au .ff-mono {
+  font-family: var(--font-mono), ui-monospace, 'SF Mono', Menlo, monospace;
+  font-feature-settings:
+    'tnum' 1,
+    'zero' 1;
+}
+
+/* ───────────────────────── atmosphere ───────────────────────── */
+
+/* fine grid, fading from the top-left brand side */
+.au::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--line-soft) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line-soft) 1px, transparent 1px);
+  background-size: 64px 64px;
+  -webkit-mask-image: radial-gradient(
+    ellipse 70% 80% at 0% 0%,
+    #000 20%,
+    transparent 70%
+  );
+  mask-image: radial-gradient(
+    ellipse 70% 80% at 0% 0%,
+    #000 20%,
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* grain overlay */
+.au::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E");
+  opacity: 0.035;
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.au-glow {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(90px);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 0;
+  background: radial-gradient(circle, var(--em-deep), transparent 70%);
+}
+
+.au-layer {
+  position: relative;
+  z-index: 1;
+}
+
+/* ───────────────────────── primitives ───────────────────────── */
+
+.au-mark {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.6rem;
+  background: linear-gradient(160deg, var(--em), var(--em-deep));
+  color: oklch(20% 0.04 165);
+  font-weight: 700;
+  box-shadow: 0 6px 16px -8px oklch(66% 0.15 165 / 0.9);
+}
+
+.au-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 9999px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--txt-dim);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+.au-chip__dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: var(--em);
+  box-shadow: 0 0 0 4px oklch(78% 0.15 165 / 0.18);
+  animation: auPulse 2.4s ease-in-out infinite;
+}
+
+.au-grad {
+  background: linear-gradient(100deg, var(--em), var(--gold));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.au-link {
+  color: var(--txt);
+  font-weight: 500;
+  text-decoration-color: oklch(78% 0.15 165 / 0.5);
+  text-underline-offset: 3px;
+  transition: color 0.2s ease;
+}
+.au-link:hover {
+  color: var(--em);
+  text-decoration: underline;
+}
+
+.au-card {
+  position: relative;
+  border-radius: 1.25rem;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, var(--card-hi), var(--card));
+  overflow: hidden;
+}
+.au-card--lit::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    oklch(100% 0 0 / 0.4),
+    transparent
+  );
+}
+
+/* ───────────────────────── buttons ───────────────────────── */
+
+.au-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  width: 100%;
+  height: 3rem;
+  padding: 0 1.25rem;
+  border-radius: 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  transition:
+    transform 0.18s cubic-bezier(0.2, 0.7, 0.2, 1),
+    box-shadow 0.25s ease,
+    background 0.25s ease,
+    border-color 0.25s ease;
+  white-space: nowrap;
+}
+.au-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.au-btn:not(:disabled):active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.au-btn--primary {
+  background: linear-gradient(180deg, var(--em), var(--em-deep));
+  color: oklch(20% 0.04 165);
+  box-shadow:
+    0 1px 0 oklch(100% 0 0 / 0.25) inset,
+    0 10px 30px -10px oklch(66% 0.15 165 / 0.7);
+}
+.au-btn--primary:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 1px 0 oklch(100% 0 0 / 0.3) inset,
+    0 18px 40px -12px oklch(66% 0.15 165 / 0.85);
+}
+
+.au-btn--ghost {
+  background: var(--card);
+  color: var(--txt);
+  border: 1px solid var(--line);
+}
+.au-btn--ghost:not(:disabled):hover {
+  background: var(--card-hi);
+  border-color: oklch(78% 0.15 165 / 0.4);
+}
+
+/* ───────────────────────── form fields ───────────────────────── */
+
+.au-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--txt-dim);
+}
+
+.au-input {
+  width: 100%;
+  height: 3rem;
+  padding: 0 0.95rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--txt);
+  font-size: 0.95rem;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+.au-input::placeholder {
+  color: var(--txt-faint);
+}
+.au-input:focus {
+  outline: none;
+  border-color: oklch(78% 0.15 165 / 0.55);
+  box-shadow: 0 0 0 3px oklch(78% 0.15 165 / 0.15);
+  background: var(--card-hi);
+}
+
+.au-sep {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  color: var(--txt-faint);
+  font-size: 0.8rem;
+}
+.au-sep::before,
+.au-sep::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
+.au-error {
+  color: oklch(75% 0.16 25);
+  font-size: 0.85rem;
+}
+
+.au-note {
+  border-radius: 0.75rem;
+  border: 1px solid var(--line-soft);
+  background: var(--card);
+  padding: 0.6rem 0.8rem;
+  font-size: 0.78rem;
+  color: var(--txt-dim);
+}
+
+/* ───────────────────────── brand-panel motifs ───────────────────────── */
+
+.au-tick {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--txt-dim);
+  font-size: 0.875rem;
+}
+.au-tick svg {
+  color: var(--em);
+  flex: none;
+}
+
+.au-journal {
+  font-size: 0.78rem;
+  line-height: 1.85;
+}
+.au-journal .c-cmt {
+  color: var(--txt-faint);
+}
+.au-journal .c-date {
+  color: var(--gold);
+}
+.au-journal .c-payee {
+  color: var(--txt);
+}
+.au-journal .c-acct {
+  color: var(--txt-dim);
+}
+.au-journal .c-pos {
+  color: var(--em);
+}
+
+/* the emerald sparkbars under the tagline (decorative) */
+.au-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.3rem;
+  height: 3rem;
+}
+.au-bars span {
+  width: 0.5rem;
+  border-radius: 0.15rem;
+  background: oklch(78% 0.15 165 / 0.45);
+}
+
+.au-icon-tile {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  background: var(--card-hi);
+  color: var(--em);
+}
+
+/* ───────────────────────── entrance ───────────────────────── */
+
+.au-rise {
+  opacity: 0;
+  animation: auRise 0.85s cubic-bezier(0.2, 0.7, 0.2, 1) var(--d, 0s) forwards;
+}
+
+@keyframes auRise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes auPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 4px oklch(78% 0.15 165 / 0.18);
+  }
+  50% {
+    box-shadow: 0 0 0 7px oklch(78% 0.15 165 / 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .au *,
+  .au *::before,
+  .au *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+  .au-rise {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -32,6 +32,8 @@ export function proxy(req: NextRequest) {
 
 // Run on every request except:
 //   /sign-in and /sign-in/error  — the auth UI itself
+//   /sign-up                     — open registration; must be reachable without
+//                                  a session, or new users get bounced to /sign-in
 //   /api/auth/*                  — better-auth's own handlers
 //   _next/* internals, favicon, static assets
 // The public landing at `/` still passes through the matcher but is short-
@@ -39,6 +41,6 @@ export function proxy(req: NextRequest) {
 // session.
 export const config = {
   matcher: [
-    '/((?!sign-in|api/auth|_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
+    '/((?!sign-in|sign-up|api/auth|_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
   ],
 };

--- a/vitest-next-font.js
+++ b/vitest-next-font.js
@@ -1,0 +1,10 @@
+// Test stub for `next/font/google`. The real module does build-time font
+// fetching that isn't available under Vitest, so importing any font factory
+// would throw during collection. Each factory returns the shape components
+// consume (className + variable). Aliased in vitest.config.ts. Add a named
+// export here when a new Google font is introduced.
+const factory = () => ({ className: 'font-mock', variable: 'font-mock-var' });
+
+export const Geist = factory;
+export const Fraunces = factory;
+export const JetBrains_Mono = factory;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, '.'),
       'server-only': path.resolve(__dirname, 'vitest-server-only.js'),
+      'next/font/google': path.resolve(__dirname, 'vitest-next-font.js'),
     },
   },
   test: {


### PR DESCRIPTION
Makes the sign-in / sign-up experience coherent with the marketing landing page, in two layers.

## 1. Full-bleed shell (was: squished column)

`AuthScreen` is a full-bleed split layout, but `AppShell`'s auth branch still wrapped it in the starter's legacy centered-card container (`max-w-md`), clamping the whole split into a ~448px column and nesting `<main>` inside `<main>`.

- Drop the width-clamp wrapper so `AuthScreen` owns its chrome.
- Add `/sign-up` to `AUTH_PATHS` (open registration) so it renders chrome-free too.

## 2. Landing-matched redesign

The auth screen used generic black/white shadcn styling — totally out of sync with the deep-green editorial home page. Rebuilt in the same visual language:

- **Theme**: deep green-ink palette, Fraunces serif display + JetBrains Mono, emerald accent, grid + grain + glow atmosphere, glass cards — scoped under `.au` in a self-contained `auth.css`, mirroring how `landing.css` owns `.lp` (keeps the conversion-critical landing page untouched).
- **BrandPanel**: editorial left rail echoing the home hero — pulsing chip, serif tagline, a mini journal terminal card, sparkbars, feature ticks.
- **AuthForm / SentNotice**: themed inputs, separator, and buttons; the primary CTA uses the same emerald gradient as the landing "Get started".
- **Layout robustness**: base `grid-cols-1` + `minmax(0,…)` + `min-w-0` so the form never overflows narrow viewports (verified `scrollWidth === clientWidth` at 390px).

## 3. Proxy fix — `/sign-up` was unreachable

The proxy matcher excluded only `/sign-in`, so unauthenticated visitors to `/sign-up` were redirected to `/sign-in?callbackUrl=/sign-up`. Added `/sign-up` to the matcher exclusion.

## Testing

- 399 tests pass; `pnpm lint` + `tsc --noEmit` clean.
- Added a `next/font/google` Vitest stub (aliased in `vitest.config.ts`) so font-importing components render under test.
- Verified rendered output via headless Chrome at desktop (1440) and mobile (390) for both `/sign-in` and `/sign-up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)