### PR TITLE
feat(account): self-service account deletion + journal backup export

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -218,8 +218,8 @@ Only relevant if this gets deployed to anyone other than you.
 - [ ] Rate limit `/api/upload` and any future write endpoint
 - [ ] Audit log of journal mutations (who, when, how many bytes)
 - [ ] Quota on per-user journal size
-- [ ] Backup / restore endpoint (download `.zip` of the journal directory)
-- [ ] Account deletion (wipe journals + DB rows)
+- [x] Backup endpoint — `GET /api/account/export` streams a `.zip` of the user's journal directory (reuses `pullLocked` + `listLocalRelPaths` + `adm-zip`). (Restore-from-backup upload still pending; import covers re-upload.)
+- [x] **Account deletion** — self-service on `/settings` Danger Zone: emailed 6-digit code (hashed, 10-min expiry, 5-attempt cap, 30s resend throttle) → `purgeUserData` wipes Garage (`clearRemote`) + local journal dir + `db.delete(user)` cascade → sign-out + `/account/deleted`. Spec: `docs/superpowers/specs/2026-06-25-account-deletion-design.md`.
 - [ ] CSP / security headers pass
 - [ ] Structured logging + an error-tracking destination
 

--- a/app/account/deleted/page.tsx
+++ b/app/account/deleted/page.tsx
@@ -1,0 +1,19 @@
+import { buttonVariants } from '@/components/ui/button';
+import Link from 'next/link';
+
+export default function AccountDeletedPage() {
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center gap-6 px-6 text-center">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold">Your account was deleted</h1>
+        <p className="text-muted-foreground max-w-md">
+          Your journals and account have been permanently removed. There is
+          nothing left to recover.
+        </p>
+      </div>
+      <Link href="/" className={buttonVariants({ variant: 'outline' })}>
+        Back to home
+      </Link>
+    </main>
+  );
+}

--- a/app/api/account/export/route.test.ts
+++ b/app/api/account/export/route.test.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import AdmZip from 'adm-zip';
+import { buildJournalZip } from './route';
+
+describe('buildJournalZip', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zip-test-'));
+    await fs.writeFile(path.join(dir, 'main.ledger'), '; main\n');
+    await fs.mkdir(path.join(dir, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'sub', 'jan.ledger'), '; jan\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('zips every file with its relative path', async () => {
+    const buf = await buildJournalZip(dir);
+    const names = new AdmZip(buf)
+      .getEntries()
+      .map((e) => e.entryName)
+      .sort();
+    expect(names).toEqual(['main.ledger', 'sub/jan.ledger']);
+  });
+
+  it('preserves file contents', async () => {
+    const buf = await buildJournalZip(dir);
+    const entry = new AdmZip(buf).getEntry('main.ledger');
+    expect(entry?.getData().toString('utf-8')).toBe('; main\n');
+  });
+});

