### PR TITLE
Phase 7 hardening: rate limiting, CSP/security headers, per-user quota

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -215,13 +215,15 @@ Only relevant if this gets deployed to anyone other than you.
   ListObjectsV2 + ETags. See `docs/deployment/garage.md` and
   `docs/superpowers/specs/2026-06-24-garage-object-storage-design.md`.
 - [ ] **Encrypted user journals at rest** — envelope encryption with **session-scoped** decryption (zero-knowledge at rest, not full E2E). One per-user DEK encrypts the journal; wrapped by passphrase + one-time recovery code, with optional passkey-PRF convenience wrap. DEK reaches the server in RAM only, for the session; server-side `ledger` preserved. Unlock once per login session + a manual Lock button. Design: `docs/superpowers/specs/2026-06-22-encrypted-journals-design.md`. (Supersedes the earlier `.env.example` "server master key" idea — that was not zero-knowledge.)
-- [ ] Rate limit `/api/upload` and any future write endpoint
+- [x] Rate limit `/api/upload` and any future write endpoint — in-memory per-user fixed-window limiter (lib/rate-limit/) on /api/upload + all mutating server actions; auth endpoints covered by better-auth.
 - [ ] Audit log of journal mutations (who, when, how many bytes)
-- [ ] Quota on per-user journal size
+- [x] Quota on per-user journal size — JOURNAL_QUOTA_MB (default 100) enforced in JournalService for imports + adds; lib/journal/quota.ts.
 - [x] Backup endpoint — `GET /api/account/export` streams a `.zip` of the user's journal directory (reuses `pullLocked` + `listLocalRelPaths` + `adm-zip`). (Restore-from-backup upload still pending; import covers re-upload.)
 - [x] **Account deletion** — self-service on `/settings` Danger Zone: emailed 6-digit code (hashed, 10-min expiry, 5-attempt cap, 30s resend throttle) → `purgeUserData` wipes Garage (`clearRemote`) + local journal dir + `db.delete(user)` cascade → sign-out + `/account/deleted`. Spec: `docs/superpowers/specs/2026-06-25-account-deletion-design.md`.
-- [ ] CSP / security headers pass
+- [x] CSP / security headers pass — strict nonce-based CSP + HSTS/X-Frame-Options/nosniff/Referrer-Policy/Permissions-Policy via proxy.ts (lib/security/headers.ts).
 - [ ] Structured logging + an error-tracking destination
+
+Spec: docs/superpowers/specs/2026-06-25-phase7-hardening-design.md.
 
 ---
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
+import { journalQuotaMb } from '@/lib/journal/quota';
 import { rateLimit, UPLOAD } from '@/lib/rate-limit';
 import { NextResponse, type NextRequest } from 'next/server';
 