--- a/app/api/account/export/route.ts
+++ b/app/api/account/export/route.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import { requireUser } from '@/lib/auth/require-user';
+import { getJournalDir } from '@/lib/journal/layout';
+import { listLocalRelPaths } from '@/lib/storage/manifest';
+import { pullLocked } from '@/lib/storage/sync';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/** Build a .zip of every file under `dir`, keyed by POSIX relative path. */
+export async function buildJournalZip(dir: string): Promise<Buffer> {
+  const zip = new AdmZip();
+  const relPaths = await listLocalRelPaths(dir);
+  for (const rel of relPaths) {
+    const data = await fs.readFile(path.join(dir, rel));
+    zip.addFile(rel.split(path.sep).join('/'), data);
+  }
+  return zip.toBuffer();
+}
+
+export async function GET(): Promise<Response> {
+  const user = await requireUser();
+  try {
+    await pullLocked(user.id);
+    const buf = await buildJournalZip(getJournalDir(user.id));
+    return new NextResponse(new Uint8Array(buf), {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="journals-${user.id}-backup.zip"`,
+      },
+    });
+  } catch (e) {
+    console.error('journal backup export failed', e);
+    return NextResponse.json(
+      { error: 'Could not export your journal' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/AppShell/publicPaths.test.ts
+++ b/components/AppShell/publicPaths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isPublicPath } from './publicPaths';
+import { bouncesSignedInToDashboard, isPublicPath } from './publicPaths';
 
 describe('isPublicPath', () => {
   it('treats the marketing landing as a public, bare-chrome page', () => {
@@ -16,5 +16,23 @@ describe('isPublicPath', () => {
     expect(isPublicPath('/sign-in')).toBe(false);
     // A nested path must not be mistaken for the landing.
     expect(isPublicPath('/reports')).toBe(false);
+  });
+});
+
+describe('bouncesSignedInToDashboard', () => {
+  it('bounces a signed-in visitor away from the marketing landing', () => {
+    expect(bouncesSignedInToDashboard('/')).toBe(true);
+  });
+
+  it('does NOT bounce /account/deleted — the goodbye page must stay reachable even with a stale session cookie present', () => {
+    // Guards commit 9352138: when signOut() fails, the cookie lingers and a
+    // presence-only bounce would strand the just-deleted user on /dashboard.
+    expect(isPublicPath('/account/deleted')).toBe(true);
+    expect(bouncesSignedInToDashboard('/account/deleted')).toBe(false);
+  });
+
+  it('does not bounce non-public paths', () => {
+    expect(bouncesSignedInToDashboard('/dashboard')).toBe(false);
+    expect(bouncesSignedInToDashboard('/reports')).toBe(false);
   });
 });

--- a/components/AppShell/publicPaths.test.ts
+++ b/components/AppShell/publicPaths.test.ts
@@ -6,6 +6,10 @@ describe('isPublicPath', () => {
     expect(isPublicPath('/')).toBe(true);
   });
 
+  it('treats /account/deleted as public', () => {
+    expect(isPublicPath('/account/deleted')).toBe(true);
+  });
+
   it('treats app and auth routes as non-public pages', () => {
     expect(isPublicPath('/dashboard')).toBe(false);
     expect(isPublicPath('/balance')).toBe(false);

--- a/components/AppShell/publicPaths.ts
+++ b/components/AppShell/publicPaths.ts
@@ -5,7 +5,7 @@
 // place. A future addition (e.g. /pricing) can be made here once, instead of
 // duplicating a magic route literal across the proxy and the shell where a
 // missed copy could silently strand a public page inside the app chrome.
-export const PUBLIC_PATHS = new Set(['/']);
+export const PUBLIC_PATHS = new Set(['/', '/account/deleted']);
 
 export const isPublicPath = (pathname: string): boolean =>
   PUBLIC_PATHS.has(pathname);

--- a/components/AppShell/publicPaths.ts
+++ b/components/AppShell/publicPaths.ts
@@ -1,11 +1,28 @@
 // Paths that are publicly reachable without a session AND render their own
-// full-bleed chrome (no sidebar, header, or app-only banners). Today that is
-// just the marketing landing at `/`. Kept in its own tested module — mirroring
-// authPaths.ts — so the "which path gets which chrome" decision lives in one
-// place. A future addition (e.g. /pricing) can be made here once, instead of
-// duplicating a magic route literal across the proxy and the shell where a
-// missed copy could silently strand a public page inside the app chrome.
+// full-bleed chrome (no sidebar, header, or app-only banners). Two routes today:
+// the marketing landing at `/` and the post-deletion goodbye page at
+// `/account/deleted`. Kept in its own tested module — mirroring authPaths.ts —
+// so the "which path gets which chrome" decision lives in one place. A future
+// addition (e.g. /pricing) can be made here once, instead of duplicating a
+// magic route literal across the proxy and the shell where a missed copy could
+// silently strand a public page inside the app chrome.
 export const PUBLIC_PATHS = new Set(['/', '/account/deleted']);
 
 export const isPublicPath = (pathname: string): boolean =>
   PUBLIC_PATHS.has(pathname);
+
+// The subset of public paths that should *also* bounce a signed-in visitor to
+// their dashboard. This is deliberately narrower than PUBLIC_PATHS: the
+// marketing landing has no use for an authenticated user, so the proxy sends
+// them to `/dashboard` on a cheap cookie check.
+//
+// `/account/deleted` is intentionally NOT here. The deletion flow can leave a
+// stale session cookie behind when `authClient.signOut()` fails (the exact case
+// commit 9352138 tolerates), and a presence-only cookie check would then bounce
+// the just-deleted user to `/dashboard` instead of the goodbye page —
+// nullifying that fix. The goodbye page must stay reachable even with a stale
+// cookie present, so it is public-for-everyone but never redirected.
+export const BOUNCE_SIGNED_IN_PATHS = new Set(['/']);
+
+export const bouncesSignedInToDashboard = (pathname: string): boolean =>
+  BOUNCE_SIGNED_IN_PATHS.has(pathname);

--- a/db/migrations/0001_nostalgic_martin_li.sql
+++ b/db/migrations/0001_nostalgic_martin_li.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "accountDeletionChallenge" (
+	"userId" text PRIMARY KEY NOT NULL,
+	"codeHash" text NOT NULL,
+	"expiresAt" timestamp NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "accountDeletionChallenge" ADD CONSTRAINT "accountDeletionChallenge_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,421 @@
+{
+  "id": "75b4f248-0893-4d9a-8e29-1ff1e4208a51",
+  "prevId": "06fbf72a-c1d1-457a-9ab2-5a170ebc6d67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accountDeletionChallenge": {
+      "name": "accountDeletionChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accountDeletionChallenge_userId_user_id_fk": {
+          "name": "accountDeletionChallenge_userId_user_id_fk",
+          "tableFrom": "accountDeletionChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commodity_price": {
+      "name": "commodity_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_date": {
+          "name": "fetched_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commodity_price_unique_per_day": {
+          "name": "commodity_price_unique_per_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol",
+            "quote",
+            "fetched_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_fetch_run": {
+      "name": "price_fetch_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbols_fetched": {
+          "name": "symbols_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "symbols_failed": {
+          "name": "symbols_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savedView": {
+      "name": "savedView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPath": {
+          "name": "targetPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "savedView_user_name": {
+          "name": "savedView_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savedView_userId_user_id_fk": {
+          "name": "savedView_userId_user_id_fk",
+          "tableFrom": "savedView",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_user_name": {
+          "name": "template_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_userId_user_id_fk": {
+          "name": "template_userId_user_id_fk",
+          "tableFrom": "template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "baseCurrency": {
+          "name": "baseCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journalMain": {
+          "name": "journalMain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main.ledger'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSetting_userId_user_id_fk": {
+          "name": "userSetting_userId_user_id_fk",
+          "tableFrom": "userSetting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1782083900166,
       "tag": "0000_mushy_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1782340998345,
+      "tag": "0001_nostalgic_martin_li",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/accountDeletionChallenge.ts
+++ b/db/schema/accountDeletionChallenge.ts
@@ -1,0 +1,20 @@
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+// One active deletion challenge per user (PK = userId; re-requesting a code
+// upserts this row). Holds only a hash of the 6-digit code — never plaintext.
+export const accountDeletionChallenge = pgTable('accountDeletionChallenge', {
+  userId: text('userId')
+    .primaryKey()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  codeHash: text('codeHash').notNull(),
+  expiresAt: timestamp('expiresAt').notNull(),
+  attempts: integer('attempts').notNull().default(0),
+  createdAt: timestamp('createdAt')
+    .notNull()
+    .default(sql`now()`),
+});
+
+export type AccountDeletionChallenge =
+  typeof accountDeletionChallenge.$inferSelect;

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -1,3 +1,7 @@
+export {
+  accountDeletionChallenge,
+  type AccountDeletionChallenge,
+} from './accountDeletionChallenge';
 export { commodityPrice, type CommodityPrice } from './commodityPrice';
 export { priceFetchRun, type PriceFetchRun } from './priceFetchRun';
 export { savedView, type SavedView } from './savedView';

--- a/docs/superpowers/plans/2026-06-25-account-deletion.md
+++ b/docs/superpowers/plans/2026-06-25-account-deletion.md
@@ -1,0 +1,1285 @@
+# Account Deletion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a self-service "delete my account" flow on `/settings`, gated behind an emailed 6-digit verification code, that permanently wipes the user's journals (Garage + local), all DB rows, and the auth identity.
+
+**Architecture:** Self-contained in `ledger-cli-ui` (no `@naeemba/next-starter` change). Follows the repo's Repository + Service + one-action-per-file convention. A new `accountDeletionChallenge` table holds a hashed, expiring, attempt-capped code. A `purgeUserData` orchestration unit does the destructive wipe in a fixed order (Garage → local → `db.delete(user)` cascade). Backup export is a new `GET /api/account/export` route reusing existing storage + zip helpers.
+
+**Tech Stack:** Next.js 16 (app router), TypeScript, Drizzle ORM (Postgres), Vitest (+ PGlite test db), `adm-zip`, shadcn/ui, sonner, better-auth (via the starter), Postal email transport.
+
+## Global Constraints
+
+- **Code params (verbatim):** 6 digits, 10-minute expiry, 5-attempt cap, 30-second re-send throttle.
+- **Code is stored hashed** (SHA-256 hex), never plaintext; compared in constant time (`crypto.timingSafeEqual`).
+- **Deletion order is load-bearing:** `clearRemote(userId)` (Garage, source of truth) → remove local journal dir → `db.delete(user)` (DB cascade). Never reorder.
+- **All actions/routes are `requireUser`-gated and self-scoped** — only ever operate on the caller's own `user.id`; no user-supplied id reaches the service.
+- **Never log the plaintext code or leak `ledger`/DB internals to the client.** Server-only `console.error` for real errors; generic messages to the user.
+- **`ledger` is never shelled out in this feature.**
+- Follow existing import style: `import 'server-only'` at the top of server-only modules; drizzle schema tables reference `user` from `@naeemba/next-starter/schema` with `{ onDelete: 'cascade' }`.
+- Test db pattern: `setupTestDb('<prefix>-')` / `teardownTestDb(ctx)` / `ctx.insertUser(id, name, email)` from `@/lib/test-utils/db`.
+- Commands: tests `pnpm test`, type-check `pnpm type-check`, migration generate `pnpm db:generate`.
+
+---
+
+### Task 1: `accountDeletionChallenge` schema + migration
+
+**Files:**
+- Create: `db/schema/accountDeletionChallenge.ts`
+- Modify: `db/schema/index.ts` (add export)
+- Create (generated): `db/migrations/XXXX_*.sql` via `pnpm db:generate`
+
+**Interfaces:**
+- Produces: `accountDeletionChallenge` table + `AccountDeletionChallenge` row type. Columns: `userId` (text PK, FK→user cascade), `codeHash` (text), `expiresAt` (timestamp), `attempts` (integer, default 0), `createdAt` (timestamp, default now).
+
+- [ ] **Step 1: Write the schema file**
+
+`db/schema/accountDeletionChallenge.ts`:
+```ts
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+// One active deletion challenge per user (PK = userId; re-requesting a code
+// upserts this row). Holds only a hash of the 6-digit code — never plaintext.
+export const accountDeletionChallenge = pgTable('accountDeletionChallenge', {
+  userId: text('userId')
+    .primaryKey()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  codeHash: text('codeHash').notNull(),
+  expiresAt: timestamp('expiresAt').notNull(),
+  attempts: integer('attempts').notNull().default(0),
+  createdAt: timestamp('createdAt')
+    .notNull()
+    .default(sql`now()`),
+});
+
+export type AccountDeletionChallenge =
+  typeof accountDeletionChallenge.$inferSelect;
+```
+
+- [ ] **Step 2: Export from the schema barrel**
+
+Add to `db/schema/index.ts` (keep alphabetical-ish ordering, place after the `account…`/before `commodityPrice` line is fine):
+```ts
+export {
+  accountDeletionChallenge,
+  type AccountDeletionChallenge,
+} from './accountDeletionChallenge';
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run: `pnpm db:generate`
+Expected: drizzle-kit writes a new `db/migrations/XXXX_*.sql` creating table `accountDeletionChallenge` with the FK to `user(id)` `ON DELETE cascade`. No prompts (new table, no renames).
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm type-check`
+Expected: PASS (no errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/schema/accountDeletionChallenge.ts db/schema/index.ts db/migrations
+git commit -m "feat(account-deletion): accountDeletionChallenge table + migration"
+```
+
+---
+
+### Task 2: `AccountDeletionChallengeRepository`
+
+**Files:**
+- Create: `lib/account-deletion/repository.ts`
+- Test: `lib/account-deletion/repository.test.ts`
+
+**Interfaces:**
+- Consumes: `accountDeletionChallenge`, `AccountDeletionChallenge` (Task 1); `DbInstance` from `@/lib/db/connection`.
+- Produces: `class AccountDeletionChallengeRepository` with:
+  - `upsert(userId: string, codeHash: string, expiresAt: Date): Promise<void>` — inserts or replaces the row, resetting `attempts` to 0 and `createdAt` to now.
+  - `get(userId: string): Promise<AccountDeletionChallenge | null>`
+  - `incrementAttempts(userId: string): Promise<number>` — returns the new attempts count.
+  - `delete(userId: string): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+`lib/account-deletion/repository.test.ts`:
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AccountDeletionChallengeRepository } from './repository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('AccountDeletionChallengeRepository', () => {
+  let ctx: TestDbContext;
+  let repo: AccountDeletionChallengeRepository;
+  const future = () => new Date(Date.now() + 600_000);
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('acct-del-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new AccountDeletionChallengeRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('upsert inserts a row with attempts=0', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    const row = await repo.get('alice');
+    expect(row?.codeHash).toBe('hash1');
+    expect(row?.attempts).toBe(0);
+  });
+
+  it('upsert replaces an existing row and resets attempts', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    await repo.incrementAttempts('alice');
+    await repo.upsert('alice', 'hash2', future());
+    const row = await repo.get('alice');
+    expect(row?.codeHash).toBe('hash2');
+    expect(row?.attempts).toBe(0);
+  });
+
+  it('get returns null when no challenge exists', async () => {
+    expect(await repo.get('alice')).toBeNull();
+  });
+
+  it('incrementAttempts returns the new count', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    expect(await repo.incrementAttempts('alice')).toBe(1);
+    expect(await repo.incrementAttempts('alice')).toBe(2);
+  });
+
+  it('delete removes the row', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    await repo.delete('alice');
+    expect(await repo.get('alice')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/account-deletion/repository.test.ts`
+Expected: FAIL — cannot find module `./repository`.
+
+- [ ] **Step 3: Write the repository**
+
+`lib/account-deletion/repository.ts`:
+```ts
+import { eq, sql } from 'drizzle-orm';
+import {
+  accountDeletionChallenge,
+  type AccountDeletionChallenge,
+} from '@/db/schema/accountDeletionChallenge';
+import type { DbInstance } from '@/lib/db/connection';
+
+export class AccountDeletionChallengeRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  async upsert(
+    userId: string,
+    codeHash: string,
+    expiresAt: Date
+  ): Promise<void> {
+    await this.db
+      .insert(accountDeletionChallenge)
+      .values({ userId, codeHash, expiresAt, attempts: 0 })
+      .onConflictDoUpdate({
+        target: accountDeletionChallenge.userId,
+        set: { codeHash, expiresAt, attempts: 0, createdAt: sql`now()` },
+      });
+  }
+
+  async get(userId: string): Promise<AccountDeletionChallenge | null> {
+    const rows = await this.db
+      .select()
+      .from(accountDeletionChallenge)
+      .where(eq(accountDeletionChallenge.userId, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async incrementAttempts(userId: string): Promise<number> {
+    const rows = await this.db
+      .update(accountDeletionChallenge)
+      .set({ attempts: sql`${accountDeletionChallenge.attempts} + 1` })
+      .where(eq(accountDeletionChallenge.userId, userId))
+      .returning({ attempts: accountDeletionChallenge.attempts });
+    return rows[0]?.attempts ?? 0;
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.db
+      .delete(accountDeletionChallenge)
+      .where(eq(accountDeletionChallenge.userId, userId));
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/account-deletion/repository.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/account-deletion/repository.ts lib/account-deletion/repository.test.ts
+git commit -m "feat(account-deletion): challenge repository"
+```
+
+---
+
+### Task 3: Code Zod schema
+
+**Files:**
+- Create: `lib/account-deletion/schema.ts`
+- Test: `lib/account-deletion/schema.test.ts`
+
+**Interfaces:**
+- Produces: `deletionCodeSchema` (Zod) accepting exactly 6 ASCII digits; `DeletionCode = string`.
+
+- [ ] **Step 1: Write the failing test**
+
+`lib/account-deletion/schema.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { deletionCodeSchema } from './schema';
+
+describe('deletionCodeSchema', () => {
+  it('accepts exactly 6 digits', () => {
+    expect(deletionCodeSchema.safeParse('012345').success).toBe(true);
+  });
+  it('rejects fewer than 6 digits', () => {
+    expect(deletionCodeSchema.safeParse('12345').success).toBe(false);
+  });
+  it('rejects more than 6 digits', () => {
+    expect(deletionCodeSchema.safeParse('1234567').success).toBe(false);
+  });
+  it('rejects non-numeric input', () => {
+    expect(deletionCodeSchema.safeParse('12a456').success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/account-deletion/schema.test.ts`
+Expected: FAIL — cannot find module `./schema`.
+
+- [ ] **Step 3: Write the schema**
+
+`lib/account-deletion/schema.ts`:
+```ts
+import { z } from 'zod';
+
+export const deletionCodeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{6}$/, 'Enter the 6-digit code from your email');
+
+export type DeletionCode = z.infer<typeof deletionCodeSchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/account-deletion/schema.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/account-deletion/schema.ts lib/account-deletion/schema.test.ts
+git commit -m "feat(account-deletion): code validation schema"
+```
+
+---
+
+### Task 4: `purgeUserData` orchestration
+
+**Files:**
+- Create: `lib/account-deletion/purge.ts`
+- Test: `lib/account-deletion/purge.test.ts`
+
+**Interfaces:**
+- Consumes: `clearRemote` from `@/lib/storage/sync`; `getJournalDir` from `@/lib/journal/layout`; `user` from `@naeemba/next-starter/schema`; `DbInstance`.
+- Produces:
+  ```ts
+  type PurgeDeps = {
+    clearRemote?: (userId: string) => Promise<void>;
+    removeLocalJournal?: (userId: string) => Promise<void>;
+  };
+  function purgeUserData(userId: string, db: DbInstance, deps?: PurgeDeps): Promise<void>;
+  ```
+  Runs, in order: `clearRemote(userId)` → `removeLocalJournal(userId)` → `db.delete(user).where(eq(user.id, userId))`. Defaults wire the real storage + `fs.rm`.
+
+- [ ] **Step 1: Write the failing test**
+
+`lib/account-deletion/purge.test.ts`:
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import { purgeUserData } from './purge';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('purgeUserData', () => {
+  let ctx: TestDbContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('acct-purge-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('runs clear → removeLocal → db.delete(user) in order', async () => {
+    const calls: string[] = [];
+    await purgeUserData('alice', ctx.db, {
+      clearRemote: async () => {
+        calls.push('clear');
+      },
+      removeLocalJournal: async () => {
+        calls.push('local');
+      },
+    });
+    expect(calls).toEqual(['clear', 'local']);
+    const rows = await ctx.db
+      .select()
+      .from(user)
+      .where(eq(user.id, 'alice'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('default removeLocalJournal deletes the journal dir', async () => {
+    const dir = path.join(ctx.tmpDir, 'journals', 'alice');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), '; test\n');
+    const prev = process.env.DATA_DIR;
+    process.env.DATA_DIR = ctx.tmpDir;
+    try {
+      await purgeUserData('alice', ctx.db, { clearRemote: async () => {} });
+    } finally {
+      process.env.DATA_DIR = prev;
+    }
+    await expect(fs.access(dir)).rejects.toThrow();
+  });
+});
+```
+
+> Note: `ctx.tmpDir` is provided by `setupTestDb` (see `lib/test-utils/db.ts` — it returns `{ client, db, insertUser, tmpDir }`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/account-deletion/purge.test.ts`
+Expected: FAIL — cannot find module `./purge`.
+
+- [ ] **Step 3: Write the orchestration**
+
+`lib/account-deletion/purge.ts`:
+```ts
+import 'server-only';
+import { promises as fs } from 'fs';
+import { eq } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import type { DbInstance } from '@/lib/db/connection';
+import { getJournalDir } from '@/lib/journal/layout';
+import { clearRemote as clearRemoteDefault } from '@/lib/storage/sync';
+
+export type PurgeDeps = {
+  clearRemote?: (userId: string) => Promise<void>;
+  removeLocalJournal?: (userId: string) => Promise<void>;
+};
+
+const removeLocalJournalDefault = (userId: string): Promise<void> =>
+  fs.rm(getJournalDir(userId), { recursive: true, force: true });
+
+/**
+ * Permanently wipe all of a user's data. ORDER MATTERS: Garage (the source of
+ * truth) first, then the local cache, then the user row (which cascades every
+ * DB row that references it — session, account, passkey, userSetting,
+ * savedView, template, accountDeletionChallenge). A mid-failure leaves only
+ * inert orphans (data with no user); re-running completes the purge.
+ */
+export async function purgeUserData(
+  userId: string,
+  db: DbInstance,
+  deps: PurgeDeps = {}
+): Promise<void> {
+  const clearRemote = deps.clearRemote ?? clearRemoteDefault;
+  const removeLocalJournal =
+    deps.removeLocalJournal ?? removeLocalJournalDefault;
+
+  await clearRemote(userId);
+  await removeLocalJournal(userId);
+  await db.delete(user).where(eq(user.id, userId));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/account-deletion/purge.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/account-deletion/purge.ts lib/account-deletion/purge.test.ts
+git commit -m "feat(account-deletion): purgeUserData orchestration"
+```
+
+---
+
+### Task 5: `AccountDeletionService` + DI wiring
+
+**Files:**
+- Create: `lib/account-deletion/service.ts`
+- Create: `lib/account-deletion/index.ts`
+- Test: `lib/account-deletion/service.test.ts`
+
+**Interfaces:**
+- Consumes: `AccountDeletionChallengeRepository` (Task 2); `purgeUserData` (Task 4); `postalTransport` from `@/lib/email-transport`; `APP_NAME` from `@/lib/app`; `db` from `@/lib/db`.
+- Produces:
+  ```ts
+  type IssueResult = { ok: true } | { ok: false; reason: 'throttled' };
+  type VerifyResult =
+    | { ok: true }
+    | { ok: false; reason: 'no-code' | 'expired' | 'too-many-attempts' }
+    | { ok: false; reason: 'invalid'; remaining: number };
+
+  class AccountDeletionService {
+    constructor(repo, deps: {
+      sendCode: (email: string, code: string) => Promise<void>;
+      purge: (userId: string) => Promise<void>;
+      now?: () => number; // injectable clock for tests; defaults to Date.now
+    });
+    issueCode(userId: string, email: string): Promise<IssueResult>;
+    verifyAndDelete(userId: string, code: string): Promise<VerifyResult>;
+  }
+  ```
+  Constants: `CODE_TTL_MS = 600_000`, `MAX_ATTEMPTS = 5`, `RESEND_THROTTLE_MS = 30_000`.
+  Singleton export from `index.ts`: `accountDeletionService`.
+
+- [ ] **Step 1: Write the failing test**
+
+`lib/account-deletion/service.test.ts`:
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AccountDeletionChallengeRepository } from './repository';
+import { AccountDeletionService } from './service';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('AccountDeletionService', () => {
+  let ctx: TestDbContext;
+  let repo: AccountDeletionChallengeRepository;
+  let sent: { email: string; code: string }[];
+  let purged: string[];
+  let nowMs: number;
+
+  const makeService = () =>
+    new AccountDeletionService(repo, {
+      sendCode: async (email, code) => {
+        sent.push({ email, code });
+      },
+      purge: async (userId) => {
+        purged.push(userId);
+      },
+      now: () => nowMs,
+    });
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('acct-svc-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new AccountDeletionChallengeRepository(ctx.db);
+    sent = [];
+    purged = [];
+    nowMs = 1_000_000;
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('issueCode emails a 6-digit code', async () => {
+    const res = await makeService().issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].email).toBe('alice@example.com');
+    expect(sent[0].code).toMatch(/^\d{6}$/);
+  });
+
+  it('issueCode throttles a re-send within 30s', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 10_000;
+    const res = await svc.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: false, reason: 'throttled' });
+    expect(sent).toHaveLength(1);
+  });
+
+  it('issueCode allows a re-send after 30s', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 31_000;
+    const res = await svc.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+    expect(sent).toHaveLength(2);
+  });
+
+  it('verifyAndDelete purges on the correct code', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const res = await svc.verifyAndDelete('alice', sent[0].code);
+    expect(res).toEqual({ ok: true });
+    expect(purged).toEqual(['alice']);
+  });
+
+  it('verifyAndDelete returns no-code when none issued', async () => {
+    const res = await makeService().verifyAndDelete('alice', '000000');
+    expect(res).toEqual({ ok: false, reason: 'no-code' });
+    expect(purged).toHaveLength(0);
+  });
+
+  it('verifyAndDelete rejects a wrong code and reports remaining attempts', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const wrong = sent[0].code === '000000' ? '111111' : '000000';
+    const res = await svc.verifyAndDelete('alice', wrong);
+    expect(res).toEqual({ ok: false, reason: 'invalid', remaining: 4 });
+    expect(purged).toHaveLength(0);
+  });
+
+  it('verifyAndDelete invalidates after 5 failed attempts', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const wrong = sent[0].code === '000000' ? '111111' : '000000';
+    let res;
+    for (let i = 0; i < 5; i++) res = await svc.verifyAndDelete('alice', wrong);
+    expect(res).toEqual({ ok: false, reason: 'too-many-attempts' });
+    // challenge is gone — a follow-up reads as no-code
+    expect(await svc.verifyAndDelete('alice', sent[0].code)).toEqual({
+      ok: false,
+      reason: 'no-code',
+    });
+  });
+
+  it('verifyAndDelete rejects an expired code', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 600_001;
+    const res = await svc.verifyAndDelete('alice', sent[0].code);
+    expect(res).toEqual({ ok: false, reason: 'expired' });
+    expect(purged).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/account-deletion/service.test.ts`
+Expected: FAIL — cannot find module `./service`.
+
+- [ ] **Step 3: Write the service**
+
+`lib/account-deletion/service.ts`:
+```ts
+import 'server-only';
+import { createHash, randomInt, timingSafeEqual } from 'crypto';
+import type { AccountDeletionChallengeRepository } from './repository';
+
+export const CODE_TTL_MS = 600_000; // 10 minutes
+export const MAX_ATTEMPTS = 5;
+export const RESEND_THROTTLE_MS = 30_000;
+
+export type IssueResult = { ok: true } | { ok: false; reason: 'throttled' };
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: 'no-code' | 'expired' | 'too-many-attempts' }
+  | { ok: false; reason: 'invalid'; remaining: number };
+
+export type AccountDeletionDeps = {
+  sendCode: (email: string, code: string) => Promise<void>;
+  purge: (userId: string) => Promise<void>;
+  now?: () => number;
+};
+
+const hashCode = (code: string): string =>
+  createHash('sha256').update(code).digest('hex');
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+};
+
+export class AccountDeletionService {
+  private readonly now: () => number;
+
+  constructor(
+    private readonly repo: AccountDeletionChallengeRepository,
+    private readonly deps: AccountDeletionDeps
+  ) {
+    this.now = deps.now ?? Date.now;
+  }
+
+  async issueCode(userId: string, email: string): Promise<IssueResult> {
+    const existing = await this.repo.get(userId);
+    if (
+      existing &&
+      this.now() - existing.createdAt.getTime() < RESEND_THROTTLE_MS
+    ) {
+      return { ok: false, reason: 'throttled' };
+    }
+    const code = String(randomInt(0, 1_000_000)).padStart(6, '0');
+    const expiresAt = new Date(this.now() + CODE_TTL_MS);
+    await this.repo.upsert(userId, hashCode(code), expiresAt);
+    await this.deps.sendCode(email, code);
+    return { ok: true };
+  }
+
+  async verifyAndDelete(userId: string, code: string): Promise<VerifyResult> {
+    const challenge = await this.repo.get(userId);
+    if (!challenge) return { ok: false, reason: 'no-code' };
+
+    if (challenge.expiresAt.getTime() < this.now()) {
+      await this.repo.delete(userId);
+      return { ok: false, reason: 'expired' };
+    }
+
+    if (!constantTimeEqual(hashCode(code), challenge.codeHash)) {
+      const attempts = await this.repo.incrementAttempts(userId);
+      if (attempts >= MAX_ATTEMPTS) {
+        await this.repo.delete(userId);
+        return { ok: false, reason: 'too-many-attempts' };
+      }
+      return { ok: false, reason: 'invalid', remaining: MAX_ATTEMPTS - attempts };
+    }
+
+    await this.deps.purge(userId);
+    // The challenge row is cascade-deleted with the user; nothing to clean up.
+    return { ok: true };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/account-deletion/service.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Write the DI wiring + email body**
+
+`lib/account-deletion/index.ts`:
+```ts
+import 'server-only';
+import { AccountDeletionChallengeRepository } from './repository';
+import { AccountDeletionService } from './service';
+import { purgeUserData } from './purge';
+import { APP_NAME } from '@/lib/app';
+import { db } from '@/lib/db';
+import { postalTransport } from '@/lib/email-transport';
+
+const sendCode = async (email: string, code: string): Promise<void> => {
+  const from = process.env.EMAIL_FROM;
+  if (!from) {
+    throw new Error('[account-deletion] EMAIL_FROM is not configured.');
+  }
+  const subject = `${APP_NAME}: confirm account deletion`;
+  const text = [
+    `Your account deletion code is ${code}.`,
+    `It expires in 10 minutes.`,
+    `If you didn't request this, ignore this email — nothing will happen.`,
+  ].join('\n\n');
+  const html =
+    `<p>Your account deletion code is <strong style="font-size:1.25rem;letter-spacing:0.15em">${code}</strong>.</p>` +
+    `<p>It expires in 10 minutes.</p>` +
+    `<p>If you didn't request this, ignore this email — nothing will happen.</p>`;
+  await postalTransport({ to: email, from, subject, html, text });
+};
+
+const accountDeletionChallengeRepository =
+  new AccountDeletionChallengeRepository(db);
+
+export const accountDeletionService = new AccountDeletionService(
+  accountDeletionChallengeRepository,
+  { sendCode, purge: (userId) => purgeUserData(userId, db) }
+);
+
+export { AccountDeletionChallengeRepository } from './repository';
+export { AccountDeletionService } from './service';
+export type { IssueResult, VerifyResult } from './service';
+export { deletionCodeSchema, type DeletionCode } from './schema';
+```
+
+- [ ] **Step 6: Type-check + run the whole account-deletion suite**
+
+Run: `pnpm type-check && pnpm test lib/account-deletion`
+Expected: PASS (type-check clean; all account-deletion tests green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/account-deletion/service.ts lib/account-deletion/service.test.ts lib/account-deletion/index.ts
+git commit -m "feat(account-deletion): service (issue/verify) + DI wiring"
+```
+
+---
+
+### Task 6: Backup export route `GET /api/account/export`
+
+**Files:**
+- Create: `app/api/account/export/route.ts`
+- Test: `app/api/account/export/route.test.ts`
+
+**Interfaces:**
+- Consumes: `requireUser`; `pullLocked` from `@/lib/storage/sync`; `listLocalRelPaths` from `@/lib/storage/manifest`; `getJournalDir` from `@/lib/journal/layout`; `adm-zip`.
+- Produces: a `GET` handler returning a `.zip` of every file under the user's journal dir, `Content-Type: application/zip`, `Content-Disposition: attachment; filename="journals-<userId>-backup.zip"`.
+
+The route's auth + storage calls are hard to unit test without a live session/store, so the testable seam is a pure helper `buildJournalZip`. Test the helper; keep the route a thin wrapper.
+
+- [ ] **Step 1: Write the failing test (pure zip helper)**
+
+`app/api/account/export/route.test.ts`:
+```ts
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildJournalZip } from './route';
+
+describe('buildJournalZip', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zip-test-'));
+    await fs.writeFile(path.join(dir, 'main.ledger'), '; main\n');
+    await fs.mkdir(path.join(dir, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'sub', 'jan.ledger'), '; jan\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('zips every file with its relative path', async () => {
+    const buf = await buildJournalZip(dir);
+    const names = new AdmZip(buf)
+      .getEntries()
+      .map((e) => e.entryName)
+      .sort();
+    expect(names).toEqual(['main.ledger', 'sub/jan.ledger']);
+  });
+
+  it('preserves file contents', async () => {
+    const buf = await buildJournalZip(dir);
+    const entry = new AdmZip(buf).getEntry('main.ledger');
+    expect(entry?.getData().toString('utf-8')).toBe('; main\n');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test app/api/account/export/route.test.ts`
+Expected: FAIL — cannot find module `./route`.
+
+- [ ] **Step 3: Write the route + helper**
+
+`app/api/account/export/route.ts`:
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import { requireUser } from '@/lib/auth/require-user';
+import { getJournalDir } from '@/lib/journal/layout';
+import { listLocalRelPaths } from '@/lib/storage/manifest';
+import { pullLocked } from '@/lib/storage/sync';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/** Build a .zip of every file under `dir`, keyed by POSIX relative path. */
+export async function buildJournalZip(dir: string): Promise<Buffer> {
+  const zip = new AdmZip();
+  const relPaths = await listLocalRelPaths(dir);
+  for (const rel of relPaths) {
+    const data = await fs.readFile(path.join(dir, rel));
+    zip.addFile(rel.split(path.sep).join('/'), data);
+  }
+  return zip.toBuffer();
+}
+
+export async function GET(): Promise<Response> {
+  const user = await requireUser();
+  try {
+    await pullLocked(user.id);
+    const buf = await buildJournalZip(getJournalDir(user.id));
+    return new NextResponse(new Uint8Array(buf), {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="journals-${user.id}-backup.zip"`,
+      },
+    });
+  } catch (e) {
+    console.error('journal backup export failed', e);
+    return NextResponse.json(
+      { error: 'Could not export your journal' },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test app/api/account/export/route.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/account/export/route.ts app/api/account/export/route.test.ts
+git commit -m "feat(account-deletion): journal backup .zip export route"
+```
+
+---
+
+### Task 7: Server actions
+
+**Files:**
+- Create: `features/settings/actions/requestAccountDeletion.ts`
+- Create: `features/settings/actions/deleteAccount.ts`
+- Modify: `features/settings/actions/index.ts` (add exports)
+
+**Interfaces:**
+- Consumes: `requireUser`; `accountDeletionService`, `deletionCodeSchema` from `@/lib/account-deletion`; `IssueResult`, `VerifyResult` types.
+- Produces:
+  - `requestAccountDeletionAction(): Promise<IssueResult>`
+  - `deleteAccountAction(code: unknown): Promise<VerifyResult>` — validates `code` first; returns `{ ok: false, reason: 'invalid', remaining: 0 }` shape on bad input so the client renders one inline error path. (Uses `remaining: 0` to mean "not a valid code format"; the UI shows the schema message.)
+
+Actions are thin; their logic is covered by the service tests. No separate action test (consistent with `setSavedBaseCurrency.ts`, which has none beyond the schema/service tests).
+
+- [ ] **Step 1: Write `requestAccountDeletion.ts`**
+
+`features/settings/actions/requestAccountDeletion.ts`:
+```ts
+'use server';
+
+import { requireUser } from '@/lib/auth/require-user';
+import { accountDeletionService, type IssueResult } from '@/lib/account-deletion';
+
+export const requestAccountDeletionAction = async (): Promise<IssueResult> => {
+  const user = await requireUser();
+  return accountDeletionService.issueCode(user.id, user.email);
+};
+```
+
+- [ ] **Step 2: Write `deleteAccount.ts`**
+
+`features/settings/actions/deleteAccount.ts`:
+```ts
+'use server';
+
+import { requireUser } from '@/lib/auth/require-user';
+import {
+  accountDeletionService,
+  deletionCodeSchema,
+  type VerifyResult,
+} from '@/lib/account-deletion';
+
+export const deleteAccountAction = async (
+  code: unknown
+): Promise<VerifyResult> => {
+  const user = await requireUser();
+  const parsed = deletionCodeSchema.safeParse(code);
+  if (!parsed.success) {
+    return { ok: false, reason: 'invalid', remaining: 0 };
+  }
+  return accountDeletionService.verifyAndDelete(user.id, parsed.data);
+};
+```
+
+- [ ] **Step 3: Export both from the barrel**
+
+Append to `features/settings/actions/index.ts`:
+```ts
+export { requestAccountDeletionAction } from './requestAccountDeletion';
+export { deleteAccountAction } from './deleteAccount';
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/settings/actions/requestAccountDeletion.ts features/settings/actions/deleteAccount.ts features/settings/actions/index.ts
+git commit -m "feat(account-deletion): request-code + delete server actions"
+```
+
+---
+
+### Task 8: Goodbye page + public-path registration
+
+**Files:**
+- Create: `app/account/deleted/page.tsx`
+- Modify: `components/AppShell/publicPaths.ts`
+- Modify: `components/AppShell/publicPaths.test.ts`
+
+**Interfaces:**
+- Produces: a public `/account/deleted` confirmation page rendered chrome-free (no sidebar/header — the user is signed out). `PUBLIC_PATHS` includes `/account/deleted`.
+
+- [ ] **Step 1: Update the failing test first**
+
+Add to `components/AppShell/publicPaths.test.ts` (inside the existing describe; mirror the existing assertion style):
+```ts
+it('treats /account/deleted as public', () => {
+  expect(isPublicPath('/account/deleted')).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test components/AppShell/publicPaths.test.ts`
+Expected: FAIL — `/account/deleted` not yet in the set.
+
+- [ ] **Step 3: Add the path**
+
+In `components/AppShell/publicPaths.ts`, change the set:
+```ts
+export const PUBLIC_PATHS = new Set(['/', '/account/deleted']);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test components/AppShell/publicPaths.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the goodbye page**
+
+`app/account/deleted/page.tsx`:
+```tsx
+import Link from 'next/link';
+import { buttonVariants } from '@/components/ui/button';
+
+export default function AccountDeletedPage() {
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center gap-6 px-6 text-center">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold">Your account was deleted</h1>
+        <p className="text-muted-foreground max-w-md">
+          Your journals and account have been permanently removed. There is
+          nothing left to recover.
+        </p>
+      </div>
+      <Link href="/" className={buttonVariants({ variant: 'outline' })}>
+        Back to home
+      </Link>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 6: Type-check**
+
+Run: `pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/account/deleted/page.tsx components/AppShell/publicPaths.ts components/AppShell/publicPaths.test.ts
+git commit -m "feat(account-deletion): post-deletion goodbye page"
+```
+
+---
+
+### Task 9: Danger Zone UI + Settings wiring
+
+**Files:**
+- Create: `features/settings/DangerZone.tsx`
+- Modify: `features/settings/Settings.tsx` (mount the card)
+
+**Interfaces:**
+- Consumes: `requestAccountDeletionAction`, `deleteAccountAction` from `./actions`; `deletionCodeSchema` for client-side pre-check (optional); `authClient` from `@/lib/auth-client`; shadcn `Card`, `Button`, `Input`, `Alert`, `Label`; `sonner` `toast`; `useRouter`.
+- Produces: `<DangerZone />` client component rendering the backup button, irreversible notice, "email me a code" button, code input, and confirm button. On `verifyResult.ok` → `authClient.signOut()` then `router.push('/account/deleted')`.
+
+This is UI; behavior is exercised via the underlying action/service tests. No new automated test (consistent with other client components like `BaseCurrencyForm`). Manual verification in Step 4.
+
+- [ ] **Step 1: Write the component**
+
+`features/settings/DangerZone.tsx`:
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { deleteAccountAction, requestAccountDeletionAction } from './actions';
+import { authClient } from '@/lib/auth-client';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button, buttonVariants } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type Phase = 'idle' | 'code-sent';
+
+const DangerZone = () => {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const sendCode = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await requestAccountDeletionAction();
+      if (!res.ok) {
+        toast.error('Please wait a moment before requesting another code.');
+        return;
+      }
+      setPhase('code-sent');
+      toast.success('Verification code sent to your email.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await deleteAccountAction(code);
+      if (res.ok) {
+        await authClient.signOut();
+        router.push('/account/deleted');
+        return;
+      }
+      switch (res.reason) {
+        case 'no-code':
+        case 'expired':
+          setError('That code expired. Request a new one.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'too-many-attempts':
+          setError('Too many attempts. Request a new code.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'invalid':
+          setError(
+            res.remaining > 0
+              ? `Incorrect code. ${res.remaining} attempt(s) left.`
+              : 'Enter the 6-digit code from your email.'
+          );
+          break;
+      }
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Card className="border-destructive/50">
+      <CardHeader>
+        <CardTitle className="text-destructive">Danger zone</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Download a backup</span>
+          <p className="text-muted-foreground text-sm">
+            Export a .zip of your journal before deleting. Recommended.
+          </p>
+          <a
+            href="/api/account/export"
+            className={buttonVariants({ variant: 'outline', size: 'sm' }) + ' w-fit'}
+          >
+            Download backup (.zip)
+          </a>
+        </div>
+
+        <Alert variant="destructive">
+          <AlertTitle>Delete account</AlertTitle>
+          <AlertDescription>
+            This permanently deletes your journals and your account. This cannot
+            be undone.
+          </AlertDescription>
+        </Alert>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {phase === 'idle' ? (
+          <Button
+            variant="destructive"
+            size="sm"
+            className="w-fit"
+            disabled={pending}
+            onClick={sendCode}
+          >
+            Email me a verification code
+          </Button>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="deletion-code">
+                Enter the 6-digit code from your email
+              </Label>
+              <Input
+                id="deletion-code"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={6}
+                value={code}
+                onChange={(e) =>
+                  setCode(e.target.value.replace(/\D/g, '').slice(0, 6))
+                }
+                className="w-40 tracking-[0.3em]"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={pending || code.length !== 6}
+                onClick={confirmDelete}
+              >
+                Permanently delete my account
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={pending}
+                onClick={() => {
+                  setPhase('idle');
+                  setCode('');
+                  setError(null);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DangerZone;
+```
+
+- [ ] **Step 2: Mount it in Settings**
+
+In `features/settings/Settings.tsx`: add the import near the other local imports:
+```tsx
+import DangerZone from './DangerZone';
+```
+Then render `<DangerZone />` as the last child inside the outer `<div className="flex flex-col gap-6">`, after the Base currency `</Card>`:
+```tsx
+      </Card>
+
+      <DangerZone />
+    </div>
+```
+
+- [ ] **Step 3: Type-check + lint**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: PASS (no type errors; eslint clean).
+
+- [ ] **Step 4: Manual verification**
+
+Run: `pnpm dev`, sign in, visit `/settings`. Confirm: Danger Zone card renders; "Download backup (.zip)" downloads a non-empty zip; "Email me a verification code" sends mail (or check server logs / Postal) and reveals the code input; a wrong code shows "Incorrect code. N attempt(s) left."; the correct code signs out and lands on `/account/deleted`. (Use a throwaway test user — this really deletes.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/settings/DangerZone.tsx features/settings/Settings.tsx
+git commit -m "feat(account-deletion): Settings danger-zone UI"
+```
+
+---
+
+### Task 10: PLAN.md update + full verification
+
+**Files:**
+- Modify: `PLAN.md`
+
+- [ ] **Step 1: Update Phase 7 in `PLAN.md`**
+
+In the Phase 7 list, check off the backup item and add the account-deletion line. Change:
+```markdown
+- [ ] Backup / restore endpoint (download `.zip` of the journal directory)
+- [ ] Account deletion (wipe journals + DB rows)
+```
+to:
+```markdown
+- [x] Backup endpoint — `GET /api/account/export` streams a `.zip` of the user's journal directory (reuses `pullLocked` + `listLocalRelPaths` + `adm-zip`). (Restore-from-backup upload still pending; import covers re-upload.)
+- [x] **Account deletion** — self-service on `/settings` Danger Zone: emailed 6-digit code (hashed, 10-min expiry, 5-attempt cap, 30s resend throttle) → `purgeUserData` wipes Garage (`clearRemote`) + local journal dir + `db.delete(user)` cascade → sign-out + `/account/deleted`. Spec: `docs/superpowers/specs/2026-06-25-account-deletion-design.md`.
+```
+
+- [ ] **Step 2: Run the full suite + type-check + lint**
+
+Run: `pnpm type-check && pnpm test && pnpm lint`
+Expected: all PASS — full test suite green, no type errors, eslint clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PLAN.md
+git commit -m "docs: mark account-deletion + journal backup done in PLAN"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Verification code (6-digit, hashed, expiry, attempt cap, throttle) → Tasks 1,2,5 ✓
+- Backup .zip export → Task 6 ✓
+- Deletion orchestration (Garage → local → DB cascade) → Task 4 ✓
+- Server actions (request + delete) → Task 7 ✓
+- Danger Zone UI + Settings wiring → Task 9 ✓
+- Goodbye page (public, chrome-free) → Task 8 ✓
+- Email via Postal transport → Task 5 (DI wiring) ✓
+- Tests: repository, schema, purge, service, export → Tasks 2,3,4,5,6 ✓
+- PLAN.md update → Task 10 ✓
+
+**Type consistency:** `accountDeletionService`, `deletionCodeSchema`, `IssueResult`, `VerifyResult`, `purgeUserData`, `buildJournalZip`, `AccountDeletionChallengeRepository` names match across producing/consuming tasks. The `now` clock injection is consistent (service constructor + tests). `VerifyResult.invalid` always carries `remaining` (number); actions emit `remaining: 0` for bad-format input, which the UI maps to the schema message.
+
+**Placeholder scan:** No TBD/TODO; every code step has full code; every test step has runnable assertions and expected output.

--- a/docs/superpowers/specs/2026-06-25-account-deletion-design.md
+++ b/docs/superpowers/specs/2026-06-25-account-deletion-design.md
@@ -1,0 +1,181 @@
+# Account Deletion — Design
+
+**Date:** 2026-06-25
+**Status:** Approved (brainstorming) — pending implementation plan
+**Phase:** 7 (Multi-user hardening). Also delivers the Phase 7 "Backup / restore — download `.zip` of journal directory" item as a byproduct.
+
+## Goal
+
+Let a signed-in user permanently delete their own account from `/settings`: wipe
+their journal data (local cache **and** Garage source-of-truth), all their
+database rows, and the auth identity itself. The action is irreversible and is
+gated behind an emailed verification code the user types back into the app.
+
+## Why a verification code (not a magic link)
+
+A code keeps the entire destructive flow on **one in-app surface** (backup →
+red notice → enter code → confirm), which is the deliberate friction an
+irreversible action wants. It also keeps everything **repo-local** — no change
+to `@naeemba/next-starter` and no version bump. better-auth's native
+`deleteUser` flow is link-based (emails a callback URL) and is **disabled** in
+the current `createAuth` config anyway, with no pass-through to enable it.
+
+The only security cost of a 6-digit code (low entropy, ~1M combinations) is
+closed by: single active code per user, short expiry (10 min), and an attempt
+cap (5). Both a link and a code ultimately prove the same property — the person
+controls the account's email.
+
+## User flow
+
+On `/settings`, a red **Danger Zone** card at the bottom:
+
+1. **"Delete account"** button → expands/opens the deletion panel.
+2. **Step 1 — Backup (optional):** "Download a backup (.zip)" button hitting
+   `GET /api/account/export`. Encouraged but not required.
+3. **Step 2 — Acknowledge:** a hard red irreversible notice ("This permanently
+   deletes your journals and your account. This cannot be undone.").
+4. **Step 3 — Verify:** "Email me a verification code" button → server issues a
+   6-digit code, emails it via Postal. UI reveals a code input.
+5. **Step 4 — Confirm:** user types the code and clicks **"Permanently delete my
+   account"**. On success: `authClient.signOut()` (clears the now-orphaned
+   session cookie) and redirect to `/account/deleted` (a public goodbye page).
+
+Wrong/expired code → inline error with remaining attempts; after 5 failed
+attempts the code is invalidated and the user must request a new one.
+
+## Architecture
+
+Self-contained in `ledger-cli-ui`. Follows the existing
+**Repository + Service + one-action-per-file** convention.
+
+### New DB table — `accountDeletionChallenge`
+
+`db/schema/accountDeletionChallenge.ts`
+
+| Column      | Type        | Notes                                              |
+|-------------|-------------|----------------------------------------------------|
+| `userId`    | text PK     | FK → `user.id`, `onDelete: 'cascade'`. One active challenge per user (PK = userId, upsert on re-request). |
+| `codeHash`  | text        | SHA-256 of the 6-digit code (never store plaintext).|
+| `expiresAt` | timestamp   | now + 10 min.                                      |
+| `attempts`  | integer     | default 0; increment on each failed verify.        |
+| `createdAt` | timestamp   | defaultNow.                                        |
+
+Registered in `db/schema/index.ts`. Requires a drizzle migration.
+
+### Challenge layer — `lib/account-deletion/`
+
+- `repository.ts` — `AccountDeletionChallengeRepository`: `upsert`, `get`,
+  `incrementAttempts`, `delete`.
+- `service.ts` — `AccountDeletionService`:
+  - `issueCode(userId, email)`: generate 6-digit code (`crypto.randomInt`),
+    hash, upsert challenge, send email via the Postal transport. Returns nothing
+    sensitive. Rate-limit re-issue (≥30s between sends) to avoid mail spam.
+  - `verifyAndDelete(userId, code)`: load challenge → check not expired →
+    constant-time compare hash → on mismatch increment attempts (invalidate at
+    5) and return a discriminated result (`expired` / `invalid` /
+    `too-many-attempts`); on match, run **deletion orchestration**, then delete
+    the challenge (moot — cascades with the user) and return `ok`.
+- `schema.ts` — Zod for the 6-digit code input.
+
+### Deletion orchestration (order is load-bearing)
+
+Inside `verifyAndDelete`, after the code matches:
+
+1. `clearRemote(userId)` — wipe Garage objects under `journals/<userId>/`
+   (source of truth first, so a mid-failure can't leave canonical data while
+   local is gone).
+2. `rm -rf {DATA_DIR}/journals/<userId>` — wipe local cache
+   (`getJournalDir(userId)`).
+3. `db.delete(user).where(eq(user.id, userId))` — cascades `session`,
+   `account`, `passkey`, `userSetting`, `savedView`, `template`, and
+   `accountDeletionChallenge`.
+
+Steps run sequentially; if a step throws, surface a generic error and abort
+(partial-delete is acceptable for a destructive op — re-running completes it,
+and orphaned Garage/local data without a user row is inert). Log the real error
+server-side only.
+
+### Backup export — `GET /api/account/export`
+
+`app/api/account/export/route.ts`. Reuses existing helpers:
+`pullLocked(userId)` (sync canonical → local) → `listLocalRelPaths(getJournalDir(userId))`
+→ read each file → `adm-zip` `.addFile(relPath, buffer)` → return
+`zip.toBuffer()` with `Content-Disposition: attachment;
+filename=journals-<userId>-backup.zip`. Guarded by `requireUser`.
+
+### Server actions — `features/settings/actions/`
+
+One file each, matching the existing convention:
+- `requestAccountDeletion.ts` → `AccountDeletionService.issueCode`.
+- `deleteAccount.ts` → `AccountDeletionService.verifyAndDelete`; returns the
+  discriminated result so the client can show inline errors or proceed to
+  sign-out + redirect.
+
+Both call `requireUser` and operate only on the caller's own `userId` (no
+user-supplied id ever reaches the service).
+
+### UI — `features/settings/DangerZone.tsx`
+
+Client component wired into `Settings.tsx` as a final `Card` with destructive
+styling. Manages the local step state (idle → code-sent → verifying), renders
+the backup button, the red `Alert variant="destructive"` notice, the code
+`Input`, and the confirm `Button variant="destructive"`. Uses `sonner` toasts
+for transient feedback, consistent with the rest of the app. On `ok`, calls
+`authClient.signOut()` and `router.push('/account/deleted')`.
+
+### Goodbye page — `app/account/deleted/page.tsx`
+
+Public (no `requireUser`) confirmation page: "Your account and all data have
+been permanently deleted." Link back to the landing page. Must render in the
+`AppShell` auth/no-sidebar layout branch (like `/login`), since the user is
+signed out.
+
+## Email
+
+Reuses the existing Postal transport (`lib/email-transport.ts`). A small
+templated message: subject "Confirm account deletion", body containing the
+6-digit code, its 10-minute expiry, and a "if you didn't request this, ignore
+this email" line. No link.
+
+## Security & edge cases
+
+- Code stored hashed (SHA-256); compared in constant time.
+- Single active challenge per user (PK = userId); re-request overwrites and
+  resets `attempts`. Re-send throttled (≥30s).
+- 10-min expiry; 5-attempt cap then invalidate.
+- All actions are `requireUser`-gated and self-scoped — no IDOR surface.
+- `ledger` is never invoked; no shell-out in this feature.
+- `verification` rows (better-auth, identifier-keyed) are left to self-expire;
+  they hold no journal data.
+
+## Testing
+
+- `repository.test.ts` — upsert/get/increment/delete round-trip.
+- `service.test.ts` — issue (hashing, throttle), verify paths: happy, wrong
+  code increments, expiry, attempt-cap invalidation; deletion orchestration
+  with a `MemoryObjectStore` and a temp journal dir asserting Garage + local +
+  DB rows all gone.
+- `export.test.ts` (or route test) — zip contains every journal file with
+  correct relative paths.
+- `schema.test.ts` — Zod rejects non-6-digit / non-numeric input.
+
+## Out of scope
+
+- Admin-initiated deletion of other users.
+- Soft-delete / grace-period / recovery window (this is a hard delete).
+- Restore-from-backup upload (import already exists; full restore UX is a
+  separate Phase 7 item).
+
+## Files touched
+
+New:
+- `db/schema/accountDeletionChallenge.ts` (+ `db/schema/index.ts` export, migration)
+- `lib/account-deletion/{repository,service,schema}.ts` (+ tests)
+- `app/api/account/export/route.ts`
+- `features/settings/actions/{requestAccountDeletion,deleteAccount}.ts` (+ `index.ts` export)
+- `features/settings/DangerZone.tsx`
+- `app/account/deleted/page.tsx`
+
+Modified:
+- `features/settings/Settings.tsx` (mount Danger Zone card)
+- `PLAN.md` (check off backup item; note account-deletion under Phase 7)

--- a/features/settings/DangerZone.tsx
+++ b/features/settings/DangerZone.tsx
@@ -31,6 +31,10 @@ const DangerZone = () => {
       }
       setPhase('code-sent');
       toast.success('Verification code sent to your email.');
+    } catch {
+      // The server logs the real cause (e.g. email transport down); surface a
+      // generic failure so the user knows the request did not go through.
+      toast.error('Could not send a verification code. Please try again.');
     } finally {
       setPending(false);
     }
@@ -52,6 +56,10 @@ const DangerZone = () => {
       }
       switch (res.reason) {
         case 'no-code':
+          setError('Request a new code.');
+          setPhase('idle');
+          setCode('');
+          break;
         case 'expired':
           setError('That code expired. Request a new one.');
           setPhase('idle');
@@ -70,6 +78,11 @@ const DangerZone = () => {
           );
           break;
       }
+    } catch {
+      // Deletion is irreversible and may partially complete server-side (e.g.
+      // remote-storage cleanup failing mid-purge). Never fail silently — the
+      // server logs the real cause; surface a generic error so the user knows.
+      setError('Something went wrong. Please try again.');
     } finally {
       setPending(false);
     }

--- a/features/settings/DangerZone.tsx
+++ b/features/settings/DangerZone.tsx
@@ -42,7 +42,11 @@ const DangerZone = () => {
     try {
       const res = await deleteAccountAction(code);
       if (res.ok) {
-        await authClient.signOut();
+        try {
+          await authClient.signOut();
+        } catch {
+          // account is already deleted server-side; the session is invalid regardless
+        }
         router.push('/account/deleted');
         return;
       }

--- a/features/settings/DangerZone.tsx
+++ b/features/settings/DangerZone.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { deleteAccountAction, requestAccountDeletionAction } from './actions';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { authClient } from '@/lib/auth-client';
+import { useRouter } from 'next/navigation';
+
+type Phase = 'idle' | 'code-sent';
+
+const DangerZone = () => {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const sendCode = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await requestAccountDeletionAction();
+      if (!res.ok) {
+        toast.error('Please wait a moment before requesting another code.');
+        return;
+      }
+      setPhase('code-sent');
+      toast.success('Verification code sent to your email.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await deleteAccountAction(code);
+      if (res.ok) {
+        await authClient.signOut();
+        router.push('/account/deleted');
+        return;
+      }
+      switch (res.reason) {
+        case 'no-code':
+        case 'expired':
+          setError('That code expired. Request a new one.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'too-many-attempts':
+          setError('Too many attempts. Request a new code.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'invalid':
+          setError(
+            res.remaining > 0
+              ? `Incorrect code. ${res.remaining} attempt(s) left.`
+              : 'Enter the 6-digit code from your email.'
+          );
+          break;
+      }
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Card className="border-destructive/50">
+      <CardHeader>
+        <CardTitle className="text-destructive">Danger zone</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Download a backup</span>
+          <p className="text-muted-foreground text-sm">
+            Export a .zip of your journal before deleting. Recommended.
+          </p>
+          <a
+            href="/api/account/export"
+            className={
+              buttonVariants({ variant: 'outline', size: 'sm' }) + ' w-fit'
+            }
+          >
+            Download backup (.zip)
+          </a>
+        </div>
+
+        <Alert variant="destructive">
+          <AlertTitle>Delete account</AlertTitle>
+          <AlertDescription>
+            This permanently deletes your journals and your account. This cannot
+            be undone.
+          </AlertDescription>
+        </Alert>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {phase === 'idle' ? (
+          <Button
+            variant="destructive"
+            size="sm"
+            className="w-fit"
+            disabled={pending}
+            onClick={sendCode}
+          >
+            Email me a verification code
+          </Button>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="deletion-code">
+                Enter the 6-digit code from your email
+              </Label>
+              <Input
+                id="deletion-code"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={6}
+                value={code}
+                onChange={(e) =>
+                  setCode(e.target.value.replace(/\D/g, '').slice(0, 6))
+                }
+                className="w-40 tracking-[0.3em]"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={pending || code.length !== 6}
+                onClick={confirmDelete}
+              >
+                Permanently delete my account
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={pending}
+                onClick={() => {
+                  setPhase('idle');
+                  setCode('');
+                  setError(null);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DangerZone;

--- a/features/settings/Settings.tsx
+++ b/features/settings/Settings.tsx
@@ -1,4 +1,5 @@
 import BaseCurrencyForm from './BaseCurrencyForm';
+import DangerZone from './DangerZone';
 import { clearSessionBaseCurrencyAction } from './actions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -46,6 +47,8 @@ const Settings = ({ base, currencies, savedDefault, envFallback }: Props) => {
           )}
         </CardContent>
       </Card>
+
+      <DangerZone />
     </div>
   );
 };

--- a/features/settings/actions/deleteAccount.ts
+++ b/features/settings/actions/deleteAccount.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import {
+  accountDeletionService,
+  deletionCodeSchema,
+  type VerifyResult,
+} from '@/lib/account-deletion';
+import { requireUser } from '@/lib/auth/require-user';
+
+export const deleteAccountAction = async (
+  code: unknown
+): Promise<VerifyResult> => {
+  const user = await requireUser();
+  const parsed = deletionCodeSchema.safeParse(code);
+  if (!parsed.success) {
+    return { ok: false, reason: 'invalid', remaining: 0 };
+  }
+  return accountDeletionService.verifyAndDelete(user.id, parsed.data);
+};

--- a/features/settings/actions/index.ts
+++ b/features/settings/actions/index.ts
@@ -7,3 +7,5 @@ export {
   type SetSessionBaseCurrencyResult,
 } from './setSessionBaseCurrency';
 export { clearSessionBaseCurrencyAction } from './clearSessionBaseCurrency';
+export { requestAccountDeletionAction } from './requestAccountDeletion';
+export { deleteAccountAction } from './deleteAccount';

--- a/features/settings/actions/requestAccountDeletion.ts
+++ b/features/settings/actions/requestAccountDeletion.ts
@@ -1,0 +1,12 @@
+'use server';
+
+import {
+  accountDeletionService,
+  type IssueResult,
+} from '@/lib/account-deletion';
+import { requireUser } from '@/lib/auth/require-user';
+
+export const requestAccountDeletionAction = async (): Promise<IssueResult> => {
+  const user = await requireUser();
+  return accountDeletionService.issueCode(user.id, user.email);
+};

--- a/lib/account-deletion/index.ts
+++ b/lib/account-deletion/index.ts
@@ -1,0 +1,38 @@
+import 'server-only';
+import { purgeUserData } from './purge';
+import { AccountDeletionChallengeRepository } from './repository';
+import { AccountDeletionService } from './service';
+import { APP_NAME } from '@/lib/app';
+import { db } from '@/lib/db';
+import { postalTransport } from '@/lib/email-transport';
+
+const sendCode = async (email: string, code: string): Promise<void> => {
+  const from = process.env.EMAIL_FROM;
+  if (!from) {
+    throw new Error('[account-deletion] EMAIL_FROM is not configured.');
+  }
+  const subject = `${APP_NAME}: confirm account deletion`;
+  const text = [
+    `Your account deletion code is ${code}.`,
+    `It expires in 10 minutes.`,
+    `If you didn't request this, ignore this email — nothing will happen.`,
+  ].join('\n\n');
+  const html =
+    `<p>Your account deletion code is <strong style="font-size:1.25rem;letter-spacing:0.15em">${code}</strong>.</p>` +
+    `<p>It expires in 10 minutes.</p>` +
+    `<p>If you didn't request this, ignore this email — nothing will happen.</p>`;
+  await postalTransport({ to: email, from, subject, html, text });
+};
+
+const accountDeletionChallengeRepository =
+  new AccountDeletionChallengeRepository(db);
+
+export const accountDeletionService = new AccountDeletionService(
+  accountDeletionChallengeRepository,
+  { sendCode, purge: (userId) => purgeUserData(userId, db) }
+);
+
+export { AccountDeletionChallengeRepository } from './repository';
+export { AccountDeletionService } from './service';
+export type { IssueResult, VerifyResult } from './service';
+export { deletionCodeSchema, type DeletionCode } from './schema';

--- a/lib/account-deletion/index.ts
+++ b/lib/account-deletion/index.ts
@@ -5,12 +5,10 @@ import { AccountDeletionService } from './service';
 import { APP_NAME } from '@/lib/app';
 import { db } from '@/lib/db';
 import { postalTransport } from '@/lib/email-transport';
+import { env } from '@/lib/env';
 
 const sendCode = async (email: string, code: string): Promise<void> => {
-  const from = process.env.EMAIL_FROM;
-  if (!from) {
-    throw new Error('[account-deletion] EMAIL_FROM is not configured.');
-  }
+  const from = env.EMAIL_FROM;
   const subject = `${APP_NAME}: confirm account deletion`;
   const text = [
     `Your account deletion code is ${code}.`,

--- a/lib/account-deletion/purge.test.ts
+++ b/lib/account-deletion/purge.test.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { purgeUserData } from './purge';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+import { user } from '@naeemba/next-starter/schema';
+
+describe('purgeUserData', () => {
+  let ctx: TestDbContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('acct-purge-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('runs clear → removeLocal → db.delete(user) in order', async () => {
+    const calls: string[] = [];
+    await purgeUserData('alice', ctx.db, {
+      clearRemote: async () => {
+        calls.push('clear');
+      },
+      removeLocalJournal: async () => {
+        calls.push('local');
+      },
+    });
+    expect(calls).toEqual(['clear', 'local']);
+    const rows = await ctx.db.select().from(user).where(eq(user.id, 'alice'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('default removeLocalJournal deletes the journal dir', async () => {
+    const dir = path.join(ctx.tmpDir, 'journals', 'alice');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), '; test\n');
+    const prev = process.env.DATA_DIR;
+    process.env.DATA_DIR = ctx.tmpDir;
+    try {
+      await purgeUserData('alice', ctx.db, { clearRemote: async () => {} });
+    } finally {
+      process.env.DATA_DIR = prev;
+    }
+    await expect(fs.access(dir)).rejects.toThrow();
+  });
+});

--- a/lib/account-deletion/purge.ts
+++ b/lib/account-deletion/purge.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import { eq } from 'drizzle-orm';
+import 'server-only';
+import type { DbInstance } from '@/lib/db/connection';
+import { getJournalDir } from '@/lib/journal/layout';
+import { clearRemote as clearRemoteDefault } from '@/lib/storage/sync';
+import { user } from '@naeemba/next-starter/schema';
+
+export type PurgeDeps = {
+  clearRemote?: (userId: string) => Promise<void>;
+  removeLocalJournal?: (userId: string) => Promise<void>;
+};
+
+const removeLocalJournalDefault = (userId: string): Promise<void> =>
+  fs.rm(getJournalDir(userId), { recursive: true, force: true });
+
+/**
+ * Permanently wipe all of a user's data. ORDER MATTERS: Garage (the source of
+ * truth) first, then the local cache, then the user row (which cascades every
+ * DB row that references it — session, account, passkey, userSetting,
+ * savedView, template, accountDeletionChallenge). A mid-failure leaves only
+ * inert orphans (data with no user); re-running completes the purge.
+ */
+export async function purgeUserData(
+  userId: string,
+  db: DbInstance,
+  deps: PurgeDeps = {}
+): Promise<void> {
+  const clearRemote = deps.clearRemote ?? clearRemoteDefault;
+  const removeLocalJournal =
+    deps.removeLocalJournal ?? removeLocalJournalDefault;
+
+  await clearRemote(userId);
+  await removeLocalJournal(userId);
+  await db.delete(user).where(eq(user.id, userId));
+}

--- a/lib/account-deletion/purge.ts
+++ b/lib/account-deletion/purge.ts
@@ -1,6 +1,6 @@
-import 'server-only';
 import { promises as fs } from 'fs';
 import { eq } from 'drizzle-orm';
+import 'server-only';
 import type { DbInstance } from '@/lib/db/connection';
 import { getJournalDir } from '@/lib/journal/layout';
 import { clearRemote as clearRemoteDefault } from '@/lib/storage/sync';

--- a/lib/account-deletion/purge.ts
+++ b/lib/account-deletion/purge.ts
@@ -1,6 +1,6 @@
+import 'server-only';
 import { promises as fs } from 'fs';
 import { eq } from 'drizzle-orm';
-import 'server-only';
 import type { DbInstance } from '@/lib/db/connection';
 import { getJournalDir } from '@/lib/journal/layout';
 import { clearRemote as clearRemoteDefault } from '@/lib/storage/sync';

--- a/lib/account-deletion/repository.test.ts
+++ b/lib/account-deletion/repository.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AccountDeletionChallengeRepository } from './repository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('AccountDeletionChallengeRepository', () => {
+  let ctx: TestDbContext;
+  let repo: AccountDeletionChallengeRepository;
+  const future = () => new Date(Date.now() + 600_000);
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('acct-del-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new AccountDeletionChallengeRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('upsert inserts a row with attempts=0', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    const row = await repo.get('alice');
+    expect(row?.codeHash).toBe('hash1');
+    expect(row?.attempts).toBe(0);
+  });
+
+  it('upsert replaces an existing row and resets attempts', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    await repo.incrementAttempts('alice');
+    await repo.upsert('alice', 'hash2', future());
+    const row = await repo.get('alice');
+    expect(row?.codeHash).toBe('hash2');
+    expect(row?.attempts).toBe(0);
+  });
+
+  it('get returns null when no challenge exists', async () => {
+    expect(await repo.get('alice')).toBeNull();
+  });
+
+  it('incrementAttempts returns the new count', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    expect(await repo.incrementAttempts('alice')).toBe(1);
+    expect(await repo.incrementAttempts('alice')).toBe(2);
+  });
+
+  it('delete removes the row', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    await repo.delete('alice');
+    expect(await repo.get('alice')).toBeNull();
+  });
+});

--- a/lib/account-deletion/repository.ts
+++ b/lib/account-deletion/repository.ts
@@ -1,0 +1,48 @@
+import { eq, sql } from 'drizzle-orm';
+import {
+  accountDeletionChallenge,
+  type AccountDeletionChallenge,
+} from '@/db/schema/accountDeletionChallenge';
+import type { DbInstance } from '@/lib/db/connection';
+
+export class AccountDeletionChallengeRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  async upsert(
+    userId: string,
+    codeHash: string,
+    expiresAt: Date
+  ): Promise<void> {
+    await this.db
+      .insert(accountDeletionChallenge)
+      .values({ userId, codeHash, expiresAt, attempts: 0 })
+      .onConflictDoUpdate({
+        target: accountDeletionChallenge.userId,
+        set: { codeHash, expiresAt, attempts: 0, createdAt: sql`now()` },
+      });
+  }
+
+  async get(userId: string): Promise<AccountDeletionChallenge | null> {
+    const rows = await this.db
+      .select()
+      .from(accountDeletionChallenge)
+      .where(eq(accountDeletionChallenge.userId, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async incrementAttempts(userId: string): Promise<number> {
+    const rows = await this.db
+      .update(accountDeletionChallenge)
+      .set({ attempts: sql`${accountDeletionChallenge.attempts} + 1` })
+      .where(eq(accountDeletionChallenge.userId, userId))
+      .returning({ attempts: accountDeletionChallenge.attempts });
+    return rows[0]?.attempts ?? 0;
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.db
+      .delete(accountDeletionChallenge)
+      .where(eq(accountDeletionChallenge.userId, userId));
+  }
+}

--- a/lib/account-deletion/repository.ts
+++ b/lib/account-deletion/repository.ts
@@ -11,14 +11,30 @@ export class AccountDeletionChallengeRepository {
   async upsert(
     userId: string,
     codeHash: string,
-    expiresAt: Date
+    expiresAt: Date,
+    createdAt?: Date
   ): Promise<void> {
+    const insertValues = {
+      userId,
+      codeHash,
+      expiresAt,
+      attempts: 0,
+      ...(createdAt && { createdAt }),
+    };
+
+    const updateSet = {
+      codeHash,
+      expiresAt,
+      attempts: 0,
+      ...(createdAt && { createdAt }),
+    };
+
     await this.db
       .insert(accountDeletionChallenge)
-      .values({ userId, codeHash, expiresAt, attempts: 0 })
+      .values(insertValues)
       .onConflictDoUpdate({
         target: accountDeletionChallenge.userId,
-        set: { codeHash, expiresAt, attempts: 0, createdAt: sql`now()` },
+        set: updateSet,
       });
   }
 

--- a/lib/account-deletion/schema.test.ts
+++ b/lib/account-deletion/schema.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { deletionCodeSchema } from './schema';
+
+describe('deletionCodeSchema', () => {
+  it('accepts exactly 6 digits', () => {
+    expect(deletionCodeSchema.safeParse('012345').success).toBe(true);
+  });
+  it('rejects fewer than 6 digits', () => {
+    expect(deletionCodeSchema.safeParse('12345').success).toBe(false);
+  });
+  it('rejects more than 6 digits', () => {
+    expect(deletionCodeSchema.safeParse('1234567').success).toBe(false);
+  });
+  it('rejects non-numeric input', () => {
+    expect(deletionCodeSchema.safeParse('12a456').success).toBe(false);
+  });
+});

--- a/lib/account-deletion/schema.ts
+++ b/lib/account-deletion/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const deletionCodeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{6}$/, 'Enter the 6-digit code from your email');
+
+export type DeletionCode = z.infer<typeof deletionCodeSchema>;

--- a/lib/account-deletion/service.test.ts
+++ b/lib/account-deletion/service.test.ts
@@ -46,6 +46,24 @@ describe('AccountDeletionService', () => {
     expect(sent[0].code).toMatch(/^\d{6}$/);
   });
 
+  it('issueCode rolls back the challenge when the email send fails', async () => {
+    const svc = new AccountDeletionService(repo, {
+      sendCode: async () => {
+        throw new Error('smtp down');
+      },
+      purge: async () => {},
+      now: () => nowMs,
+    });
+    await expect(svc.issueCode('alice', 'alice@example.com')).rejects.toThrow(
+      'smtp down'
+    );
+    // The throttle must not be armed by a failed send: a retry can issue again.
+    expect(await repo.get('alice')).toBeNull();
+    const retry = await makeService().issueCode('alice', 'alice@example.com');
+    expect(retry).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+  });
+
   it('issueCode throttles a re-send within 30s', async () => {
     const svc = makeService();
     await svc.issueCode('alice', 'alice@example.com');

--- a/lib/account-deletion/service.test.ts
+++ b/lib/account-deletion/service.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AccountDeletionChallengeRepository } from './repository';
+import { AccountDeletionService } from './service';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('AccountDeletionService', () => {
+  let ctx: TestDbContext;
+  let repo: AccountDeletionChallengeRepository;
+  let sent: { email: string; code: string }[];
+  let purged: string[];
+  let nowMs: number;
+
+  const makeService = () =>
+    new AccountDeletionService(repo, {
+      sendCode: async (email, code) => {
+        sent.push({ email, code });
+      },
+      purge: async (userId) => {
+        purged.push(userId);
+      },
+      now: () => nowMs,
+    });
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('acct-svc-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new AccountDeletionChallengeRepository(ctx.db);
+    sent = [];
+    purged = [];
+    nowMs = 1_000_000;
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('issueCode emails a 6-digit code', async () => {
+    const res = await makeService().issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].email).toBe('alice@example.com');
+    expect(sent[0].code).toMatch(/^\d{6}$/);
+  });
+
+  it('issueCode throttles a re-send within 30s', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 10_000;
+    const res = await svc.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: false, reason: 'throttled' });
+    expect(sent).toHaveLength(1);
+  });
+
+  it('issueCode allows a re-send after 30s', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 31_000;
+    const res = await svc.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+    expect(sent).toHaveLength(2);
+  });
+
+  it('verifyAndDelete purges on the correct code', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const res = await svc.verifyAndDelete('alice', sent[0].code);
+    expect(res).toEqual({ ok: true });
+    expect(purged).toEqual(['alice']);
+  });
+
+  it('verifyAndDelete returns no-code when none issued', async () => {
+    const res = await makeService().verifyAndDelete('alice', '000000');
+    expect(res).toEqual({ ok: false, reason: 'no-code' });
+    expect(purged).toHaveLength(0);
+  });
+
+  it('verifyAndDelete rejects a wrong code and reports remaining attempts', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const wrong = sent[0].code === '000000' ? '111111' : '000000';
+    const res = await svc.verifyAndDelete('alice', wrong);
+    expect(res).toEqual({ ok: false, reason: 'invalid', remaining: 4 });
+    expect(purged).toHaveLength(0);
+  });
+
+  it('verifyAndDelete invalidates after 5 failed attempts', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const wrong = sent[0].code === '000000' ? '111111' : '000000';
+    let res;
+    for (let i = 0; i < 5; i++) res = await svc.verifyAndDelete('alice', wrong);
+    expect(res).toEqual({ ok: false, reason: 'too-many-attempts' });
+    // challenge is gone — a follow-up reads as no-code
+    expect(await svc.verifyAndDelete('alice', sent[0].code)).toEqual({
+      ok: false,
+      reason: 'no-code',
+    });
+  });
+
+  it('verifyAndDelete rejects an expired code', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 600_001;
+    const res = await svc.verifyAndDelete('alice', sent[0].code);
+    expect(res).toEqual({ ok: false, reason: 'expired' });
+    expect(purged).toHaveLength(0);
+  });
+});

--- a/lib/account-deletion/service.ts
+++ b/lib/account-deletion/service.ts
@@ -1,5 +1,5 @@
-import { createHash, randomInt, timingSafeEqual } from 'crypto';
 import 'server-only';
+import { createHash, randomInt, timingSafeEqual } from 'crypto';
 import type { AccountDeletionChallengeRepository } from './repository';
 
 export const CODE_TTL_MS = 600_000; // 10 minutes

--- a/lib/account-deletion/service.ts
+++ b/lib/account-deletion/service.ts
@@ -1,0 +1,85 @@
+import { createHash, randomInt, timingSafeEqual } from 'crypto';
+import 'server-only';
+import type { AccountDeletionChallengeRepository } from './repository';
+
+export const CODE_TTL_MS = 600_000; // 10 minutes
+export const MAX_ATTEMPTS = 5;
+export const RESEND_THROTTLE_MS = 30_000;
+
+export type IssueResult = { ok: true } | { ok: false; reason: 'throttled' };
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: 'no-code' | 'expired' | 'too-many-attempts' }
+  | { ok: false; reason: 'invalid'; remaining: number };
+
+export type AccountDeletionDeps = {
+  sendCode: (email: string, code: string) => Promise<void>;
+  purge: (userId: string) => Promise<void>;
+  now?: () => number;
+};
+
+const hashCode = (code: string): string =>
+  createHash('sha256').update(code).digest('hex');
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+};
+
+export class AccountDeletionService {
+  private readonly now: () => number;
+
+  constructor(
+    private readonly repo: AccountDeletionChallengeRepository,
+    private readonly deps: AccountDeletionDeps
+  ) {
+    this.now = deps.now ?? Date.now;
+  }
+
+  async issueCode(userId: string, email: string): Promise<IssueResult> {
+    const existing = await this.repo.get(userId);
+    if (
+      existing &&
+      this.now() - existing.createdAt.getTime() < RESEND_THROTTLE_MS
+    ) {
+      return { ok: false, reason: 'throttled' };
+    }
+    const code = String(randomInt(0, 1_000_000)).padStart(6, '0');
+    const nowTime = this.now();
+    const expiresAt = new Date(nowTime + CODE_TTL_MS);
+    const createdAt = new Date(nowTime);
+    await this.repo.upsert(userId, hashCode(code), expiresAt, createdAt);
+    await this.deps.sendCode(email, code);
+    return { ok: true };
+  }
+
+  async verifyAndDelete(userId: string, code: string): Promise<VerifyResult> {
+    const challenge = await this.repo.get(userId);
+    if (!challenge) return { ok: false, reason: 'no-code' };
+
+    if (challenge.expiresAt.getTime() < this.now()) {
+      await this.repo.delete(userId);
+      return { ok: false, reason: 'expired' };
+    }
+
+    if (!constantTimeEqual(hashCode(code), challenge.codeHash)) {
+      const attempts = await this.repo.incrementAttempts(userId);
+      if (attempts >= MAX_ATTEMPTS) {
+        await this.repo.delete(userId);
+        return { ok: false, reason: 'too-many-attempts' };
+      }
+      return {
+        ok: false,
+        reason: 'invalid',
+        remaining: MAX_ATTEMPTS - attempts,
+      };
+    }
+
+    await this.deps.purge(userId);
+    // The challenge row is cascade-deleted with the user; nothing to clean up.
+    return { ok: true };
+  }
+}

--- a/lib/account-deletion/service.ts
+++ b/lib/account-deletion/service.ts
@@ -52,7 +52,15 @@ export class AccountDeletionService {
     const expiresAt = new Date(nowTime + CODE_TTL_MS);
     const createdAt = new Date(nowTime);
     await this.repo.upsert(userId, hashCode(code), expiresAt, createdAt);
-    await this.deps.sendCode(email, code);
+    try {
+      await this.deps.sendCode(email, code);
+    } catch (err) {
+      // The upsert above armed the resend throttle. If the email never went
+      // out, roll the challenge back so the user can retry immediately rather
+      // than being locked out for the throttle window with no code in hand.
+      await this.repo.delete(userId);
+      throw err;
+    }
     return { ok: true };
   }
 

--- a/lib/account-deletion/service.ts
+++ b/lib/account-deletion/service.ts
@@ -1,5 +1,5 @@
-import 'server-only';
 import { createHash, randomInt, timingSafeEqual } from 'crypto';
+import 'server-only';
 import type { AccountDeletionChallengeRepository } from './repository';
 
 export const CODE_TTL_MS = 600_000; // 10 minutes

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,14 +1,25 @@
-import { isPublicPath } from '@/components/AppShell/publicPaths';
+import {
+  bouncesSignedInToDashboard,
+  isPublicPath,
+} from '@/components/AppShell/publicPaths';
 import { getSessionCookie } from '@naeemba/next-starter/proxy';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export function proxy(req: NextRequest) {
-  // The marketing landing at `/` is public — logged-out visitors are its whole
-  // audience, so it stays reachable without a session. Signed-in visitors have
-  // no use for it, so send them straight to their dashboard. This is a cheap
-  // cookie check (no DB), which keeps the landing fully decoupled from auth.
+  // Public paths are reachable without a session. A subset (the marketing
+  // landing at `/`) also bounces signed-in visitors to their dashboard via a
+  // cheap cookie check (no DB), since logged-in users have no use for it.
+  //
+  // `/account/deleted` is public but NOT a bounce path: the deletion flow can
+  // leave a stale session cookie behind when signOut() fails, and bouncing on a
+  // presence-only cookie check would strand the just-deleted user on
+  // `/dashboard` instead of the goodbye page (defeating commit 9352138). It
+  // must stay reachable even with a stale cookie present.
   if (isPublicPath(req.nextUrl.pathname)) {
-    if (getSessionCookie(req)) {
+    if (
+      bouncesSignedInToDashboard(req.nextUrl.pathname) &&
+      getSessionCookie(req)
+    ) {
       const target = req.nextUrl.clone();
       target.pathname = '/dashboard';
       target.search = '';


### PR DESCRIPTION
Phase 7 self-service **account deletion** plus a journal **backup export** (both were unchecked Phase 7 items). Built via spec → 10-task plan → subagent-driven TDD; full whole-branch review passed.

## Flow
On `/settings`, a red **Danger Zone**: download a `.zip` backup → hard irreversible notice → emailed **6-digit verification code** → confirm → permanent wipe → sign out → `/account/deleted`.

## What it wipes (order is load-bearing)
1. **Garage** objects (`clearRemote` — source of truth first)
2. **Local** journal dir (`rm -rf {DATA_DIR}/journals/{userId}`)
3. **`db.delete(user)`** — FK-cascades `session`/`account`/`passkey` + `userSetting`/`savedView`/`template`/`accountDeletionChallenge`

A mid-failure leaves only inert orphans (data with no owning user); re-running completes the wipe.

## Verification code
SHA-256 hashed at rest, constant-time compared, 10-min expiry, 5-attempt cap (then invalidated), 30s resend throttle — all enforced server-side. The purge is unreachable without a valid, non-expired challenge.

## Notable pieces
- New `accountDeletionChallenge` table + migration (PK = userId, FK cascade).
- `lib/account-deletion/` — repository + service (issue/verify state machine) + `purgeUserData` orchestration + Zod schema, with the project's Repository+Service convention.
- `GET /api/account/export` — streams the user's journal dir as a `.zip` (reuses `pullLocked` + `listLocalRelPaths` + `adm-zip`). *(Also delivers the Phase 7 backup item.)*
- `features/settings/actions/` — `requestAccountDeletion` + `deleteAccount` (one-action-per-file, `requireUser`-gated, self-scoped).
- `features/settings/DangerZone.tsx` + public `/account/deleted` goodbye page.

## Security review (whole-branch, opus)
Ready to merge — no Critical/Important. Every entry point is `requireUser`-scoped; `db.delete(user)` is always `where(user.id == caller.id)`; all 7 cascade FKs confirmed in the live schema + migration; no plaintext code stored/logged; export returns a generic 500 without leaking internals.

## Tests
421 passing (84 files), type-check + `eslint .` clean. New unit tests cover the repository, code schema, purge orchestration (Garage + local + DB), the service state machine (throttle/expiry/attempt-cap/happy path), and the backup-zip round-trip.

> Note: manual dev-server smoke (click-through) was not run in the dev environment (no local Postgres). Worth a quick local pass before relying on it — and use a throwaway user, since it really deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)