@@ -45,7 +46,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       if (result.quotaExceeded) {
         return NextResponse.json(
           {
-            error: `Importing this would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+            error: `Importing this would exceed your ${journalQuotaMb()} MB journal limit.`,
           },
           { status: 413 }
         );
@@ -69,7 +70,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       if (result.quotaExceeded) {
         return NextResponse.json(
           {
-            error: `Importing this would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+            error: `Importing this would exceed your ${journalQuotaMb()} MB journal limit.`,
           },
           { status: 413 }
         );

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -42,6 +42,14 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     if (ext === ZIP_EXT) {
       const result = await journalService.replaceFromZip(user.id, buffer);
+      if (result.quotaExceeded) {
+        return NextResponse.json(
+          {
+            error: `Importing this would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+          },
+          { status: 413 }
+        );
+      }
       return NextResponse.json({
         ok: true,
         mode: 'archive',
@@ -58,6 +66,14 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         user.id,
         buffer
       );
+      if (result.quotaExceeded) {
+        return NextResponse.json(
+          {
+            error: `Importing this would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+          },
+          { status: 413 }
+        );
+      }
       return NextResponse.json({
         ok: true,
         mode: 'single',

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
+import { rateLimit, UPLOAD } from '@/lib/rate-limit';
 import { NextResponse, type NextRequest } from 'next/server';
 
 const ALLOWED_SINGLE_EXTS = new Set(['.ledger', '.dat', '.journal', '.txt']);
@@ -9,6 +10,17 @@ const MAX_BYTES = 25 * 1024 * 1024;
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const user = await requireUser();
+  const limit = rateLimit(UPLOAD, user.id);
+  if (!limit.allowed) {
+    const retryAfter = Math.ceil((limit.resetAt - Date.now()) / 1000);
+    return NextResponse.json(
+      { error: 'Too many uploads. Please wait a moment and try again.' },
+      {
+        status: 429,
+        headers: { 'Retry-After': String(Math.max(1, retryAfter)) },
+      }
+    );
+  }
   const data = await req.formData();
   const file = data.get('file');
 

--- a/docs/superpowers/plans/2026-06-25-phase7-hardening.md
+++ b/docs/superpowers/plans/2026-06-25-phase7-hardening.md
@@ -1,0 +1,939 @@
+# Phase 7 Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-user rate limiting, a strict nonce-based CSP + security headers, and a cumulative per-user journal quota to close the three open Phase 7 hardening gaps.
+
+**Architecture:** A self-contained in-memory rate limiter (`lib/rate-limit/`) behind a one-method store interface, applied at `/api/upload` and every authenticated mutating server action. Security headers (incl. a nonce-based CSP) are emitted from a Next.js 16 `proxy.ts` using a pure `buildSecurityHeaders(nonce)` helper. A quota helper (`lib/journal/quota.ts`) plus a new `JOURNAL_QUOTA_MB` env var caps total journal-dir bytes, enforced centrally in `JournalService`.
+
+**Tech Stack:** Next.js 16.2.6 (App Router, `proxy` convention), TypeScript (strict), Zod v4, Drizzle/Postgres, Vitest, pnpm. Edge runtime for `proxy.ts` (Web Crypto + `btoa` available).
+
+## Global Constraints
+
+- **Next.js 16 `proxy` convention:** the request-interception file is `proxy.ts` at the repo root, exporting `export function proxy(request: NextRequest)` and a `config.matcher`. Do NOT create `middleware.ts` (removed convention in this version).
+- **Package manager is pnpm.** Verification commands: `pnpm test` (vitest run), `pnpm type-check` (tsc --noEmit), `pnpm lint` (eslint .).
+- **Code style:** single quotes, semicolons, 2-space indent, Prettier-formatted (matches existing files). `server-only` import at the top of server-only modules; OMIT it from pure utilities that have unit tests (`lib/rate-limit/store.ts`, `lib/security/headers.ts`) so Vitest can import them.
+- **Result-shape rule:** rate-limited/quota outcomes must reuse each action's EXISTING result variants and fields — do NOT widen any `reason` union or change any consumer UI. Exact mappings are given per task.
+- **Rate-limit state is in-memory, single-process** (single-container deploy). Keys are always `${policy.name}:${userId}` — every guarded surface is authenticated.
+- **Single-sourced limits:** quota MB is read from `process.env.JOURNAL_QUOTA_MB` (default 100) lazily, mirroring `lib/journal/layout.ts`'s `DATA_DIR` pattern, AND declared in `lib/env/index.ts` for startup validation.
+
+---
+
+### Task 1: Rate-limit core module (`lib/rate-limit/`)
+
+**Files:**
+- Create: `lib/rate-limit/store.ts`
+- Create: `lib/rate-limit/limits.ts`
+- Create: `lib/rate-limit/index.ts`
+- Test: `lib/rate-limit/store.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface RateLimitPolicy { name: string; max: number; windowMs: number }`
+  - `interface RateLimitResult { allowed: boolean; remaining: number; resetAt: number }`
+  - `class MemoryStore { constructor(now?: () => number); hit(key: string, policy: RateLimitPolicy): RateLimitResult }`
+  - `const UPLOAD`, `WRITE`, `DESTRUCTIVE: RateLimitPolicy`; `const RATE_LIMIT_MESSAGE: string`
+  - `function rateLimit(policy: RateLimitPolicy, userId: string): RateLimitResult`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/rate-limit/store.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { MemoryStore, type RateLimitPolicy } from './store';
+
+const policy: RateLimitPolicy = { name: 'test', max: 3, windowMs: 1000 };
+
+describe('MemoryStore', () => {
+  it('allows hits up to the limit then blocks', () => {
+    const store = new MemoryStore(() => 0);
+    expect(store.hit('k', policy).allowed).toBe(true); // 1
+    expect(store.hit('k', policy).allowed).toBe(true); // 2
+    expect(store.hit('k', policy).allowed).toBe(true); // 3
+    const fourth = store.hit('k', policy); // 4
+    expect(fourth.allowed).toBe(false);
+    expect(fourth.remaining).toBe(0);
+    expect(fourth.resetAt).toBe(1000);
+  });
+
+  it('resets after the window elapses', () => {
+    let now = 0;
+    const store = new MemoryStore(() => now);
+    store.hit('k', policy);
+    store.hit('k', policy);
+    store.hit('k', policy);
+    expect(store.hit('k', policy).allowed).toBe(false);
+    now = 1000; // window boundary reached
+    expect(store.hit('k', policy).allowed).toBe(true);
+  });
+
+  it('tracks keys independently', () => {
+    const store = new MemoryStore(() => 0);
+    store.hit('a', policy);
+    store.hit('a', policy);
+    store.hit('a', policy);
+    expect(store.hit('a', policy).allowed).toBe(false);
+    expect(store.hit('b', policy).allowed).toBe(true);
+  });
+
+  it('reports remaining correctly', () => {
+    const store = new MemoryStore(() => 0);
+    expect(store.hit('k', policy).remaining).toBe(2);
+    expect(store.hit('k', policy).remaining).toBe(1);
+    expect(store.hit('k', policy).remaining).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/rate-limit/store.test.ts`
+Expected: FAIL — cannot find module `./store`.
+
+- [ ] **Step 3: Write `lib/rate-limit/store.ts`**
+
+```ts
+export interface RateLimitPolicy {
+  name: string;
+  max: number;
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+export interface RateLimitStore {
+  hit(key: string, policy: RateLimitPolicy): RateLimitResult;
+}
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const SWEEP_EVERY = 1000;
+
+/**
+ * Fixed-window counter, single-process. Keyed by an opaque string. The clock is
+ * injectable for deterministic tests. Stale buckets are swept lazily so the map
+ * cannot grow without bound.
+ */
+export class MemoryStore implements RateLimitStore {
+  private readonly buckets = new Map<string, Bucket>();
+  private hits = 0;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  hit(key: string, policy: RateLimitPolicy): RateLimitResult {
+    const t = this.now();
+    if (++this.hits % SWEEP_EVERY === 0) this.sweep(t);
+
+    let bucket = this.buckets.get(key);
+    if (!bucket || t >= bucket.resetAt) {
+      bucket = { count: 0, resetAt: t + policy.windowMs };
+      this.buckets.set(key, bucket);
+    }
+    bucket.count++;
+    return {
+      allowed: bucket.count <= policy.max,
+      remaining: Math.max(0, policy.max - bucket.count),
+      resetAt: bucket.resetAt,
+    };
+  }
+
+  private sweep(t: number): void {
+    for (const [key, bucket] of this.buckets) {
+      if (t >= bucket.resetAt) this.buckets.delete(key);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Write `lib/rate-limit/limits.ts`**
+
+```ts
+import type { RateLimitPolicy } from './store';
+
+/** Expensive import + ledger parse. */
+export const UPLOAD: RateLimitPolicy = {
+  name: 'upload',
+  max: 10,
+  windowMs: 60_000,
+};
+
+/** Journal/template/saved-view/settings mutations. */
+export const WRITE: RateLimitPolicy = {
+  name: 'write',
+  max: 60,
+  windowMs: 60_000,
+};
+
+/** Account-deletion request & verify. */
+export const DESTRUCTIVE: RateLimitPolicy = {
+  name: 'destructive',
+  max: 5,
+  windowMs: 60_000,
+};
+
+export const RATE_LIMIT_MESSAGE =
+  'Too many requests. Please wait a moment and try again.';
+```
+
+- [ ] **Step 5: Write `lib/rate-limit/index.ts`**
+
+```ts
+import 'server-only';
+import { MemoryStore, type RateLimitPolicy, type RateLimitResult } from './store';
+
+const store = new MemoryStore();
+
+/** Per-user rate-limit check against a named policy. */
+export function rateLimit(
+  policy: RateLimitPolicy,
+  userId: string
+): RateLimitResult {
+  return store.hit(`${policy.name}:${userId}`, policy);
+}
+
+export { UPLOAD, WRITE, DESTRUCTIVE, RATE_LIMIT_MESSAGE } from './limits';
+export type { RateLimitPolicy, RateLimitResult } from './store';
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm test lib/rate-limit/store.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Type-check and commit**
+
+```bash
+pnpm type-check
+git add lib/rate-limit
+git commit -m "feat(rate-limit): in-memory fixed-window rate limiter"
+```
+
+---
+
+### Task 2: Rate-limit `/api/upload`
+
+**Files:**
+- Modify: `app/api/upload/route.ts`
+
+**Interfaces:**
+- Consumes: `rateLimit`, `UPLOAD` from `@/lib/rate-limit`.
+
+- [ ] **Step 1: Add the guard after `requireUser()`**
+
+In `app/api/upload/route.ts`, add to the imports:
+
+```ts
+import { rateLimit, UPLOAD } from '@/lib/rate-limit';
+```
+
+Then immediately after `const user = await requireUser();` (line 11), insert:
+
+```ts
+  const limit = rateLimit(UPLOAD, user.id);
+  if (!limit.allowed) {
+    const retryAfter = Math.ceil((limit.resetAt - Date.now()) / 1000);
+    return NextResponse.json(
+      { error: 'Too many uploads. Please wait a moment and try again.' },
+      { status: 429, headers: { 'Retry-After': String(Math.max(1, retryAfter)) } }
+    );
+  }
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: both pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/upload/route.ts
+git commit -m "feat(rate-limit): throttle /api/upload (429 + Retry-After)"
+```
+
+---
+
+### Task 3: Rate-limit transaction actions
+
+**Files:**
+- Modify: `features/transactions/actions/createTransaction.ts`
+- Modify: `features/transactions/actions/updateTransaction.ts`
+- Modify: `features/transactions/actions/deleteTransaction.ts`
+
+**Interfaces:**
+- Consumes: `rateLimit`, `WRITE`, `RATE_LIMIT_MESSAGE` from `@/lib/rate-limit`.
+- Mapping: these return `TransactionActionState` (`{ ok; fieldErrors?; formError? }`). Rate-limited → `{ ok: false, formError: RATE_LIMIT_MESSAGE }`.
+
+- [ ] **Step 1: Guard `createTransaction.ts`**
+
+Add import:
+
+```ts
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+```
+
+After `const user = await requireUser();`, insert:
+
+```ts
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, formError: RATE_LIMIT_MESSAGE };
+  }
+```
+
+- [ ] **Step 2: Guard `updateTransaction.ts` and `deleteTransaction.ts` the same way**
+
+Open each file. Add the same import. After the file's `const user = await requireUser();`, insert the same three-line guard returning `{ ok: false, formError: RATE_LIMIT_MESSAGE }` (both return `TransactionActionState`, so this shape type-checks in both).
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/transactions/actions
+git commit -m "feat(rate-limit): throttle transaction add/edit/delete actions"
+```
+
+---
+
+### Task 4: Rate-limit template, saved-view, and saved-currency actions
+
+**Files:**
+- Modify: `features/templates/actions/saveTemplate.ts`
+- Modify: `features/templates/actions/renameTemplate.ts`
+- Modify: `features/templates/actions/deleteTemplate.ts`
+- Modify: `features/savedViews/actions/saveSavedView.ts`
+- Modify: `features/savedViews/actions/renameSavedView.ts`
+- Modify: `features/savedViews/actions/deleteSavedView.ts`
+- Modify: `features/settings/actions/setSavedBaseCurrency.ts`
+
+**Interfaces:**
+- Consumes: `rateLimit`, `WRITE`, `RATE_LIMIT_MESSAGE` from `@/lib/rate-limit`.
+- Each guard goes right after that file's `const user = await requireUser();`. Map onto each file's existing union (no union widening):
+
+| File | Rate-limited return value |
+|------|---------------------------|
+| `saveTemplate.ts` | `{ ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE }` |
+| `renameTemplate.ts` | `{ ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE }` |
+| `deleteTemplate.ts` | `{ ok: false, message: RATE_LIMIT_MESSAGE }` |
+| `saveSavedView.ts` | `{ ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE }` |
+| `renameSavedView.ts` | `{ ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE }` |
+| `deleteSavedView.ts` | `{ ok: false, message: RATE_LIMIT_MESSAGE }` |
+| `setSavedBaseCurrency.ts` | `{ ok: false, message: RATE_LIMIT_MESSAGE }` |
+
+> NOT rate-limited (documented exclusions): `setSessionBaseCurrency` / `clearSessionBaseCurrency` are anonymous cookie writes (no `userId` to key on, not abuse vectors); `refreshPrices` is already throttled to once-per-day at the price-service layer.
+
+- [ ] **Step 1: Add import + guard to each of the seven files**
+
+For every file above, add:
+
+```ts
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+```
+
+and, immediately after `const user = await requireUser();`, insert (substituting that file's return value from the table):
+
+```ts
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return <rate-limited return value for this file>;
+  }
+```
+
+Example, `saveTemplate.ts`:
+
+```ts
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE };
+  }
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: both pass (each return value already matches its file's union).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add features/templates/actions features/savedViews/actions features/settings/actions/setSavedBaseCurrency.ts
+git commit -m "feat(rate-limit): throttle template, saved-view, and saved-currency writes"
+```
+
+---
+
+### Task 5: Rate-limit account-deletion actions
+
+**Files:**
+- Modify: `features/settings/actions/requestAccountDeletion.ts`
+- Modify: `features/settings/actions/deleteAccount.ts`
+
+**Interfaces:**
+- Consumes: `rateLimit`, `DESTRUCTIVE` from `@/lib/rate-limit`.
+- Mapping (reuse existing reasons — no union change, no UI change):
+  - `requestAccountDeletion` returns `IssueResult` → rate-limited = `{ ok: false, reason: 'throttled' }`.
+  - `deleteAccount` returns `VerifyResult` → rate-limited = `{ ok: false, reason: 'too-many-attempts' }`.
+
+- [ ] **Step 1: Guard `requestAccountDeletion.ts`**
+
+```ts
+import { rateLimit, DESTRUCTIVE } from '@/lib/rate-limit';
+```
+
+After `const user = await requireUser();`:
+
+```ts
+  if (!rateLimit(DESTRUCTIVE, user.id).allowed) {
+    return { ok: false, reason: 'throttled' };
+  }
+```
+
+- [ ] **Step 2: Guard `deleteAccount.ts`**
+
+```ts
+import { rateLimit, DESTRUCTIVE } from '@/lib/rate-limit';
+```
+
+After `const user = await requireUser();`:
+
+```ts
+  if (!rateLimit(DESTRUCTIVE, user.id).allowed) {
+    return { ok: false, reason: 'too-many-attempts' };
+  }
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/settings/actions/requestAccountDeletion.ts features/settings/actions/deleteAccount.ts
+git commit -m "feat(rate-limit): throttle account-deletion request/verify actions"
+```
+
+---
+
+### Task 6: Security-headers helper (`lib/security/headers.ts`)
+
+**Files:**
+- Create: `lib/security/headers.ts`
+- Test: `lib/security/headers.test.ts`
+
+**Interfaces:**
+- Produces: `function buildSecurityHeaders(nonce: string): Record<string, string>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/security/headers.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildSecurityHeaders } from './headers';
+
+describe('buildSecurityHeaders', () => {
+  it('embeds the nonce in script-src with strict-dynamic', () => {
+    const h = buildSecurityHeaders('abc123');
+    const csp = h['Content-Security-Policy'];
+    expect(csp).toContain("script-src 'self' 'nonce-abc123' 'strict-dynamic'");
+  });
+
+  it('sets the core directives and static headers', () => {
+    const csp = buildSecurityHeaders('n')['Content-Security-Policy'];
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("img-src 'self' data:");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+
+    const h = buildSecurityHeaders('n');
+    expect(h['X-Content-Type-Options']).toBe('nosniff');
+    expect(h['X-Frame-Options']).toBe('DENY');
+    expect(h['Referrer-Policy']).toBe('strict-origin-when-cross-origin');
+    expect(h['Strict-Transport-Security']).toContain('max-age=');
+    expect(h['Permissions-Policy']).toContain('camera=()');
+  });
+
+  it('varies the nonce per call', () => {
+    const a = buildSecurityHeaders('one')['Content-Security-Policy'];
+    const b = buildSecurityHeaders('two')['Content-Security-Policy'];
+    expect(a).not.toBe(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/security/headers.test.ts`
+Expected: FAIL — cannot find module `./headers`.
+
+- [ ] **Step 3: Write `lib/security/headers.ts`**
+
+```ts
+/**
+ * Builds the full security-header set, including a strict nonce-based CSP.
+ * Pure and framework-free so it can be unit-tested and called from proxy.ts.
+ *
+ * style-src keeps 'unsafe-inline' because Recharts and Base UI write inline
+ * `style=` attributes that a nonce cannot cover; injected CSS is far lower-risk
+ * than injected script, which 'nonce' + 'strict-dynamic' fully gate.
+ */
+export function buildSecurityHeaders(nonce: string): Record<string, string> {
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join('; ');
+
+  return {
+    'Content-Security-Policy': csp,
+    'Strict-Transport-Security': 'max-age=63072000; includeSubDomains',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/security/headers.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm type-check
+git add lib/security
+git commit -m "feat(security): buildSecurityHeaders with strict nonce CSP"
+```
+
+---
+
+### Task 7: Wire `proxy.ts`
+
+**Files:**
+- Create: `proxy.ts` (repo root)
+
+**Interfaces:**
+- Consumes: `buildSecurityHeaders` from `@/lib/security/headers`.
+
+- [ ] **Step 1: Write `proxy.ts`**
+
+```ts
+import { NextResponse, type NextRequest } from 'next/server';
+import { buildSecurityHeaders } from '@/lib/security/headers';
+
+export function proxy(request: NextRequest): NextResponse {
+  // Per-request nonce (Web Crypto + btoa are available in the Edge runtime).
+  const nonce = btoa(crypto.randomUUID());
+  const headers = buildSecurityHeaders(nonce);
+
+  // Forward the nonce + CSP on the request so Next threads the nonce into its
+  // own bootstrap <script> tags.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', headers['Content-Security-Policy']);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  for (const [key, value] of Object.entries(headers)) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
+export const config = {
+  matcher: [
+    {
+      source: '/((?!_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};
+```
+
+- [ ] **Step 2: Verify it loads and the app renders**
+
+Run: `pnpm type-check`
+Then start the dev server and confirm it boots without a "proxy must export" error and pages render:
+
+```bash
+pnpm dev
+```
+
+Open `http://localhost:3000`, sign in, and visit the Dashboard. In the browser devtools **Console**, confirm there are **no CSP violation errors**, and check **Network → the document response Headers** show `Content-Security-Policy` with a `nonce-…`, plus `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`. Specifically exercise: Dashboard charts (Recharts), Cmd+K command palette / a dialog (Base UI), and a toast (save a transaction → sonner). All must render with no console CSP errors.
+
+> If the build reports the proxy export is wrong, switch `export function proxy` to `export default function proxy` and re-verify — both are accepted; the named form is the Next 16 default.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add proxy.ts
+git commit -m "feat(security): emit nonce CSP + security headers via proxy.ts"
+```
+
+---
+
+### Task 8: Quota helper + env var (`lib/journal/quota.ts`)
+
+**Files:**
+- Create: `lib/journal/quota.ts`
+- Modify: `lib/env/index.ts` (add `JOURNAL_QUOTA_MB`)
+- Test: `lib/journal/quota.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `function journalQuotaBytes(): number`
+  - `async function getJournalDirSize(userId: string): Promise<number>`
+
+- [ ] **Step 1: Declare the env var**
+
+In `lib/env/index.ts`, inside `envSchema.extend({ ... })`, add (next to `DATA_DIR`):
+
+```ts
+    // Per-user cumulative journal-dir size cap (MB). Read lazily at runtime via
+    // process.env in lib/journal/quota.ts (so tests can override per-case);
+    // validated here so a bad value fails fast at startup.
+    JOURNAL_QUOTA_MB: z.coerce.number().int().positive().default(100),
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `lib/journal/quota.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getJournalDirSize, journalQuotaBytes } from './quota';
+
+let dataDir: string;
+const userId = 'user-quota';
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'quota-'));
+  process.env.DATA_DIR = dataDir;
+});
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true });
+  delete process.env.JOURNAL_QUOTA_MB;
+});
+
+describe('journalQuotaBytes', () => {
+  it('defaults to 100 MB', () => {
+    delete process.env.JOURNAL_QUOTA_MB;
+    expect(journalQuotaBytes()).toBe(100 * 1024 * 1024);
+  });
+
+  it('reads JOURNAL_QUOTA_MB from the environment', () => {
+    process.env.JOURNAL_QUOTA_MB = '5';
+    expect(journalQuotaBytes()).toBe(5 * 1024 * 1024);
+  });
+});
+
+describe('getJournalDirSize', () => {
+  it('returns 0 when the dir does not exist', async () => {
+    expect(await getJournalDirSize(userId)).toBe(0);
+  });
+
+  it('sums nested file sizes', async () => {
+    const dir = path.join(dataDir, 'journals', userId);
+    await fs.mkdir(path.join(dir, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), 'a'.repeat(100));
+    await fs.writeFile(path.join(dir, 'sub', 'inc.ledger'), 'b'.repeat(50));
+    expect(await getJournalDirSize(userId)).toBe(150);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test lib/journal/quota.test.ts`
+Expected: FAIL — cannot find module `./quota`.
+
+- [ ] **Step 4: Write `lib/journal/quota.ts`**
+
+```ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import 'server-only';
+import { listLocalRelPaths } from '@/lib/storage/manifest';
+import { getJournalDir } from './layout';
+
+/**
+ * Per-user cumulative journal-dir cap in bytes. Read lazily from process.env so
+ * tests can override it, mirroring DATA_DIR in layout.ts. The Zod-validated env
+ * in @/lib/env is the production source of truth.
+ */
+export const journalQuotaBytes = (): number =>
+  Number(process.env.JOURNAL_QUOTA_MB ?? 100) * 1024 * 1024;
+
+/** Total bytes of all files under the user's journal dir (0 if absent). */
+export const getJournalDirSize = async (userId: string): Promise<number> => {
+  const dir = getJournalDir(userId);
+  const rels = await listLocalRelPaths(dir);
+  let total = 0;
+  for (const rel of rels) {
+    try {
+      total += (await fs.stat(path.join(dir, rel))).size;
+    } catch {
+      // File vanished between listing and stat — ignore.
+    }
+  }
+  return total;
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test lib/journal/quota.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Type-check and commit**
+
+```bash
+pnpm type-check
+git add lib/journal/quota.ts lib/journal/quota.test.ts lib/env/index.ts
+git commit -m "feat(quota): journalQuotaBytes + getJournalDirSize helper and env var"
+```
+
+---
+
+### Task 9: Enforce quota in `JournalService` + map at `/api/upload`
+
+**Files:**
+- Modify: `lib/journal/service.ts`
+- Modify: `app/api/upload/route.ts`
+- Test: `lib/journal/quota-enforcement.test.ts`
+
+**Interfaces:**
+- Consumes: `journalQuotaBytes`, `getJournalDirSize` from `./quota`.
+- Produces (return-type additions, both optional so existing callers are unaffected):
+  - `replaceFromSingleFile` / `replaceFromZip` return objects gain `quotaExceeded?: boolean`.
+  - `addTransaction` returns its existing `AddTransactionResult` with a `formError` on quota failure.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/journal/quota-enforcement.test.ts`:
+
+```ts
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { journalService } from '@/lib/journal';
+
+let dataDir: string;
+const userId = 'user-quota-enforce';
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'quota-enf-'));
+  process.env.DATA_DIR = dataDir;
+  process.env.STORAGE_BACKEND = 'memory';
+  process.env.JOURNAL_QUOTA_MB = '1'; // 1 MB cap
+});
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true });
+  delete process.env.JOURNAL_QUOTA_MB;
+});
+
+describe('quota enforcement', () => {
+  it('rejects a single-file import over the quota without writing', async () => {
+    const big = Buffer.alloc(2 * 1024 * 1024, '\n'); // 2 MB > 1 MB cap
+    const result = await journalService.replaceFromSingleFile(userId, big);
+    expect(result.quotaExceeded).toBe(true);
+    // Nothing was written to the journal dir.
+    const dir = path.join(dataDir, 'journals', userId, 'main.ledger');
+    await expect(fs.stat(dir)).rejects.toBeTruthy();
+  });
+
+  it('allows a small import', async () => {
+    const small = Buffer.from('2020-01-01 Opening\n  Assets  1\n  Equity  -1\n');
+    const result = await journalService.replaceFromSingleFile(userId, small);
+    expect(result.quotaExceeded).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test lib/journal/quota-enforcement.test.ts`
+Expected: FAIL — `result.quotaExceeded` is `undefined` (not yet implemented), the first assertion fails.
+
+- [ ] **Step 3: Add the import + guards in `lib/journal/service.ts`**
+
+Add to the imports block (near the other `./` imports):
+
+```ts
+import { getJournalDirSize, journalQuotaBytes } from './quota';
+```
+
+**3a.** Widen the two import return types. Change `replaceFromSingleFile`'s signature return to:
+
+```ts
+  ): Promise<{ uidsAdded: number; parseFailure?: string; quotaExceeded?: boolean }> {
+```
+
+and `replaceFromZip`'s to:
+
+```ts
+  ): Promise<{
+    mainFile: string;
+    fileCount: number;
+    uidsAdded: number;
+    parseFailure?: string;
+    quotaExceeded?: boolean;
+  }> {
+```
+
+**3b.** In `replaceFromSingleFile`, as the FIRST statement inside the `withUserLock(userId, async () => {` callback (before `await pull(userId)`):
+
+```ts
+      if (content.length > journalQuotaBytes()) {
+        return { uidsAdded: 0, quotaExceeded: true };
+      }
+```
+
+**3c.** In `replaceFromZip`, after the path-traversal validation loop and BEFORE `return withUserLock(...)` (so we never wipe the dir when the extracted payload is too big), compute the extracted size from the already-parsed `entries`:
+
+```ts
+    const extractedBytes = entries.reduce(
+      (sum, entry) => sum + entry.getData().length,
+      0
+    );
+    if (extractedBytes > journalQuotaBytes()) {
+      return {
+        mainFile: '',
+        fileCount: entries.length,
+        uidsAdded: 0,
+        quotaExceeded: true,
+      };
+    }
+```
+
+**3d.** In `addTransaction`, inside the `withUserLock` callback, after `const block = ...` and BEFORE `await this.repo.appendFile(mainPath, block)`:
+
+```ts
+      const projected =
+        (await getJournalDirSize(userId)) + Buffer.byteLength(block);
+      if (projected > journalQuotaBytes()) {
+        return {
+          ok: false,
+          fieldErrors: {},
+          formError: `This transaction would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+        };
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test lib/journal/quota-enforcement.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Map `quotaExceeded` to HTTP 413 in `app/api/upload/route.ts`**
+
+In both the `ext === ZIP_EXT` branch and the `ALLOWED_SINGLE_EXTS.has(ext)` branch, right after the `const result = await journalService.replace...` line and BEFORE building the success `NextResponse.json`, insert:
+
+```ts
+      if (result.quotaExceeded) {
+        return NextResponse.json(
+          {
+            error: `Importing this would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+          },
+          { status: 413 }
+        );
+      }
+```
+
+- [ ] **Step 6: Verify everything**
+
+Run: `pnpm type-check && pnpm lint && pnpm test`
+Expected: all pass (full suite green, including the prior account-deletion/journal tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/journal/service.ts app/api/upload/route.ts lib/journal/quota-enforcement.test.ts
+git commit -m "feat(quota): enforce per-user journal cap on imports and adds"
+```
+
+---
+
+### Task 10: Update PLAN.md and final whole-branch verification
+
+**Files:**
+- Modify: `PLAN.md`
+
+- [ ] **Step 1: Check off the three Phase 7 items in `PLAN.md`**
+
+Under `## Phase 7 — Multi-user hardening / backups`, change these three lines from `[ ]` to `[x]` and append a one-line note + spec reference to each:
+
+- `Rate limit /api/upload and any future write endpoint` → `[x] Rate limit ... — in-memory per-user fixed-window limiter (lib/rate-limit/) on /api/upload + all mutating server actions; auth endpoints covered by better-auth.`
+- `Quota on per-user journal size` → `[x] Quota on per-user journal size — JOURNAL_QUOTA_MB (default 100) enforced in JournalService for imports + adds; lib/journal/quota.ts.`
+- `CSP / security headers pass` → `[x] CSP / security headers pass — strict nonce-based CSP + HSTS/X-Frame-Options/nosniff/Referrer-Policy/Permissions-Policy via proxy.ts (lib/security/headers.ts).`
+
+Add a trailing reference line after the Phase 7 list:
+`Spec: docs/superpowers/specs/2026-06-25-phase7-hardening-design.md.`
+
+- [ ] **Step 2: Full verification**
+
+Run: `pnpm test && pnpm type-check && pnpm lint`
+Expected: all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PLAN.md
+git commit -m "docs(phase7): mark rate-limit, quota, security-headers items done"
+```
+
+- [ ] **Step 4: Manual smoke (must do before opening the PR)**
+
+With `pnpm dev` running and signed in:
+1. Confirm Dashboard/charts/command-palette/toast all render with **no CSP console errors** (re-confirm Task 7 if skipped).
+2. Set `JOURNAL_QUOTA_MB=0.001` in `.env`, restart, and import a normal journal → expect a 413 / "would exceed your … limit" message; saving a transaction shows the limit error. Then restore `JOURNAL_QUOTA_MB` (or remove it to default 100).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Rate limiting store/limits/index → Task 1. ✓
+- Rate limit `/api/upload` (429 + Retry-After) → Task 2. ✓
+- Rate limit all mutating actions → Tasks 3–5 (transactions, templates, saved-views, saved-currency, account-deletion); documented exclusions for anonymous cookie toggles + already-throttled price refresh. ✓
+- `buildSecurityHeaders` with strict nonce CSP + static headers → Task 6. ✓
+- `proxy.ts` nonce + matcher + manual CSP verification → Task 7. ✓
+- `JOURNAL_QUOTA_MB` env + `getJournalDirSize` → Task 8. ✓
+- Quota enforcement in service (imports + add) + 413 mapping → Task 9. ✓
+- PLAN.md check-off → Task 10. ✓
+
+**Placeholder scan:** No TBD/TODO. The one templated string `<rate-limited return value for this file>` in Task 4 is immediately resolved by the explicit per-file table and worked example in the same task. ✓
+
+**Type consistency:** `RateLimitPolicy`/`RateLimitResult`/`MemoryStore`/`rateLimit` names match across Tasks 1–5. `journalQuotaBytes`/`getJournalDirSize` match across Tasks 8–9. `quotaExceeded` field name matches between service return types (Task 9 step 3) and route mapping (Task 9 step 5). Account-deletion mappings use only reasons that exist in `IssueResult` (`throttled`) and `VerifyResult` (`too-many-attempts`). ✓

--- a/docs/superpowers/specs/2026-06-25-phase7-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase7-hardening-design.md
@@ -1,0 +1,251 @@
+# Phase 7 Hardening — Rate Limiting, Security Headers, Per-User Quota — Design
+
+**Date:** 2026-06-25
+**Status:** Approved (brainstorming) — pending implementation plan
+**Phase:** 7 (Multi-user hardening / backups)
+
+## Goal
+
+Now that the app is genuinely multi-user (open passwordless registration,
+self-service account deletion), close three concrete exposure gaps before
+adding more surface area:
+
+1. **Rate limiting** — nothing throttles authenticated request volume today.
+   An authed user can hammer `/api/upload` (a 25 MB import + `ledger` parse each
+   time) or spam any write action.
+2. **Security headers / CSP** — `next.config.js` is `module.exports = {}`. No
+   CSP, HSTS, framing protection, MIME-sniffing protection, or referrer policy.
+3. **Per-user quota** — only a single-upload 25 MB cap exists. A user can grow
+   their journal directory unbounded via repeated imports or incremental adds.
+
+What is **already covered** and out of scope:
+
+- **Auth endpoints** (`/api/auth/*`) — better-auth (the `@naeemba/next-starter`
+  dependency) ships built-in rate limiting on login/signup.
+- **Account-deletion email code** — `lib/account-deletion/service.ts` already has
+  a Postgres-backed 30s resend throttle + 5-attempt cap + 10-min expiry. This
+  durable throttle on the *code itself* stays as-is; we add an action-level
+  request-rate guard on top (see below).
+
+## Decisions (taken 2026-06-25 during brainstorming)
+
+- **Rate-limit state lives in-memory, behind a pluggable store interface.** The
+  app deploys as a single container (node-cron runs in-process via
+  `instrumentation.ts`, so single-instance is already assumed). In-memory token
+  counters need zero new dependencies and no per-request DB write. The one flow
+  where durability genuinely matters — account deletion — already has a DB-backed
+  throttle. The store sits behind a one-method interface so a Postgres/Redis
+  backend is a contained swap if the app ever scales horizontally.
+- **Rate limiter covers `/api/upload` + all mutating server actions.** Broadest
+  coverage with a single helper, rather than only the destructive/expensive
+  surfaces.
+- **CSP is strict and nonce-based, implemented in `proxy.ts`** (Next.js 16
+  renamed the `middleware` convention to `proxy`). A pragmatic
+  `script-src 'unsafe-inline'` policy would ship a header that *looks* like a CSP
+  without delivering XSS protection. This app is the ideal case for a strict CSP:
+  **zero runtime third-party scripts** (everything bundled; `next/font/google`
+  self-hosts fonts at build time → served from `/_next/static`). The usual cost
+  of nonce CSP — pages become per-request dynamic — is already paid, since every
+  page shells out to `ledger` per-user and reads cookies. The one honest
+  concession is `style-src 'self' 'unsafe-inline'`, because Recharts/Base-UI write
+  inline `style=` attributes that nonces cannot cover; injected CSS is far
+  lower-risk than injected script.
+- **Quota is a total-directory-size cap**, configurable via env, enforced in
+  `JournalService` so every write path is covered (not just `/api/upload`).
+- **Ships as one PR** (`feat/phase7-hardening`) with three logically separate
+  commits — shared spec and a little shared plumbing make one review pass the
+  lower-overhead choice for a solo project.
+
+---
+
+## 1. Rate limiting — `lib/rate-limit/`
+
+Self-contained module, no external dependencies.
+
+### `store.ts`
+
+```ts
+export interface RateLimitPolicy { name: string; max: number; windowMs: number }
+export interface RateLimitResult { allowed: boolean; remaining: number; resetAt: number }
+export interface RateLimitStore {
+  hit(key: string, policy: RateLimitPolicy): RateLimitResult
+}
+```
+
+`MemoryStore implements RateLimitStore` — a **fixed-window counter** backed by a
+`Map<string, { count: number; resetAt: number }>`:
+
+- On `hit`, if the entry is missing or `now >= resetAt`, start a fresh window
+  (`count = 1`, `resetAt = now + windowMs`) and allow.
+- Otherwise increment; `allowed = count <= max`.
+- **Lazy expiry** on access plus an occasional sweep (every Nth call, or when the
+  map exceeds a size threshold) to drop stale entries so the map cannot grow
+  unbounded.
+- Clock is injectable (`now: () => number`, default `Date.now`) for deterministic
+  tests.
+
+Fixed-window is chosen over a sliding log for simplicity; the small burst-at-
+window-boundary imprecision is irrelevant for abuse-prevention thresholds.
+
+### `limits.ts`
+
+Named policies so call sites read intent, not magic numbers:
+
+| Policy        | max | windowMs | Applies to                                            |
+|---------------|-----|----------|-------------------------------------------------------|
+| `UPLOAD`      | 10  | 60_000   | `POST /api/upload`                                    |
+| `WRITE`       | 60  | 60_000   | transaction add/edit/delete, template & saved-view writes, settings writes |
+| `DESTRUCTIVE` | 5   | 60_000   | account-deletion request & verify actions             |
+
+(Exact numbers are easy to tune in the plan; these are sane starting points for a
+single human user where any higher rate implies a script.)
+
+### `index.ts`
+
+- Module-level singleton `MemoryStore`.
+- `rateLimit(policy: RateLimitPolicy, userId: string): RateLimitResult` — derives
+  the key as `${policy.name}:${userId}`. Every surface is authenticated, so
+  per-user identity is the natural key (no IP-spoofing concerns, no anonymous
+  traffic).
+
+### Application
+
+- **`/api/upload`** — after `requireUser()`, call `rateLimit(UPLOAD, user.id)`.
+  On `!allowed`, return **HTTP 429** with `Retry-After: <seconds-until-resetAt>`
+  and a JSON error body.
+- **Mutating server actions** — each gains a one-line guard near the top, after
+  the user is resolved:
+
+  ```ts
+  const rl = rateLimit(WRITE, user.id)
+  if (!rl.allowed) return { ok: false, reason: 'rate-limited' as const }
+  ```
+
+  The `rate-limited` reason is added to each action's existing result union and
+  surfaced inline by the form (consistent with how `stale` / `invalid` /
+  `parse-failed` already surface). Actions that currently redirect on success
+  instead return the error variant so the form can show a "slow down" message.
+
+---
+
+## 2. Security headers + CSP — `proxy.ts` + `lib/security/headers.ts`
+
+### `lib/security/headers.ts`
+
+`buildSecurityHeaders(nonce: string): Record<string, string>` — single source of
+truth for every security header. Pure function, unit-testable.
+
+**Content-Security-Policy** (nonce interpolated):
+
+```
+default-src 'self';
+script-src 'self' 'nonce-<nonce>' 'strict-dynamic';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data:;
+font-src 'self';
+connect-src 'self';
+frame-ancestors 'none';
+base-uri 'self';
+form-action 'self';
+object-src 'none';
+```
+
+Plus the static headers:
+
+| Header                      | Value                                                    |
+|-----------------------------|----------------------------------------------------------|
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` (HTTPS via Coolify/Caddy) |
+| `X-Content-Type-Options`    | `nosniff`                                                 |
+| `X-Frame-Options`           | `DENY` (belt-and-suspenders with `frame-ancestors 'none'`) |
+| `Referrer-Policy`           | `strict-origin-when-cross-origin`                        |
+| `Permissions-Policy`        | `camera=(), microphone=(), geolocation=(), interest-cohort=()` |
+
+### `proxy.ts`
+
+- Generates a per-request nonce via Web Crypto
+  (`crypto.getRandomValues` → base64), available in the Edge runtime.
+- Sets the nonce on a forwarded **`x-nonce` request header** so Next.js threads it
+  into its own bootstrap `<script>` tags automatically, and emits
+  `buildSecurityHeaders(nonce)` on the response.
+- **Matcher** excludes static assets that don't need a per-request nonce:
+  `['/((?!_next/static|_next/image|favicon.ico).*)']`.
+- No security headers are duplicated in `next.config.js` — `proxy.ts` is the only
+  place they are defined.
+
+### Verification
+
+Manual click-through of the running app before merge: Dashboard charts
+(Recharts), command palette / dialogs (Base-UI), and toast (sonner) must render
+with no CSP violations in the browser console. (Single-user app → no report-only
+rollout; direct manual verification is sufficient.)
+
+---
+
+## 3. Per-user quota — `lib/journal/quota.ts`
+
+### Config
+
+`JOURNAL_QUOTA_MB` declared in `lib/env/index.ts`:
+
+```ts
+JOURNAL_QUOTA_MB: z.coerce.number().positive().default(100),
+```
+
+### `getJournalDirSize(userId): Promise<number>`
+
+Recursively sums the byte size of all files under the user's journal directory
+(`getJournalDir(userId)`), reusing the existing local-path listing helper from the
+Garage sync layer (`listLocalRelPaths` or equivalent) where practical, falling
+back to a direct recursive `fs.stat` walk.
+
+### Enforcement in `JournalService`
+
+A new `quota-exceeded` reason is added to the relevant result unions; every write
+path is guarded centrally so no caller can bypass it:
+
+- **`replaceFromSingleFile` / `replaceFromZip`** — these wipe-and-replace the dir,
+  so the new total equals the incoming bytes. Reject **before** `resetLocalJournal`
+  if incoming bytes exceed the quota.
+- **`addTransaction`** — check `getJournalDirSize(userId)` + the serialized block
+  size against the quota. In practice always passes (transactions are tiny), but
+  it closes the unbounded-incremental-growth path.
+- Edits/deletes don't grow the journal meaningfully and are not gated (delete can
+  only shrink it).
+
+### Surfacing
+
+- **`/api/upload`** maps `quota-exceeded` → **HTTP 413** with a clear message:
+  "Importing this would exceed your NN MB journal limit."
+- **`addTransaction`** surfaces `quota-exceeded` inline on the transaction form,
+  like the existing `parse-failed` path.
+
+---
+
+## 4. Testing
+
+| Area          | Tests                                                                        |
+|---------------|------------------------------------------------------------------------------|
+| Rate limiting | `MemoryStore`: allow under limit; block at limit+1; reset after window elapses (injected clock); independent keys don't interfere; sweep drops stale entries. |
+| Headers       | `buildSecurityHeaders`: nonce appears in `script-src`; all expected directives & static headers present; nonce varies per call. |
+| Quota         | `getJournalDirSize` against a temp dir with nested files; `JournalService` returns `quota-exceeded` when incoming/total exceeds limit and writes nothing. |
+
+Manual: CSP click-through verification (Section 2) before merge.
+
+## Out of scope (future Phase 7 items)
+
+- Audit log of journal mutations.
+- Structured logging + error-tracking destination.
+- IP-based or anonymous rate limiting (all current surfaces are authenticated).
+- Distributed/durable rate-limit store (the interface leaves the door open).
+
+## Files touched
+
+**New:** `lib/rate-limit/{store,limits,index}.ts` (+ tests),
+`lib/security/headers.ts` (+ test), `proxy.ts`,
+`lib/journal/quota.ts` (+ test).
+
+**Modified:** `app/api/upload/route.ts` (rate limit + quota mapping),
+mutating server actions under `features/*/actions/` (rate-limit guard),
+`lib/journal/service.ts` (quota enforcement + result unions),
+`lib/env/index.ts` (`JOURNAL_QUOTA_MB`),
+`PLAN.md` (check off the three Phase 7 items).

--- a/features/savedViews/actions/deleteSavedView.ts
+++ b/features/savedViews/actions/deleteSavedView.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { savedViewService } from '@/lib/savedViews';
 import { revalidatePath } from 'next/cache';
 
@@ -12,6 +13,9 @@ export const deleteSavedViewAction = async (
   id: string
 ): Promise<DeleteSavedViewResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
   try {
     await savedViewService.delete(user.id, id);
   } catch (e) {

--- a/features/savedViews/actions/renameSavedView.ts
+++ b/features/savedViews/actions/renameSavedView.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { savedViewService, savedViewNameSchema } from '@/lib/savedViews';
 import { revalidatePath } from 'next/cache';
 
@@ -17,6 +18,9 @@ export const renameSavedViewAction = async (
   name: string
 ): Promise<RenameSavedViewResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE };
+  }
   const parsed = savedViewNameSchema.safeParse(name);
   if (!parsed.success) {
     return {

--- a/features/savedViews/actions/saveSavedView.ts
+++ b/features/savedViews/actions/saveSavedView.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { savedViewService, savedViewInputSchema } from '@/lib/savedViews';
 import { revalidatePath } from 'next/cache';
 
@@ -18,6 +19,9 @@ export const saveSavedViewAction = async (
   opts: { overwrite?: boolean } = {}
 ): Promise<SaveSavedViewResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE };
+  }
   const parsed = savedViewInputSchema.safeParse(input);
   if (!parsed.success) {
     const fieldErrors: Record<string, string> = {};

--- a/features/settings/actions/deleteAccount.ts
+++ b/features/settings/actions/deleteAccount.ts
@@ -6,11 +6,15 @@ import {
   type VerifyResult,
 } from '@/lib/account-deletion';
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, DESTRUCTIVE } from '@/lib/rate-limit';
 
 export const deleteAccountAction = async (
   code: unknown
 ): Promise<VerifyResult> => {
   const user = await requireUser();
+  if (!rateLimit(DESTRUCTIVE, user.id).allowed) {
+    return { ok: false, reason: 'too-many-attempts' };
+  }
   const parsed = deletionCodeSchema.safeParse(code);
   if (!parsed.success) {
     return { ok: false, reason: 'invalid', remaining: 0 };

--- a/features/settings/actions/requestAccountDeletion.ts
+++ b/features/settings/actions/requestAccountDeletion.ts
@@ -5,8 +5,12 @@ import {
   type IssueResult,
 } from '@/lib/account-deletion';
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, DESTRUCTIVE } from '@/lib/rate-limit';
 
 export const requestAccountDeletionAction = async (): Promise<IssueResult> => {
   const user = await requireUser();
+  if (!rateLimit(DESTRUCTIVE, user.id).allowed) {
+    return { ok: false, reason: 'throttled' };
+  }
   return accountDeletionService.issueCode(user.id, user.email);
 };

--- a/features/settings/actions/setSavedBaseCurrency.ts
+++ b/features/settings/actions/setSavedBaseCurrency.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { baseCurrencySchema, userSettingService } from '@/lib/settings';
 import { revalidatePath } from 'next/cache';
 
@@ -12,6 +13,9 @@ export const setSavedBaseCurrencyAction = async (
   value: unknown
 ): Promise<SetSavedBaseCurrencyResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
   const parsed = baseCurrencySchema.safeParse(value);
   if (!parsed.success) {
     return { ok: false, message: 'Invalid currency code.' };

--- a/features/templates/actions/deleteTemplate.ts
+++ b/features/templates/actions/deleteTemplate.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { templateRepository } from '@/lib/templates';
 import { revalidatePath } from 'next/cache';
 
@@ -12,6 +13,9 @@ export const deleteTemplateAction = async (
   id: string
 ): Promise<DeleteTemplateResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
   try {
     await templateRepository.delete(user.id, id);
   } catch (e) {

--- a/features/templates/actions/renameTemplate.ts
+++ b/features/templates/actions/renameTemplate.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { templateService } from '@/lib/templates';
 import { templateNameSchema } from '@/lib/templates/schema';
 import { revalidatePath } from 'next/cache';
@@ -19,6 +20,9 @@ export const renameTemplateAction = async (
   name: unknown
 ): Promise<RenameTemplateResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE };
+  }
   const parsed = templateNameSchema.safeParse(name);
   if (!parsed.success) {
     return {

--- a/features/templates/actions/saveTemplate.ts
+++ b/features/templates/actions/saveTemplate.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { requireUser } from '@/lib/auth/require-user';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { templateService } from '@/lib/templates';
 import { templateInputSchema } from '@/lib/templates/schema';
 import { revalidatePath } from 'next/cache';
@@ -19,6 +20,9 @@ export const saveTemplateAction = async (
   opts: { overwrite?: boolean } = {}
 ): Promise<SaveTemplateResult> => {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, reason: 'invalid', message: RATE_LIMIT_MESSAGE };
+  }
   const parsed = templateInputSchema.safeParse(input);
   if (!parsed.success) {
     const fieldErrors: Record<string, string> = {};

--- a/features/transactions/actions/createTransaction.ts
+++ b/features/transactions/actions/createTransaction.ts
@@ -3,12 +3,16 @@
 import type { TransactionActionState } from './types';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 
 export async function createTransactionAction(
   _prev: TransactionActionState | null,
   formData: FormData
 ): Promise<TransactionActionState> {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, formError: RATE_LIMIT_MESSAGE };
+  }
   const draftJson = formData.get('draft');
   if (typeof draftJson !== 'string') {
     return { ok: false, formError: 'Missing transaction payload' };

--- a/features/transactions/actions/deleteTransaction.ts
+++ b/features/transactions/actions/deleteTransaction.ts
@@ -2,6 +2,7 @@
 
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 
 export type DeleteTransactionResult =
   | { ok: true }
@@ -12,6 +13,9 @@ export async function deleteTransactionAction(
   expectedFingerprint: string
 ): Promise<DeleteTransactionResult> {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
   const result = await journalService.deleteTransaction(user.id, {
     kind: 'delete',
     uid,

--- a/features/transactions/actions/updateTransaction.ts
+++ b/features/transactions/actions/updateTransaction.ts
@@ -3,6 +3,7 @@
 import type { TransactionActionState } from './types';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import type { TransactionDraft } from '@/lib/transactions/schema';
 
 export async function updateTransactionAction(
@@ -10,6 +11,9 @@ export async function updateTransactionAction(
   formData: FormData
 ): Promise<TransactionActionState> {
   const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, formError: RATE_LIMIT_MESSAGE };
+  }
   const draftJson = formData.get('draft');
   const uid = formData.get('uid');
   const expectedFingerprint = formData.get('expectedFingerprint');

--- a/lib/env/index.ts
+++ b/lib/env/index.ts
@@ -22,6 +22,11 @@ const envSchema = clientEnvSchema
     // lib/journal/layout.ts (so tests can override it per-case).
     DATA_DIR: z.string().min(1).default('./data'),
 
+    // Per-user cumulative journal-dir size cap (MB). Read lazily at runtime via
+    // process.env in lib/journal/quota.ts (so tests can override per-case);
+    // validated here so a bad value fails fast at startup.
+    JOURNAL_QUOTA_MB: z.coerce.number().int().positive().default(100),
+
     // Email (magic link). Delivered via the self-hosted Postal server (see
     // lib/email-transport.ts). Both Postal vars are required so a missing/empty
     // value fails fast at startup rather than the first time someone signs in.

--- a/lib/journal/quota-enforcement.test.ts
+++ b/lib/journal/quota-enforcement.test.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+import { JournalService } from './service';
+import { resetObjectStore } from '@/lib/storage';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+const userId = 'user-quota-enforce';
+
+describe('quota enforcement', () => {
+  let ctx: TestDbContext;
+  let service: JournalService;
+
+  beforeEach(async () => {
+    resetObjectStore();
+    ctx = await setupTestDb('quota-enf-');
+    await ctx.insertUser(userId);
+    service = new JournalService(new JournalRepository(ctx.db));
+    process.env.STORAGE_BACKEND = 'memory';
+    process.env.JOURNAL_QUOTA_MB = '1'; // 1 MB cap
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    resetObjectStore();
+    delete process.env.JOURNAL_QUOTA_MB;
+  });
+
+  it('rejects a single-file import over the quota without writing', async () => {
+    const big = Buffer.alloc(2 * 1024 * 1024, '\n'); // 2 MB > 1 MB cap
+    const result = await service.replaceFromSingleFile(userId, big);
+    expect(result.quotaExceeded).toBe(true);
+    // Nothing was written to the journal dir.
+    const dir = path.join(ctx.tmpDir, 'journals', userId, 'main.ledger');
+    await expect(fs.stat(dir)).rejects.toBeTruthy();
+  });
+
+  it('allows a small import', async () => {
+    await fs.mkdir(getJournalDir(userId), { recursive: true });
+    const small = Buffer.from(
+      '2020-01-01 Opening\n  Assets  1\n  Equity  -1\n'
+    );
+    const result = await service.replaceFromSingleFile(userId, small);
+    expect(result.quotaExceeded).toBeUndefined();
+  });
+});

--- a/lib/journal/quota.test.ts
+++ b/lib/journal/quota.test.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PRICE_DB_NAME } from './layout';
 import { getJournalDirSize, journalQuotaBytes } from './quota';
 
 let dataDir: string;
@@ -28,6 +29,14 @@ describe('journalQuotaBytes', () => {
     process.env.JOURNAL_QUOTA_MB = '5';
     expect(journalQuotaBytes()).toBe(5 * 1024 * 1024);
   });
+
+  it.each(['abc', '0', '-5'])(
+    'falls back to 100 MB (fail closed) for invalid value %j',
+    (value) => {
+      process.env.JOURNAL_QUOTA_MB = value;
+      expect(journalQuotaBytes()).toBe(100 * 1024 * 1024);
+    }
+  );
 });
 
 describe('getJournalDirSize', () => {
@@ -41,5 +50,13 @@ describe('getJournalDirSize', () => {
     await fs.writeFile(path.join(dir, 'main.ledger'), 'a'.repeat(100));
     await fs.writeFile(path.join(dir, 'sub', 'inc.ledger'), 'b'.repeat(50));
     expect(await getJournalDirSize(userId)).toBe(150);
+  });
+
+  it('excludes the auto-managed price DB from the total', async () => {
+    const dir = path.join(dataDir, 'journals', userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), 'a'.repeat(100));
+    await fs.writeFile(path.join(dir, PRICE_DB_NAME), 'p'.repeat(500));
+    expect(await getJournalDirSize(userId)).toBe(100);
   });
 });

--- a/lib/journal/quota.test.ts
+++ b/lib/journal/quota.test.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getJournalDirSize, journalQuotaBytes } from './quota';
+
+let dataDir: string;
+const userId = 'user-quota';
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'quota-'));
+  process.env.DATA_DIR = dataDir;
+});
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true });
+  delete process.env.JOURNAL_QUOTA_MB;
+});
+
+describe('journalQuotaBytes', () => {
+  it('defaults to 100 MB', () => {
+    delete process.env.JOURNAL_QUOTA_MB;
+    expect(journalQuotaBytes()).toBe(100 * 1024 * 1024);
+  });
+
+  it('reads JOURNAL_QUOTA_MB from the environment', () => {
+    process.env.JOURNAL_QUOTA_MB = '5';
+    expect(journalQuotaBytes()).toBe(5 * 1024 * 1024);
+  });
+});
+
+describe('getJournalDirSize', () => {
+  it('returns 0 when the dir does not exist', async () => {
+    expect(await getJournalDirSize(userId)).toBe(0);
+  });
+
+  it('sums nested file sizes', async () => {
+    const dir = path.join(dataDir, 'journals', userId);
+    await fs.mkdir(path.join(dir, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), 'a'.repeat(100));
+    await fs.writeFile(path.join(dir, 'sub', 'inc.ledger'), 'b'.repeat(50));
+    expect(await getJournalDirSize(userId)).toBe(150);
+  });
+});

--- a/lib/journal/quota.test.ts
+++ b/lib/journal/quota.test.ts
@@ -14,6 +14,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await fs.rm(dataDir, { recursive: true, force: true });
+  delete process.env.DATA_DIR;
   delete process.env.JOURNAL_QUOTA_MB;
 });
 

--- a/lib/journal/quota.ts
+++ b/lib/journal/quota.ts
@@ -1,23 +1,40 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import 'server-only';
-import { getJournalDir } from './layout';
+import { PRICE_DB_NAME, getJournalDir } from './layout';
 import { listLocalRelPaths } from '@/lib/storage/manifest';
+
+const DEFAULT_QUOTA_MB = 100;
 
 /**
  * Per-user cumulative journal-dir cap in bytes. Read lazily from process.env so
  * tests can override it, mirroring DATA_DIR in layout.ts. The Zod-validated env
  * in @/lib/env is the production source of truth.
+ *
+ * Falls back to DEFAULT_QUOTA_MB when the runtime value is missing or
+ * non-numeric so a bad env var defaults *closed* (still enforcing a cap) rather
+ * than silently disabling the quota (Number('x') → NaN → every check false).
  */
-export const journalQuotaBytes = (): number =>
-  Number(process.env.JOURNAL_QUOTA_MB ?? 100) * 1024 * 1024;
+export const journalQuotaBytes = (): number => {
+  const mb = Number(process.env.JOURNAL_QUOTA_MB);
+  return (Number.isFinite(mb) && mb > 0 ? mb : DEFAULT_QUOTA_MB) * 1024 * 1024;
+};
 
-/** Total bytes of all files under the user's journal dir (0 if absent). */
+/**
+ * Total bytes of user-authored files under the journal dir (0 if absent).
+ *
+ * Excludes the auto-managed price DB (`price-db.ledger`): it is system-generated
+ * price data from refreshPrices, not user content. Counting it would let a large
+ * price DB block addTransaction even when the user's own content is under quota,
+ * while imports (which don't count it) would still succeed — an inconsistency the
+ * user can't fix by trimming their journal.
+ */
 export const getJournalDirSize = async (userId: string): Promise<number> => {
   const dir = getJournalDir(userId);
   const rels = await listLocalRelPaths(dir);
   let total = 0;
   for (const rel of rels) {
+    if (path.basename(rel) === PRICE_DB_NAME) continue;
     try {
       total += (await fs.stat(path.join(dir, rel))).size;
     } catch {

--- a/lib/journal/quota.ts
+++ b/lib/journal/quota.ts
@@ -15,10 +15,12 @@ const DEFAULT_QUOTA_MB = 100;
  * non-numeric so a bad env var defaults *closed* (still enforcing a cap) rather
  * than silently disabling the quota (Number('x') → NaN → every check false).
  */
-export const journalQuotaBytes = (): number => {
+export const journalQuotaMb = (): number => {
   const mb = Number(process.env.JOURNAL_QUOTA_MB);
-  return (Number.isFinite(mb) && mb > 0 ? mb : DEFAULT_QUOTA_MB) * 1024 * 1024;
+  return Number.isFinite(mb) && mb > 0 ? mb : DEFAULT_QUOTA_MB;
 };
+
+export const journalQuotaBytes = (): number => journalQuotaMb() * 1024 * 1024;
 
 /**
  * Total bytes of user-authored files under the journal dir (0 if absent).

--- a/lib/journal/quota.ts
+++ b/lib/journal/quota.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import 'server-only';
+import { getJournalDir } from './layout';
+import { listLocalRelPaths } from '@/lib/storage/manifest';
+
+/**
+ * Per-user cumulative journal-dir cap in bytes. Read lazily from process.env so
+ * tests can override it, mirroring DATA_DIR in layout.ts. The Zod-validated env
+ * in @/lib/env is the production source of truth.
+ */
+export const journalQuotaBytes = (): number =>
+  Number(process.env.JOURNAL_QUOTA_MB ?? 100) * 1024 * 1024;
+
+/** Total bytes of all files under the user's journal dir (0 if absent). */
+export const getJournalDirSize = async (userId: string): Promise<number> => {
+  const dir = getJournalDir(userId);
+  const rels = await listLocalRelPaths(dir);
+  let total = 0;
+  for (const rel of rels) {
+    try {
+      total += (await fs.stat(path.join(dir, rel))).size;
+    } catch {
+      // File vanished between listing and stat — ignore.
+    }
+  }
+  return total;
+};

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -292,17 +292,25 @@ export class JournalService {
       }
     }
 
-    const extractedBytes = entries.reduce(
-      (sum, entry) => sum + entry.getData().length,
-      0
-    );
-    if (extractedBytes > journalQuotaBytes()) {
-      return {
-        mainFile: '',
-        fileCount: entries.length,
-        uidsAdded: 0,
-        quotaExceeded: true,
-      };
+    // Decompress each entry exactly once (adm-zip does not cache buffers) and
+    // short-circuit the quota sum as soon as it crosses the cap, so a malicious
+    // archive (a "zip bomb") can't force us to decompress its entire payload
+    // into memory before the quota rejects it.
+    const quota = journalQuotaBytes();
+    const decompressed: { entry: AdmZip.IZipEntry; data: Buffer }[] = [];
+    let extractedBytes = 0;
+    for (const entry of entries) {
+      const data = entry.getData();
+      extractedBytes += data.length;
+      decompressed.push({ entry, data });
+      if (extractedBytes > quota) {
+        return {
+          mainFile: '',
+          fileCount: entries.length,
+          uidsAdded: 0,
+          quotaExceeded: true,
+        };
+      }
     }
 
     return withUserLock(userId, async () => {
@@ -310,14 +318,14 @@ export class JournalService {
       await this.repo.resetLocalJournal(userId); // wipe local files, keep manifest
       const dir = getJournalDir(userId);
 
-      for (const entry of entries) {
+      for (const { entry, data } of decompressed) {
         const target = path.join(dir, entry.entryName);
         const resolved = path.resolve(target);
         if (!resolved.startsWith(path.resolve(dir) + path.sep)) {
           throw new Error(`Unsafe path in archive: ${entry.entryName}`);
         }
         await fs.mkdir(path.dirname(target), { recursive: true });
-        await fs.writeFile(target, entry.getData());
+        await fs.writeFile(target, data);
       }
 
       const mainFile = detectMain(entries.map((e) => ({ name: e.entryName })));

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -16,6 +16,7 @@ import {
   type ParsedJournal,
   type Transaction,
 } from './parser';
+import { getJournalDirSize, journalQuotaBytes } from './quota';
 import { JournalRepository } from './repository';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
@@ -152,6 +153,15 @@ export class JournalService {
       const snapshot = await this.repo.readFile(mainPath);
       // Leading "\n\n" guards against imported files that lack a trailing newline.
       const block = `\n\n${formatTransaction(draft)}\n`;
+      const projected =
+        (await getJournalDirSize(userId)) + Buffer.byteLength(block);
+      if (projected > journalQuotaBytes()) {
+        return {
+          ok: false,
+          fieldErrors: {},
+          formError: `This transaction would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+        };
+      }
       try {
         await this.repo.appendFile(mainPath, block);
       } catch (e) {
@@ -221,8 +231,15 @@ export class JournalService {
   async replaceFromSingleFile(
     userId: string,
     content: Buffer
-  ): Promise<{ uidsAdded: number; parseFailure?: string }> {
+  ): Promise<{
+    uidsAdded: number;
+    parseFailure?: string;
+    quotaExceeded?: boolean;
+  }> {
     return withUserLock(userId, async () => {
+      if (content.length > journalQuotaBytes()) {
+        return { uidsAdded: 0, quotaExceeded: true };
+      }
       await pull(userId); // sync local cache + manifest to canonical
       await this.repo.resetLocalJournal(userId); // wipe local files, keep manifest
       const dir = getJournalDir(userId);
@@ -261,6 +278,7 @@ export class JournalService {
     fileCount: number;
     uidsAdded: number;
     parseFailure?: string;
+    quotaExceeded?: boolean;
   }> {
     const zip = new AdmZip(buffer);
     const entries = zip.getEntries().filter((e) => !e.isDirectory);
@@ -272,6 +290,19 @@ export class JournalService {
       ) {
         throw new Error(`Unsafe path in archive: ${entry.entryName}`);
       }
+    }
+
+    const extractedBytes = entries.reduce(
+      (sum, entry) => sum + entry.getData().length,
+      0
+    );
+    if (extractedBytes > journalQuotaBytes()) {
+      return {
+        mainFile: '',
+        fileCount: entries.length,
+        uidsAdded: 0,
+        quotaExceeded: true,
+      };
     }
 
     return withUserLock(userId, async () => {

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -16,7 +16,7 @@ import {
   type ParsedJournal,
   type Transaction,
 } from './parser';
-import { getJournalDirSize, journalQuotaBytes } from './quota';
+import { getJournalDirSize, journalQuotaBytes, journalQuotaMb } from './quota';
 import { JournalRepository } from './repository';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
@@ -159,7 +159,7 @@ export class JournalService {
         return {
           ok: false,
           fieldErrors: {},
-          formError: `This transaction would exceed your ${process.env.JOURNAL_QUOTA_MB ?? 100} MB journal limit.`,
+          formError: `This transaction would exceed your ${journalQuotaMb()} MB journal limit.`,
         };
       }
       try {

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+import {
+  MemoryStore,
+  type RateLimitPolicy,
+  type RateLimitResult,
+} from './store';
+
+const store = new MemoryStore();
+
+/** Per-user rate-limit check against a named policy. */
+export function rateLimit(
+  policy: RateLimitPolicy,
+  userId: string
+): RateLimitResult {
+  return store.hit(`${policy.name}:${userId}`, policy);
+}
+
+export { UPLOAD, WRITE, DESTRUCTIVE, RATE_LIMIT_MESSAGE } from './limits';
+export type { RateLimitPolicy, RateLimitResult } from './store';

--- a/lib/rate-limit/limits.ts
+++ b/lib/rate-limit/limits.ts
@@ -1,0 +1,25 @@
+import type { RateLimitPolicy } from './store';
+
+/** Expensive import + ledger parse. */
+export const UPLOAD: RateLimitPolicy = {
+  name: 'upload',
+  max: 10,
+  windowMs: 60_000,
+};
+
+/** Journal/template/saved-view/settings mutations. */
+export const WRITE: RateLimitPolicy = {
+  name: 'write',
+  max: 60,
+  windowMs: 60_000,
+};
+
+/** Account-deletion request & verify. */
+export const DESTRUCTIVE: RateLimitPolicy = {
+  name: 'destructive',
+  max: 5,
+  windowMs: 60_000,
+};
+
+export const RATE_LIMIT_MESSAGE =
+  'Too many requests. Please wait a moment and try again.';

--- a/lib/rate-limit/store.test.ts
+++ b/lib/rate-limit/store.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { MemoryStore, type RateLimitPolicy } from './store';
+
+const policy: RateLimitPolicy = { name: 'test', max: 3, windowMs: 1000 };
+
+describe('MemoryStore', () => {
+  it('allows hits up to the limit then blocks', () => {
+    const store = new MemoryStore(() => 0);
+    expect(store.hit('k', policy).allowed).toBe(true); // 1
+    expect(store.hit('k', policy).allowed).toBe(true); // 2
+    expect(store.hit('k', policy).allowed).toBe(true); // 3
+    const fourth = store.hit('k', policy); // 4
+    expect(fourth.allowed).toBe(false);
+    expect(fourth.remaining).toBe(0);
+    expect(fourth.resetAt).toBe(1000);
+  });
+
+  it('resets after the window elapses', () => {
+    let now = 0;
+    const store = new MemoryStore(() => now);
+    store.hit('k', policy);
+    store.hit('k', policy);
+    store.hit('k', policy);
+    expect(store.hit('k', policy).allowed).toBe(false);
+    now = 1000; // window boundary reached
+    expect(store.hit('k', policy).allowed).toBe(true);
+  });
+
+  it('tracks keys independently', () => {
+    const store = new MemoryStore(() => 0);
+    store.hit('a', policy);
+    store.hit('a', policy);
+    store.hit('a', policy);
+    expect(store.hit('a', policy).allowed).toBe(false);
+    expect(store.hit('b', policy).allowed).toBe(true);
+  });
+
+  it('reports remaining correctly', () => {
+    const store = new MemoryStore(() => 0);
+    expect(store.hit('k', policy).remaining).toBe(2);
+    expect(store.hit('k', policy).remaining).toBe(1);
+    expect(store.hit('k', policy).remaining).toBe(0);
+  });
+});

--- a/lib/rate-limit/store.ts
+++ b/lib/rate-limit/store.ts
@@ -1,0 +1,57 @@
+export interface RateLimitPolicy {
+  name: string;
+  max: number;
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+export interface RateLimitStore {
+  hit(key: string, policy: RateLimitPolicy): RateLimitResult;
+}
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const SWEEP_EVERY = 1000;
+
+/**
+ * Fixed-window counter, single-process. Keyed by an opaque string. The clock is
+ * injectable for deterministic tests. Stale buckets are swept lazily so the map
+ * cannot grow without bound.
+ */
+export class MemoryStore implements RateLimitStore {
+  private readonly buckets = new Map<string, Bucket>();
+  private hits = 0;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  hit(key: string, policy: RateLimitPolicy): RateLimitResult {
+    const t = this.now();
+    if (++this.hits % SWEEP_EVERY === 0) this.sweep(t);
+
+    let bucket = this.buckets.get(key);
+    if (!bucket || t >= bucket.resetAt) {
+      bucket = { count: 0, resetAt: t + policy.windowMs };
+      this.buckets.set(key, bucket);
+    }
+    bucket.count++;
+    return {
+      allowed: bucket.count <= policy.max,
+      remaining: Math.max(0, policy.max - bucket.count),
+      resetAt: bucket.resetAt,
+    };
+  }
+
+  private sweep(t: number): void {
+    for (const [key, bucket] of this.buckets) {
+      if (t >= bucket.resetAt) this.buckets.delete(key);
+    }
+  }
+}

--- a/lib/security/headers.test.ts
+++ b/lib/security/headers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildSecurityHeaders } from './headers';
+
+describe('buildSecurityHeaders', () => {
+  it('embeds the nonce in script-src with strict-dynamic', () => {
+    const h = buildSecurityHeaders('abc123');
+    const csp = h['Content-Security-Policy'];
+    expect(csp).toContain("script-src 'self' 'nonce-abc123' 'strict-dynamic'");
+  });
+
+  it('sets the core directives and static headers', () => {
+    const csp = buildSecurityHeaders('n')['Content-Security-Policy'];
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("img-src 'self' data:");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+
+    const h = buildSecurityHeaders('n');
+    expect(h['X-Content-Type-Options']).toBe('nosniff');
+    expect(h['X-Frame-Options']).toBe('DENY');
+    expect(h['Referrer-Policy']).toBe('strict-origin-when-cross-origin');
+    expect(h['Strict-Transport-Security']).toContain('max-age=');
+    expect(h['Permissions-Policy']).toContain('camera=()');
+  });
+
+  it('varies the nonce per call', () => {
+    const a = buildSecurityHeaders('one')['Content-Security-Policy'];
+    const b = buildSecurityHeaders('two')['Content-Security-Policy'];
+    expect(a).not.toBe(b);
+  });
+});

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -1,0 +1,31 @@
+/**
+ * Builds the full security-header set, including a strict nonce-based CSP.
+ * Pure and framework-free so it can be unit-tested and called from proxy.ts.
+ *
+ * style-src keeps 'unsafe-inline' because Recharts and Base UI write inline
+ * `style=` attributes that a nonce cannot cover; injected CSS is far lower-risk
+ * than injected script, which 'nonce' + 'strict-dynamic' fully gate.
+ */
+export function buildSecurityHeaders(nonce: string): Record<string, string> {
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join('; ');
+
+  return {
+    'Content-Security-Policy': csp,
+    'Strict-Transport-Security': 'max-age=63072000; includeSubDomains',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  };
+}

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -26,6 +26,7 @@ export function buildSecurityHeaders(nonce: string): Record<string, string> {
     'X-Content-Type-Options': 'nosniff',
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'strict-origin-when-cross-origin',
-    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+    'Permissions-Policy':
+      'camera=(), microphone=(), geolocation=(), interest-cohort=()',
   };
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,8 +2,32 @@ import {
   bouncesSignedInToDashboard,
   isPublicPath,
 } from '@/components/AppShell/publicPaths';
+import { buildSecurityHeaders } from '@/lib/security/headers';
 import { getSessionCookie } from '@naeemba/next-starter/proxy';
 import { type NextRequest, NextResponse } from 'next/server';
+
+function withSecurityHeaders(req: NextRequest): NextResponse {
+  // Per-request nonce (Web Crypto + btoa are available in the Edge runtime).
+  const nonce = btoa(crypto.randomUUID());
+  const headers = buildSecurityHeaders(nonce);
+
+  // Forward the nonce + CSP on the request so Next threads the nonce into its
+  // own bootstrap <script> tags.
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set(
+    'Content-Security-Policy',
+    headers['Content-Security-Policy']
+  );
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+
+  // Emit all security headers on the response.
+  for (const [key, value] of Object.entries(headers)) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
 
 export function proxy(req: NextRequest) {
   // Public paths are reachable without a session. A subset (the marketing
@@ -25,7 +49,7 @@ export function proxy(req: NextRequest) {
       target.search = '';
       return NextResponse.redirect(target);
     }
-    return NextResponse.next();
+    return withSecurityHeaders(req);
   }
 
   if (!getSessionCookie(req)) {
@@ -38,7 +62,7 @@ export function proxy(req: NextRequest) {
     );
     return NextResponse.redirect(target);
   }
-  return NextResponse.next();
+  return withSecurityHeaders(req);
 }
 
 // Run on every request except:

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,3 +1,4 @@
+import { isAuthPath } from '@/components/AppShell/authPaths';
 import {
   bouncesSignedInToDashboard,
   isPublicPath,
@@ -30,6 +31,15 @@ function withSecurityHeaders(req: NextRequest): NextResponse {
 }
 
 export function proxy(req: NextRequest) {
+  // Auth pages (sign-in / sign-up) are reachable regardless of session and must
+  // NOT trigger the no-session redirect (that would loop on /sign-in). They were
+  // previously excluded from the matcher entirely; now they pass through so they
+  // receive security headers (notably X-Frame-Options / frame-ancestors against
+  // clickjacking of the credential forms).
+  if (isAuthPath(req.nextUrl.pathname)) {
+    return withSecurityHeaders(req);
+  }
+
   // Public paths are reachable without a session. A subset (the marketing
   // landing at `/`) also bounces signed-in visitors to their dashboard via a
   // cheap cookie check (no DB), since logged-in users have no use for it.
@@ -66,16 +76,17 @@ export function proxy(req: NextRequest) {
 }
 
 // Run on every request except:
-//   /sign-in and /sign-in/error  — the auth UI itself
-//   /sign-up                     — open registration; must be reachable without
-//                                  a session, or new users get bounced to /sign-in
 //   /api/auth/*                  — better-auth's own handlers
 //   _next/* internals, favicon, static assets
+// /sign-in, /sign-in/error, and /sign-up now pass through (removed from the
+// negative-lookahead) so they receive security headers (X-Frame-Options, CSP
+// frame-ancestors) against clickjacking. The isAuthPath branch at the top of
+// proxy() short-circuits them before the no-session redirect, so there is no
+// redirect loop.
 // The public landing at `/` still passes through the matcher but is short-
-// circuited above via isPublicPath/PUBLIC_PATHS, so it renders without a
-// session.
+// circuited via isPublicPath/PUBLIC_PATHS, so it renders without a session.
 export const config = {
   matcher: [
-    '/((?!sign-in|sign-up|api/auth|_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
+    '/((?!api/auth|_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
   ],
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -30,6 +30,20 @@ function withSecurityHeaders(req: NextRequest): NextResponse {
   return response;
 }
 
+/**
+ * Attaches the security-header baseline to a redirect so 3xx responses carry the
+ * same CSP/HSTS/X-Frame-Options set as rendered pages. A fresh nonce is minted
+ * for completeness even though a redirect has no body to apply it to.
+ */
+function redirectWithSecurityHeaders(target: URL): NextResponse {
+  const response = NextResponse.redirect(target);
+  const nonce = btoa(crypto.randomUUID());
+  for (const [key, value] of Object.entries(buildSecurityHeaders(nonce))) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
 export function proxy(req: NextRequest) {
   // Auth pages (sign-in / sign-up) are reachable regardless of session and must
   // NOT trigger the no-session redirect (that would loop on /sign-in). They were
@@ -57,7 +71,7 @@ export function proxy(req: NextRequest) {
       const target = req.nextUrl.clone();
       target.pathname = '/dashboard';
       target.search = '';
-      return NextResponse.redirect(target);
+      return redirectWithSecurityHeaders(target);
     }
     return withSecurityHeaders(req);
   }
@@ -70,7 +84,7 @@ export function proxy(req: NextRequest) {
       'callbackUrl',
       req.nextUrl.pathname + req.nextUrl.search
     );
-    return NextResponse.redirect(target);
+    return redirectWithSecurityHeaders(target);
   }
   return withSecurityHeaders(req);
 }


### PR DESCRIPTION
## Phase 7 — Multi-user hardening: rate limiting, CSP/security headers, per-user quota

Closes three open Phase 7 items now that the app is genuinely multi-user (open registration + self-service account deletion). Spec: `docs/superpowers/specs/2026-06-25-phase7-hardening-design.md`; plan: `docs/superpowers/plans/2026-06-25-phase7-hardening.md`.

### 1. Rate limiting (`lib/rate-limit/`)
- In-memory fixed-window limiter behind a one-method store interface (swappable for Redis/Postgres later), keyed per-user (every guarded surface is authenticated).
- Applied to `POST /api/upload` (**HTTP 429 + `Retry-After`**) and all 11 authenticated mutating server actions (transactions, templates, saved-views, saved base-currency, account-deletion request/verify).
- Guards sit **after** `requireUser()` (unauth → still 401) and **before** side effects; each returns a value that's already a member of that action's existing result union — no UI/type changes.
- Out of scope (already covered): auth endpoints (better-auth built-in), account-deletion email-code throttle (existing DB throttle), price refresh (daily server-side cap), anonymous currency-cookie toggles.

### 2. CSP + security headers (`proxy.ts`, `lib/security/headers.ts`)
- Strict **nonce-based CSP** emitted from the Next.js 16 `proxy.ts`: `script-src` is nonce + `strict-dynamic` (no `unsafe-inline`); `style-src 'unsafe-inline'` is the only inline allowance (Recharts/Base-UI inline `style=`). Plus HSTS, `X-Frame-Options: DENY`/`frame-ancestors 'none'`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`.
- Per-request nonce threaded onto request headers (so Next nonces its bootstrap scripts) and the full set onto the response; existing better-auth routing preserved.
- **Auth pages fix (folded in):** `/sign-in`, `/sign-in/error`, `/sign-up` now pass through the proxy via an `isAuthPath` early-return, so the credential forms get clickjacking protection without a redirect loop.

### 3. Per-user quota (`lib/journal/quota.ts`)
- `JOURNAL_QUOTA_MB` (default 100) enforced centrally in `JournalService`: imports are rejected **before** the journal dir is wiped (`replaceFromZip` checks extracted bytes before the lock; `replaceFromSingleFile` before `resetLocalJournal`), and `addTransaction` checks before append — the snapshot/verify/rollback/push flow is untouched. Mapped to **HTTP 413** in both upload branches.

### Verification
- **438 tests pass** (88 files; +13 new), type-check + lint clean.
- New unit tests: rate-limit store, `buildSecurityHeaders`, quota helper, quota enforcement.
- Final whole-branch review (Opus): **Ready to merge — 0 Critical, 0 Important.** Remaining findings cosmetic.

### ⚠️ Before merge — manual browser smoke (needs a configured env)
The strict nonce CSP couldn't be verified in-browser from the CI/worktree (no `DATABASE_URL`/Postgres there). Please run `pnpm dev` and confirm no CSP violations break Recharts charts, the Cmd+K palette / dialogs (Base-UI), or sonner toasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
