### PR TITLE
Encrypted journals P2: client crypto, gated wizard, unlock, migration

### DIFF
--- a/app/api/crypto/material/route.test.ts
+++ b/app/api/crypto/material/route.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './route';
+
+const getMock = vi.fn();
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice' })),
+}));
+vi.mock('@/lib/crypto', () => ({
+  getUserCryptoRepository: () => ({ get: getMock }),
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/crypto/material', () => {
+  it('returns the opaque material when set up', async () => {
+    getMock.mockResolvedValue({
+      passSalt: 's',
+      argonParams: { m: 1, t: 1, p: 1 },
+      wrapPassphrase: 'wp',
+      wrapRecovery: 'wr',
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      passSalt: 's',
+      argonParams: { m: 1, t: 1, p: 1 },
+      wrapPassphrase: 'wp',
+      wrapRecovery: 'wr',
+    });
+  });
+  it('404s when not set up', async () => {
+    getMock.mockResolvedValue(null);
+    expect((await GET()).status).toBe(404);
+  });
+});

--- a/app/api/crypto/material/route.ts
+++ b/app/api/crypto/material/route.ts
@@ -1,0 +1,21 @@
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { NextResponse } from 'next/server';
+
+export async function GET(): Promise<NextResponse> {
+  const user = await requireUser();
+  const row = await getUserCryptoRepository().get(user.id);
+  if (!row) {
+    return NextResponse.json(
+      { error: 'Encryption is not set up.' },
+      { status: 404 }
+    );
+  }
+  // All four are opaque without the user's secret.
+  return NextResponse.json({
+    passSalt: row.passSalt,
+    argonParams: row.argonParams,
+    wrapPassphrase: row.wrapPassphrase,
+    wrapRecovery: row.wrapRecovery,
+  });
+}

--- a/app/api/crypto/material/route.ts
+++ b/app/api/crypto/material/route.ts
@@ -1,5 +1,6 @@
 import { requireUser } from '@/lib/auth/require-user';
 import { getUserCryptoRepository } from '@/lib/crypto';
+import type { CryptoMaterial } from '@/lib/crypto/setupSchema';
 import { NextResponse } from 'next/server';
 
 export async function GET(): Promise<NextResponse> {
@@ -12,10 +13,11 @@ export async function GET(): Promise<NextResponse> {
     );
   }
   // All four are opaque without the user's secret.
-  return NextResponse.json({
+  const material: CryptoMaterial = {
     passSalt: row.passSalt,
     argonParams: row.argonParams,
     wrapPassphrase: row.wrapPassphrase,
     wrapRecovery: row.wrapRecovery,
-  });
+  };
+  return NextResponse.json(material);
 }

--- a/app/crypto/setup/page.tsx
+++ b/app/crypto/setup/page.tsx
@@ -1,0 +1,7 @@
+import { SetupWizard } from '@/features/crypto/SetupWizard';
+import { requireUser } from '@/lib/auth/require-user';
+
+export default async function Page() {
+  await requireUser();
+  return <SetupWizard />;
+}

--- a/app/crypto/setup/page.tsx
+++ b/app/crypto/setup/page.tsx
@@ -1,7 +1,15 @@
 import { SetupWizard } from '@/features/crypto/SetupWizard';
 import { requireUser } from '@/lib/auth/require-user';
+import { cryptoStatus } from '@/lib/crypto/gate';
+import { redirect } from 'next/navigation';
 
 export default async function Page() {
-  await requireUser();
+  const user = await requireUser();
+  // If a userCrypto row already exists (e.g. a prior setup attempt wrote the
+  // row but the page was reloaded), don't re-enter the wizard — setupCrypto
+  // would reject with "already set up" and wedge the user. Route them to
+  // unlock instead. The CryptoGate no-ops on /crypto/* paths, so this page
+  // owns the redirect for already-set-up users.
+  if ((await cryptoStatus(user.id)) !== 'unset') redirect('/crypto/unlock');
   return <SetupWizard />;
 }

--- a/app/crypto/unlock/page.tsx
+++ b/app/crypto/unlock/page.tsx
@@ -1,0 +1,7 @@
+import { UnlockScreen } from '@/features/crypto/UnlockScreen';
+import { requireUser } from '@/lib/auth/require-user';
+
+export default async function Page() {
+  await requireUser();
+  return <UnlockScreen />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import AppShell from '@/components/AppShell';
 import BaseCurrencyBanner from '@/components/BaseCurrencyBanner';
 import { BaseCurrencyPickerSlot } from '@/components/BaseCurrencyPicker';
+import { CryptoGate } from '@/components/crypto/CryptoGate';
 import { APP_NAME } from '@/lib/app';
 import { cn } from '@/lib/utils';
 import { Geist } from 'next/font/google';
@@ -22,6 +23,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn('font-sans', geist.variable)}>
       <body>
+        <CryptoGate />
         <AppShell
           headerSlot={<BaseCurrencyPickerSlot />}
           bannerSlot={<BaseCurrencyBanner />}

--- a/components/AppShell/AppShell.tsx
+++ b/components/AppShell/AppShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { isAuthPath } from './authPaths';
+import { isCryptoPath } from './cryptoPaths';
 import { isPublicPath } from './publicPaths';
 import CommandPalette, {
   CommandPaletteProvider,
@@ -23,7 +24,7 @@ type Props = {
 
 const AppShell = ({ children, headerSlot, bannerSlot }: Props) => {
   const pathname = usePathname();
-  const isAuthPage = isAuthPath(pathname);
+  const isBare = isAuthPath(pathname) || isCryptoPath(pathname);
 
   // Public marketing pages own their own full-bleed chrome — no sidebar,
   // header, or app-only banners. Centralized in publicPaths.ts (tested) so the
@@ -32,11 +33,9 @@ const AppShell = ({ children, headerSlot, bannerSlot }: Props) => {
     return <>{children}</>;
   }
 
-  // Auth pages own their own full-bleed chrome — AuthScreen renders its own
-  // <main> split layout, so the shell must not wrap it in a width-clamped
-  // container (the old starter centered-card wrapper squished the split into a
-  // narrow column and nested <main> inside <main>).
-  if (isAuthPage) {
+  // Auth and crypto pages own their own full-bleed chrome — they render their
+  // own layouts and must not be wrapped in the app sidebar/header chrome.
+  if (isBare) {
     return (
       <TooltipProvider>
         {children}

--- a/components/AppShell/cryptoPaths.ts
+++ b/components/AppShell/cryptoPaths.ts
@@ -1,0 +1,3 @@
+export const CRYPTO_PATHS = new Set(['/crypto/setup', '/crypto/unlock']);
+export const isCryptoPath = (pathname: string): boolean =>
+  CRYPTO_PATHS.has(pathname);

--- a/components/Header/AppHeader.tsx
+++ b/components/Header/AppHeader.tsx
@@ -23,6 +23,7 @@ import {
   NavigationMenuTrigger,
 } from '@/components/ui/navigation-menu';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { LockButton } from '@/features/crypto/LockButton';
 import { authClient } from '@/lib/auth-client';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -37,6 +38,8 @@ const AppHeader = ({ slot }: Props) => {
   const userInitial = (user?.email?.[0] ?? 'U').toUpperCase();
 
   const signOut = async () => {
+    // Drop DEK before signing out (best-effort; ignore failure)
+    await fetch('/api/crypto/lock', { method: 'POST' }).catch(() => {});
     await authClient.signOut();
     router.push('/sign-in');
     router.refresh();
@@ -114,6 +117,7 @@ const AppHeader = ({ slot }: Props) => {
               <DropdownMenuItem render={<Link href="/settings" />}>
                 <SettingsIcon /> Settings
               </DropdownMenuItem>
+              <LockButton />
               <DropdownMenuItem onClick={signOut}>
                 <LogOutIcon /> Sign out
               </DropdownMenuItem>

--- a/components/crypto/CryptoGate.tsx
+++ b/components/crypto/CryptoGate.tsx
@@ -1,0 +1,28 @@
+import { isAuthPath } from '@/components/AppShell/authPaths';
+import { isCryptoPath } from '@/components/AppShell/cryptoPaths';
+import { isPublicPath } from '@/components/AppShell/publicPaths';
+import { getOptionalUser } from '@/lib/auth/require-user';
+import { cryptoStatus } from '@/lib/crypto/gate';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+/** Server gate: routes set-up-incomplete users to /crypto/setup and locked
+ * users to /crypto/unlock. No-op on auth/public/crypto paths. Correctness is
+ * still backstopped by LockedError at the data layer. */
+export async function CryptoGate() {
+  const pathname = (await headers()).get('x-pathname') ?? '';
+  if (
+    !pathname ||
+    isAuthPath(pathname) ||
+    isPublicPath(pathname) ||
+    isCryptoPath(pathname)
+  ) {
+    return null;
+  }
+  const user = await getOptionalUser();
+  if (!user) return null; // proxy already redirects unauthenticated users
+  const status = await cryptoStatus(user.id);
+  if (status === 'unset') redirect('/crypto/setup');
+  if (status === 'locked') redirect('/crypto/unlock');
+  return null;
+}

--- a/db/migrations/0003_thankful_tag.sql
+++ b/db/migrations/0003_thankful_tag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "userCrypto" ADD COLUMN "migratedAt" timestamp;

--- a/db/migrations/meta/0003_snapshot.json
+++ b/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,512 @@
+{
+  "id": "76bc8ac3-0bd3-4a3d-87a2-e19560a0a6d6",
+  "prevId": "bd413888-6e81-4843-9547-40254dce6a87",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accountDeletionChallenge": {
+      "name": "accountDeletionChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accountDeletionChallenge_userId_user_id_fk": {
+          "name": "accountDeletionChallenge_userId_user_id_fk",
+          "tableFrom": "accountDeletionChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commodity_price": {
+      "name": "commodity_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_date": {
+          "name": "fetched_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commodity_price_unique_per_day": {
+          "name": "commodity_price_unique_per_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol",
+            "quote",
+            "fetched_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_fetch_run": {
+      "name": "price_fetch_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbols_fetched": {
+          "name": "symbols_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "symbols_failed": {
+          "name": "symbols_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savedView": {
+      "name": "savedView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPath": {
+          "name": "targetPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "savedView_user_name": {
+          "name": "savedView_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savedView_userId_user_id_fk": {
+          "name": "savedView_userId_user_id_fk",
+          "tableFrom": "savedView",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_user_name": {
+          "name": "template_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_userId_user_id_fk": {
+          "name": "template_userId_user_id_fk",
+          "tableFrom": "template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userCrypto": {
+      "name": "userCrypto",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wrapPassphrase": {
+          "name": "wrapPassphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passSalt": {
+          "name": "passSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argonParams": {
+          "name": "argonParams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapRecovery": {
+          "name": "wrapRecovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recoveryCreatedAt": {
+          "name": "recoveryCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kdfVersion": {
+          "name": "kdfVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "migratedAt": {
+          "name": "migratedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userCrypto_userId_user_id_fk": {
+          "name": "userCrypto_userId_user_id_fk",
+          "tableFrom": "userCrypto",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "baseCurrency": {
+          "name": "baseCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journalMain": {
+          "name": "journalMain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main.ledger'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSetting_userId_user_id_fk": {
+          "name": "userSetting_userId_user_id_fk",
+          "tableFrom": "userSetting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782380043515,
       "tag": "0002_living_shooting_star",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782391793514,
+      "tag": "0003_thankful_tag",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/userCrypto.ts
+++ b/db/schema/userCrypto.ts
@@ -18,6 +18,11 @@ export const userCrypto = pgTable('userCrypto', {
     .notNull()
     .default(sql`now()`),
   kdfVersion: integer('kdfVersion').notNull().default(1),
+  // Set once the bulk journal migration (enableEncryption) has completed for
+  // this user. Lets the unlock-time reconcile short-circuit without a full
+  // pull+push for the common already-migrated case; null means a prior setup
+  // wrote the row but never finished migrating the journal at rest.
+  migratedAt: timestamp('migratedAt'),
   createdAt: timestamp('createdAt')
     .notNull()
     .default(sql`now()`),

--- a/docs/superpowers/plans/2026-06-25-encrypted-journals-p2.md
+++ b/docs/superpowers/plans/2026-06-25-encrypted-journals-p2.md
@@ -1,0 +1,861 @@
+# Encrypted Journals — P2: Wizard, Unlock, Client Crypto & Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. UI tasks (8–10) additionally pair with superpowers' frontend-design guidance and the existing `au-*` design system.
+
+**Goal:** Make zero-knowledge encryption real and usable: a gated onboarding **wizard** that generates the DEK client-side, sets a passphrase + recovery code, and migrates the existing plaintext journal to ciphertext; a per-session **unlock** screen; a **Lock** control; and the **server gate** that routes users into setup/unlock.
+
+**Architecture:** All secret handling is **client-side** (WebCrypto + `hash-wasm` Argon2id). The browser generates a 32-byte DEK, derives KEKs from the passphrase (Argon2id) and a one-time recovery code (HKDF), AES-GCM-wraps the DEK under each KEK, and uploads only the opaque wrap blobs (P1's `userCrypto` table). The raw DEK is POSTed to P1's `/api/crypto/unlock` (in-RAM, session-scoped) so the server can run `ledger`. Migration re-encrypts the existing plaintext journal under `withUserLock` using the in-RAM DEK. A server gate (proxy forwards `x-pathname`; a root-layout server check reads it) redirects un-set-up users to `/crypto/setup` and locked users to `/crypto/unlock`; the data layer's `LockedError` (P1) is the hard correctness backstop.
+
+**Tech Stack:** TypeScript, Next.js 16 app router, WebCrypto (AES-256-GCM, HKDF-SHA256), `hash-wasm` (Argon2id, WASM bundled inline — no bundler config needed), Drizzle + Postgres, Vitest. UI in the `au-*` editorial design system (`features/auth/auth.css`, Fraunces + JetBrains Mono).
+
+## Global Constraints
+
+- **Zero-knowledge:** the passphrase and recovery code NEVER leave the browser. Only opaque wrap blobs + salts + Argon2 params are uploaded; only the raw DEK (over TLS) reaches the server, held in RAM for the session. Never log secrets, the DEK, or wraps.
+- **DEK:** 32 random bytes from `crypto.getRandomValues`. Generated once at setup; never changes (changing passphrase / rotating recovery / adding passkey only re-wraps it).
+- **Passphrase KEK:** `Argon2id(passphrase, passSalt, params)` → 32 bytes, used directly as the AES-256-GCM wrapping key. Start params `{ m: 65536 /* KiB = 64 MiB */, t: 3, p: 1 }`, `hashLength: 32`. `passSalt` = 16 random bytes (base64).
+- **Recovery KEK:** `HKDF-SHA256(recoveryBytes, salt=empty, info="ledger-recovery-v1")` → AES-256-GCM key. Recovery code = 256 random bits shown once as grouped Base32 (Crockford-free standard RFC 4648 Base32, grouped `XXXX-XXXX-…`).
+- **Wrap blob format (client-owned, opaque to server):** `base64( nonce(12) ‖ AES-GCM-ciphertext-with-tag )`. WebCrypto appends the 16-byte tag to the ciphertext automatically.
+- **`userCrypto` columns (P1, do not change):** `wrapPassphrase`, `passSalt`, `argonParams {m,t,p}`, `wrapRecovery`, `recoveryCreatedAt`, `kdfVersion` (=1), timestamps. No recovery salt column — recovery HKDF uses an empty salt + fixed info (the recovery code is full-entropy).
+- **Migration** re-encrypts every journal file under `withUserLock`, idempotent via P1's `isCiphertext` (`LEJ1` magic). Requires the in-RAM DEK; throws `LockedError` if absent.
+- **Gate must not touch `/crypto/*`, auth paths, or public paths.** `/crypto/setup` and `/crypto/unlock` render chrome-free (like auth pages).
+- **Reuse P1 verbatim:** `DEK_BYTES` from `@/lib/crypto/constants`; `getUserCryptoRepository()` from `@/lib/crypto`; `getSessionDek`/`dropSessionDek`/`LockedError` from `@/lib/crypto/sessionKeys`; `encryptFile`/`isCiphertext` from `@/lib/crypto/fileCrypto`; `decodeDek` contract of `/api/crypto/unlock`.
+- **Test command:** `pnpm test`. **Type-check:** `pnpm type-check`. Pre-commit husky runs type-check + lint-staged; commitlint requires lowercase commit subjects (use the `feat(...)` / `chore(...)` messages given per task).
+
+---
+
+## File Structure
+
+**Create — client crypto & shared schema:**
+- `features/crypto/lib/clientCrypto.ts` — pure browser crypto: `generateDek`, `derivePassphraseKek`, `wrapDek`, `unwrapDek`, `recoveryHkdfKey`, `generateRecoveryCode`, `parseRecoveryCode`, base64/Base32 helpers.
+- `lib/crypto/setupSchema.ts` — Zod schema for the setup payload (shared by the action). Pure, server-importable.
+
+**Create — server actions / routes:**
+- `features/crypto/actions/setupCrypto.ts` — `'use server'`: validate payload, `userCryptoRepository.create`, reject if already set up.
+- `features/crypto/actions/finalizeEncryption.ts` — `'use server'`: call `journalService.enableEncryption(userId)` after the DEK is unlocked.
+- `app/api/crypto/material/route.ts` — `GET`: return the current user's `{ passSalt, argonParams, wrapPassphrase, wrapRecovery }` (opaque; useless without the secret) for unlock.
+
+**Create — gate:**
+- `lib/crypto/gate.ts` — `cryptoStatus(userId)` → `'unset' | 'locked' | 'ready'`; `isCryptoPath(pathname)`.
+- `components/crypto/CryptoGate.tsx` — server component rendered in the root layout; reads `x-pathname`, redirects.
+- `components/AppShell/cryptoPaths.ts` — `CRYPTO_PATHS` (`/crypto/setup`, `/crypto/unlock`), `isCryptoPath`.
+
+**Create — UI:**
+- `app/crypto/setup/page.tsx`, `app/crypto/unlock/page.tsx` — chrome-free route pages.
+- `features/crypto/SetupWizard.tsx` (+ step subcomponents `StepWhy`, `StepPassphrase`, `StepRecovery`, `StepEncrypting`), `features/crypto/UnlockScreen.tsx`, `features/crypto/LockButton.tsx`, `features/crypto/cryptoCopy.ts`.
+
+**Modify:**
+- `lib/journal/service.ts` — add `enableEncryption(userId)`.
+- `proxy.ts` — forward `x-pathname` request header.
+- `app/layout.tsx` — render `<CryptoGate/>` (server) for the gate.
+- `components/AppShell/AppShell.tsx` + `authPaths`/`publicPaths` usage — treat `/crypto/*` as chrome-free.
+- `lib/auth-client.ts` or the sign-out call site — drop the DEK on sign-out (POST `/api/crypto/lock`).
+- `package.json` / `next.config` — add `hash-wasm`.
+
+---
+
+## Task 1: Add `hash-wasm` + verify WASM bundling
+
+**Files:** Modify `package.json` (+ lockfile); possibly `next.config.js`.
+
+- [ ] **Step 1:** `pnpm add hash-wasm` (it embeds its WASM as inline base64 — no webpack/turbopack config is required; confirm by the build in Step 3).
+- [ ] **Step 2:** Write a throwaway node check that imports `argon2id` from `hash-wasm` and hashes a constant, to confirm the dep resolves: `pnpm exec node -e "import('hash-wasm').then(m=>m.argon2id({password:'x',salt:new Uint8Array(16),parallelism:1,iterations:2,memorySize:512,hashLength:32,outputType:'binary'})).then(h=>console.log('ok',h.length))"` → expect `ok 32`.
+- [ ] **Step 3:** `pnpm build` (or `pnpm dev` smoke) to confirm no WASM bundling error surfaces. If a turbopack WASM error appears, add to `next.config.js`: `nextConfig.webpack = (c)=>{ c.experiments={...c.experiments, asyncWebAssembly:true}; return c; }` and note it; otherwise leave config untouched.
+- [ ] **Step 4: Commit** `git add package.json pnpm-lock.yaml next.config.js 2>/dev/null; git commit -m "chore(crypto): add hash-wasm for client-side argon2id"`
+
+---
+
+## Task 2: Client crypto library (`features/crypto/lib/clientCrypto.ts`)
+
+**Files:** Create `features/crypto/lib/clientCrypto.ts`, `features/crypto/lib/clientCrypto.test.ts`.
+
+**Interfaces — Produces:**
+- `generateDek(): Uint8Array` (32 bytes)
+- `derivePassphraseKek(passphrase: string, salt: Uint8Array, params: {m:number;t:number;p:number}): Promise<CryptoKey>` (AES-GCM key)
+- `recoveryHkdfKey(recovery: Uint8Array): Promise<CryptoKey>` (AES-GCM key via HKDF)
+- `wrapDek(dek: Uint8Array, kek: CryptoKey): Promise<string>` (base64 `nonce‖ct+tag`)
+- `unwrapDek(wrapB64: string, kek: CryptoKey): Promise<Uint8Array>`
+- `generateRecoveryCode(): { code: string; bytes: Uint8Array }` (grouped Base32)
+- `parseRecoveryCode(code: string): Uint8Array`
+- `toBase64(b: Uint8Array): string`, `fromBase64(s: string): Uint8Array`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// features/crypto/lib/clientCrypto.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  derivePassphraseKek,
+  generateDek,
+  generateRecoveryCode,
+  parseRecoveryCode,
+  recoveryHkdfKey,
+  unwrapDek,
+  wrapDek,
+} from './clientCrypto';
+
+const PARAMS = { m: 512, t: 2, p: 1 }; // small for test speed
+
+describe('clientCrypto', () => {
+  it('generates a 32-byte DEK', () => {
+    expect(generateDek().length).toBe(32);
+  });
+
+  it('passphrase wrap/unwrap round-trips and is deterministic for same salt+params', async () => {
+    const dek = generateDek();
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const kek1 = await derivePassphraseKek('correct horse', salt, PARAMS);
+    const wrap = await wrapDek(dek, kek1);
+    const kek2 = await derivePassphraseKek('correct horse', salt, PARAMS);
+    const out = await unwrapDek(wrap, kek2);
+    expect([...out]).toEqual([...dek]);
+  });
+
+  it('wrong passphrase fails to unwrap', async () => {
+    const dek = generateDek();
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const wrap = await wrapDek(dek, await derivePassphraseKek('right', salt, PARAMS));
+    const wrongKek = await derivePassphraseKek('wrong', salt, PARAMS);
+    await expect(unwrapDek(wrap, wrongKek)).rejects.toBeTruthy();
+  });
+
+  it('recovery code round-trips and unwraps the DEK', async () => {
+    const dek = generateDek();
+    const { code, bytes } = generateRecoveryCode();
+    expect(parseRecoveryCode(code)).toEqual(bytes);
+    const wrap = await wrapDek(dek, await recoveryHkdfKey(bytes));
+    const out = await unwrapDek(wrap, await recoveryHkdfKey(parseRecoveryCode(code)));
+    expect([...out]).toEqual([...dek]);
+  });
+
+  it('recovery code is grouped Base32 of 256 bits', () => {
+    const { code, bytes } = generateRecoveryCode();
+    expect(bytes.length).toBe(32);
+    expect(code).toMatch(/^[A-Z2-7]{4}(-[A-Z2-7]{4})+$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** `pnpm test features/crypto/lib/clientCrypto.test.ts` (module not found).
+
+- [ ] **Step 3: Implement**
+
+```ts
+// features/crypto/lib/clientCrypto.ts
+import { argon2id } from 'hash-wasm';
+
+const GCM_NONCE = 12;
+const RECOVERY_INFO = new TextEncoder().encode('ledger-recovery-v1');
+
+export const toBase64 = (b: Uint8Array): string =>
+  btoa(String.fromCharCode(...b));
+export const fromBase64 = (s: string): Uint8Array =>
+  Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+
+export const generateDek = (): Uint8Array =>
+  crypto.getRandomValues(new Uint8Array(32));
+
+export const derivePassphraseKek = async (
+  passphrase: string,
+  salt: Uint8Array,
+  params: { m: number; t: number; p: number }
+): Promise<CryptoKey> => {
+  const raw = await argon2id({
+    password: passphrase,
+    salt,
+    parallelism: params.p,
+    iterations: params.t,
+    memorySize: params.m, // KiB
+    hashLength: 32,
+    outputType: 'binary',
+  });
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', false, [
+    'encrypt',
+    'decrypt',
+  ]);
+};
+
+export const recoveryHkdfKey = async (
+  recovery: Uint8Array
+): Promise<CryptoKey> => {
+  const base = await crypto.subtle.importKey('raw', recovery, 'HKDF', false, [
+    'deriveKey',
+  ]);
+  return crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: RECOVERY_INFO },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+};
+
+export const wrapDek = async (
+  dek: Uint8Array,
+  kek: CryptoKey
+): Promise<string> => {
+  const iv = crypto.getRandomValues(new Uint8Array(GCM_NONCE));
+  const ct = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, kek, dek)
+  );
+  const blob = new Uint8Array(iv.length + ct.length);
+  blob.set(iv, 0);
+  blob.set(ct, iv.length);
+  return toBase64(blob);
+};
+
+export const unwrapDek = async (
+  wrapB64: string,
+  kek: CryptoKey
+): Promise<Uint8Array> => {
+  const blob = fromBase64(wrapB64);
+  const iv = blob.subarray(0, GCM_NONCE);
+  const ct = blob.subarray(GCM_NONCE);
+  return new Uint8Array(
+    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, kek, ct)
+  );
+};
+
+// RFC 4648 Base32, grouped XXXX-XXXX for readability.
+const B32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const base32Encode = (bytes: Uint8Array): string => {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const b of bytes) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) {
+      out += B32[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += B32[(value << (5 - bits)) & 31];
+  return out;
+};
+const base32Decode = (s: string): Uint8Array => {
+  const clean = s.replace(/-/g, '').toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of clean) {
+    const idx = B32.indexOf(ch);
+    if (idx < 0) throw new Error('Invalid recovery code character');
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Uint8Array.from(out);
+};
+
+export const generateRecoveryCode = (): { code: string; bytes: Uint8Array } => {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  const raw = base32Encode(bytes); // 52 chars for 256 bits
+  const code = (raw.match(/.{1,4}/g) ?? []).join('-');
+  return { code, bytes };
+};
+
+export const parseRecoveryCode = (code: string): Uint8Array =>
+  base32Decode(code).subarray(0, 32);
+```
+
+- [ ] **Step 4: Run — expect PASS** `pnpm test features/crypto/lib/clientCrypto.test.ts`. (Vitest `environment: 'node'` provides WebCrypto via Node's global `crypto`. If `crypto.subtle` is undefined in the test env, add `// @vitest-environment jsdom` at the top of the test file or import `webcrypto` — report which was needed.)
+
+- [ ] **Step 5: Commit** `git add features/crypto/lib/clientCrypto.ts features/crypto/lib/clientCrypto.test.ts && git commit -m "feat(crypto): client-side dek/kek/wrap + recovery code module"`
+
+---
+
+## Task 3: Setup payload schema + `setupCrypto` server action
+
+**Files:** Create `lib/crypto/setupSchema.ts`, `features/crypto/actions/setupCrypto.ts`, `features/crypto/actions/setupCrypto.test.ts`.
+
+**Interfaces:**
+- Consumes: `getUserCryptoRepository()` (P1), `requireUser`.
+- Produces: `setupCryptoSchema` (Zod); `setupCrypto(input): Promise<{ ok: true } | { ok: false; error: string }>`.
+
+- [ ] **Step 1: Write the schema**
+
+```ts
+// lib/crypto/setupSchema.ts
+import { z } from 'zod';
+
+const b64 = z.string().min(1).max(2000);
+export const setupCryptoSchema = z.object({
+  wrapPassphrase: b64,
+  passSalt: b64,
+  argonParams: z.object({
+    m: z.number().int().positive(),
+    t: z.number().int().positive(),
+    p: z.number().int().positive(),
+  }),
+  wrapRecovery: b64,
+});
+export type SetupCryptoInput = z.infer<typeof setupCryptoSchema>;
+```
+
+- [ ] **Step 2: Write the failing test** (uses setupTestDb to verify the row is created and double-setup is rejected)
+
+```ts
+// features/crypto/actions/setupCrypto.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserCryptoRepository } from '@/lib/crypto';
+import { setupTestDb, teardownTestDb, type TestDbContext } from '@/lib/test-utils/db';
+
+const repoHolder: { repo: UserCryptoRepository | null } = { repo: null };
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice' })),
+}));
+vi.mock('@/lib/crypto', async (orig) => ({
+  ...(await orig<typeof import('@/lib/crypto')>()),
+  getUserCryptoRepository: () => repoHolder.repo,
+}));
+
+import { setupCrypto } from './setupCrypto';
+
+const VALID = {
+  wrapPassphrase: 'd2FwUA==',
+  passSalt: 'c2FsdA==',
+  argonParams: { m: 65536, t: 3, p: 1 },
+  wrapRecovery: 'd2FwUg==',
+};
+
+describe('setupCrypto', () => {
+  let ctx: TestDbContext;
+  beforeEach(async () => {
+    ctx = await setupTestDb('setup-crypto-');
+    await ctx.insertUser('alice');
+    repoHolder.repo = new UserCryptoRepository(ctx.db);
+  });
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.clearAllMocks();
+  });
+
+  it('creates the userCrypto row', async () => {
+    const res = await setupCrypto(VALID);
+    expect(res.ok).toBe(true);
+    expect(await repoHolder.repo!.exists('alice')).toBe(true);
+  });
+
+  it('rejects a second setup', async () => {
+    await setupCrypto(VALID);
+    const res = await setupCrypto(VALID);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a malformed payload', async () => {
+    const res = await setupCrypto({ ...VALID, argonParams: { m: -1, t: 3, p: 1 } });
+    expect(res.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect FAIL** `pnpm test features/crypto/actions/setupCrypto.test.ts`.
+
+- [ ] **Step 4: Implement**
+
+```ts
+// features/crypto/actions/setupCrypto.ts
+'use server';
+
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { setupCryptoSchema } from '@/lib/crypto/setupSchema';
+
+type Result = { ok: true } | { ok: false; error: string };
+
+export async function setupCrypto(input: unknown): Promise<Result> {
+  const user = await requireUser();
+  const parsed = setupCryptoSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: 'Invalid setup payload' };
+
+  const repo = getUserCryptoRepository();
+  if (await repo.exists(user.id)) {
+    return { ok: false, error: 'Encryption is already set up' };
+  }
+  await repo.create({
+    userId: user.id,
+    wrapPassphrase: parsed.data.wrapPassphrase,
+    passSalt: parsed.data.passSalt,
+    argonParams: parsed.data.argonParams,
+    wrapRecovery: parsed.data.wrapRecovery,
+  });
+  return { ok: true };
+}
+```
+
+- [ ] **Step 5: Run — expect PASS**, then **Commit** `git add lib/crypto/setupSchema.ts features/crypto/actions/setupCrypto.ts features/crypto/actions/setupCrypto.test.ts && git commit -m "feat(crypto): setupCrypto action stores client-created wraps"`
+
+---
+
+## Task 4: `JournalService.enableEncryption` (migration)
+
+**Files:** Modify `lib/journal/service.ts`; create `lib/journal/service.enableEncryption.test.ts` (or extend the existing service test file — match the repo's convention; if `service.test.ts` exists, add a `describe` there).
+
+**Interfaces:**
+- Consumes: `withUserLock`, `pull`, `push`, `getJournalDir`, `listLocalRelPaths`, `getSessionDek`/`LockedError`, `encryptFile`/`isCiphertext`.
+- Produces: `enableEncryption(userId: string): Promise<{ encrypted: number; alreadyCiphertext: number }>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/journal/service.enableEncryption.test.ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomBytes } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isCiphertext } from '@/lib/crypto/fileCrypto';
+import { LockedError, __resetSessionKeysForTest, setSessionDek } from '@/lib/crypto/sessionKeys';
+import { getJournalDir } from '@/lib/journal/layout';
+import { journalService } from '@/lib/journal';
+import { MemoryObjectStore } from '@/lib/storage/memoryObjectStore';
+import { resetObjectStore, getObjectStore } from '@/lib/storage';
+import { keyFor } from '@/lib/storage/manifest';
+import { setupTestDb, teardownTestDb, type TestDbContext } from '@/lib/test-utils/db';
+
+// NOTE: confirm the exact helpers to force a MemoryObjectStore in tests
+// (resetObjectStore + STORAGE_BACKEND=memory). Mirror an existing storage test's setup.
+
+describe('JournalService.enableEncryption', () => {
+  let ctx: TestDbContext;
+  beforeEach(async () => {
+    ctx = await setupTestDb('enable-enc-');
+    await ctx.insertUser('alice');
+    resetObjectStore();
+  });
+  afterEach(async () => {
+    __resetSessionKeysForTest();
+    await teardownTestDb(ctx);
+  });
+
+  it('re-encrypts existing plaintext files and is idempotent', async () => {
+    const userId = 'alice';
+    const dir = getJournalDir(userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), '2026/01/01 Opening\n  Assets:Cash  $10\n');
+
+    setSessionDek(userId, randomBytes(32));
+    const r1 = await journalService.enableEncryption(userId);
+    expect(r1.encrypted).toBe(1);
+
+    const remote = await getObjectStore().get(keyFor(userId, 'main.ledger'));
+    expect(isCiphertext(remote.body)).toBe(true);
+
+    // idempotent: pulling decrypts to plaintext locally; re-running re-encrypts the same content
+    const r2 = await journalService.enableEncryption(userId);
+    expect(r2.encrypted + r2.alreadyCiphertext).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws LockedError when no session DEK', async () => {
+    const dir = getJournalDir('alice');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), 'x');
+    await expect(journalService.enableEncryption('alice')).rejects.toBeInstanceOf(LockedError);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.** (If the singleton `journalService` can't reach the test DB, the implementer should mirror however the existing `service.test.ts` exercises the singleton — note it in the report. `enableEncryption` itself does NOT touch the DB, so this should be clean.)
+
+- [ ] **Step 3: Implement** — add to `JournalService`:
+
+```ts
+async enableEncryption(
+  userId: string
+): Promise<{ encrypted: number; alreadyCiphertext: number }> {
+  return withUserLock(userId, async () => {
+    const dek = getSessionDek(userId);
+    if (!dek) throw new LockedError();
+    await pull(userId); // bring canonical down (decrypts any already-ciphertext)
+    const dir = getJournalDir(userId);
+    let encrypted = 0;
+    let alreadyCiphertext = 0;
+    for (const rel of await listLocalRelPaths(dir)) {
+      const abs = path.join(dir, rel);
+      const body = await fs.readFile(abs);
+      if (isCiphertext(body)) {
+        alreadyCiphertext++;
+        continue;
+      }
+      await fs.writeFile(abs, encryptFile(dek, rel, body));
+      encrypted++;
+    }
+    await push(userId); // re-encrypts on the seam too (DEK present) — uploads ciphertext
+    return { encrypted, alreadyCiphertext };
+  });
+}
+```
+
+Add the necessary imports at the top of `service.ts` (`encryptFile`, `isCiphertext` from `@/lib/crypto/fileCrypto`; `getSessionDek`, `LockedError` from `@/lib/crypto/sessionKeys`; `listLocalRelPaths` from `@/lib/storage/manifest` if not already imported; `pull`/`push` are already used).
+
+> **Design note for the implementer/reviewer:** with the DEK present, P1's `push` seam would itself encrypt plaintext. Writing ciphertext to the local file *before* `push` is intentional belt-and-suspenders so the on-disk working copy is also ciphertext at rest the moment migration completes, and so `alreadyCiphertext` accounting is meaningful on re-run. Both layers produce identical envelopes; the double pass is correct, not redundant encryption of ciphertext (the `isCiphertext` guard prevents re-wrapping).
+
+- [ ] **Step 4: Run — expect PASS**, then **Commit** `git add lib/journal/service.ts lib/journal/service.enableEncryption.test.ts && git commit -m "feat(crypto): JournalService.enableEncryption migrates plaintext journal"`
+
+---
+
+## Task 5: `GET /api/crypto/material` (unlock material) + `finalizeEncryption` action
+
+**Files:** Create `app/api/crypto/material/route.ts`, `app/api/crypto/material/route.test.ts`, `features/crypto/actions/finalizeEncryption.ts`.
+
+**Interfaces:**
+- `GET /api/crypto/material` → 200 `{ passSalt, argonParams, wrapPassphrase, wrapRecovery }` or 404 if not set up.
+- `finalizeEncryption(): Promise<{ ok: boolean; error?: string }>` — server action wrapping `journalService.enableEncryption(user.id)` (DEK must already be unlocked).
+
+- [ ] **Step 1: Write the material route**
+
+```ts
+// app/api/crypto/material/route.ts
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { NextResponse } from 'next/server';
+
+export async function GET(): Promise<NextResponse> {
+  const user = await requireUser();
+  const row = await getUserCryptoRepository().get(user.id);
+  if (!row) {
+    return NextResponse.json({ error: 'Encryption is not set up.' }, { status: 404 });
+  }
+  // All four are opaque without the user's secret.
+  return NextResponse.json({
+    passSalt: row.passSalt,
+    argonParams: row.argonParams,
+    wrapPassphrase: row.wrapPassphrase,
+    wrapRecovery: row.wrapRecovery,
+  });
+}
+```
+
+- [ ] **Step 2: Test the material route** (mock `requireUser` + `getUserCryptoRepository`, assert 200 shape and 404). Mirror the P1 `app/api/crypto/unlock/route.test.ts` mock style.
+
+```ts
+// app/api/crypto/material/route.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+const getMock = vi.fn();
+vi.mock('@/lib/auth/require-user', () => ({ requireUser: vi.fn(async () => ({ id: 'alice' })) }));
+vi.mock('@/lib/crypto', () => ({ getUserCryptoRepository: () => ({ get: getMock }) }));
+import { GET } from './route';
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/crypto/material', () => {
+  it('returns the opaque material when set up', async () => {
+    getMock.mockResolvedValue({ passSalt: 's', argonParams: { m: 1, t: 1, p: 1 }, wrapPassphrase: 'wp', wrapRecovery: 'wr' });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ passSalt: 's', argonParams: { m: 1, t: 1, p: 1 }, wrapPassphrase: 'wp', wrapRecovery: 'wr' });
+  });
+  it('404s when not set up', async () => {
+    getMock.mockResolvedValue(null);
+    expect((await GET()).status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 3: finalizeEncryption action**
+
+```ts
+// features/crypto/actions/finalizeEncryption.ts
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { LockedError } from '@/lib/crypto/sessionKeys';
+
+export async function finalizeEncryption(): Promise<{ ok: boolean; error?: string }> {
+  const user = await requireUser();
+  try {
+    await journalService.enableEncryption(user.id);
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof LockedError) return { ok: false, error: 'Session is locked; unlock and retry.' };
+    console.error('finalizeEncryption failed', e);
+    return { ok: false, error: 'Could not encrypt your journal. Please retry.' };
+  }
+}
+```
+
+- [ ] **Step 4: Run material test — expect PASS**, then **Commit** `git add app/api/crypto/material features/crypto/actions/finalizeEncryption.ts && git commit -m "feat(crypto): unlock-material route + finalizeEncryption action"`
+
+---
+
+## Task 6: The server gate (proxy header + root-layout check)
+
+**Files:** Modify `proxy.ts`, `app/layout.tsx`; create `lib/crypto/gate.ts`, `components/AppShell/cryptoPaths.ts`, `components/crypto/CryptoGate.tsx`, `lib/crypto/gate.test.ts`.
+
+**Interfaces:**
+- `cryptoStatus(userId): Promise<'unset' | 'locked' | 'ready'>` (`unset` = no userCrypto row; `locked` = row exists but no session DEK; `ready` = DEK in RAM).
+- `isCryptoPath(pathname): boolean`.
+- `<CryptoGate/>` server component: reads `x-pathname` from `headers()`, and for a gated path redirects.
+
+- [ ] **Step 1: `cryptoPaths.ts`**
+
+```ts
+// components/AppShell/cryptoPaths.ts
+export const CRYPTO_PATHS = new Set(['/crypto/setup', '/crypto/unlock']);
+export const isCryptoPath = (pathname: string): boolean =>
+  CRYPTO_PATHS.has(pathname);
+```
+
+- [ ] **Step 2: `gate.ts` + unit test**
+
+```ts
+// lib/crypto/gate.ts
+import 'server-only';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { hasSessionDek } from '@/lib/crypto/sessionKeys';
+
+export type CryptoStatus = 'unset' | 'locked' | 'ready';
+
+export const cryptoStatus = async (userId: string): Promise<CryptoStatus> => {
+  if (!(await getUserCryptoRepository().exists(userId))) return 'unset';
+  return hasSessionDek(userId) ? 'ready' : 'locked';
+};
+```
+
+```ts
+// lib/crypto/gate.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { __resetSessionKeysForTest, setSessionDek } from '@/lib/crypto/sessionKeys';
+import { randomBytes } from 'crypto';
+const existsMock = vi.fn();
+vi.mock('@/lib/crypto', () => ({ getUserCryptoRepository: () => ({ exists: existsMock }) }));
+import { cryptoStatus } from './gate';
+afterEach(() => { __resetSessionKeysForTest(); vi.clearAllMocks(); });
+
+describe('cryptoStatus', () => {
+  it('unset when no row', async () => { existsMock.mockResolvedValue(false); expect(await cryptoStatus('a')).toBe('unset'); });
+  it('locked when row but no DEK', async () => { existsMock.mockResolvedValue(true); expect(await cryptoStatus('a')).toBe('locked'); });
+  it('ready when row and DEK', async () => { existsMock.mockResolvedValue(true); setSessionDek('a', randomBytes(32)); expect(await cryptoStatus('a')).toBe('ready'); });
+});
+```
+
+- [ ] **Step 3: proxy forwards `x-pathname`** — in `proxy.ts` `withSecurityHeaders`, add to the `requestHeaders` block: `requestHeaders.set('x-pathname', req.nextUrl.pathname);` so server components can read the path.
+
+- [ ] **Step 4: `CryptoGate` server component**
+
+```tsx
+// components/crypto/CryptoGate.tsx
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { isAuthPath } from '@/components/AppShell/authPaths';
+import { isPublicPath } from '@/components/AppShell/publicPaths';
+import { isCryptoPath } from '@/components/AppShell/cryptoPaths';
+import { getOptionalUser } from '@/lib/auth/require-user';
+import { cryptoStatus } from '@/lib/crypto/gate';
+
+/** Server gate: routes set-up-incomplete users to /crypto/setup and locked
+ * users to /crypto/unlock. No-op on auth/public/crypto paths. Correctness is
+ * still backstopped by LockedError at the data layer. */
+export async function CryptoGate() {
+  const pathname = (await headers()).get('x-pathname') ?? '';
+  if (!pathname || isAuthPath(pathname) || isPublicPath(pathname) || isCryptoPath(pathname)) {
+    return null;
+  }
+  const user = await getOptionalUser();
+  if (!user) return null; // proxy already redirects unauthenticated users
+  const status = await cryptoStatus(user.id);
+  if (status === 'unset') redirect('/crypto/setup');
+  if (status === 'locked') redirect('/crypto/unlock');
+  return null;
+}
+```
+
+- [ ] **Step 5: Render the gate** — in `app/layout.tsx`, render `<CryptoGate />` near the top of `<body>` (it returns `null` or redirects; it must be inside the server layout so `redirect()` works). Keep it above `<AppShell>`.
+
+- [ ] **Step 6: `/crypto/*` chrome-free** — ensure `AppShell` treats `/crypto/setup` and `/crypto/unlock` like auth pages (chrome-free). Modify `AppShell.tsx`: `const isBare = isAuthPath(pathname) || isCryptoPath(pathname);` and use `isBare` where it currently uses `isAuthPage` for the minimal-wrapper branch.
+
+- [ ] **Step 7: Run gate unit test — expect PASS.** Type-check. **Commit** `git add proxy.ts app/layout.tsx lib/crypto/gate.ts lib/crypto/gate.test.ts components/AppShell/cryptoPaths.ts components/crypto/CryptoGate.tsx components/AppShell/AppShell.tsx && git commit -m "feat(crypto): server gate routes users to setup/unlock"`
+
+> **Reviewer note:** the root-layout gate fires on hard loads, not soft client navigations (root layout persists). That's acceptable: post-sign-in landing is a hard navigation, and `LockedError` backstops any soft-nav edge case. Do not add per-page gating.
+
+---
+
+## Task 7: `cryptoCopy.ts` + unlock orchestration hook
+
+**Files:** Create `features/crypto/cryptoCopy.ts` (all wizard/unlock strings), `features/crypto/lib/unlockFlow.ts` (+ test) — the client orchestration that the UI calls.
+
+**Interfaces (`unlockFlow.ts`):**
+- `unlockWithPassphrase(passphrase: string): Promise<void>` — fetch material → derive KEK → unwrap DEK → POST `/api/crypto/unlock` → throws on failure.
+- `unlockWithRecovery(code: string): Promise<void>` — same via recovery wrap.
+- `postDek(dek: Uint8Array): Promise<void>` — POST base64 DEK to `/api/crypto/unlock` (409/400 → throw friendly error).
+- `lock(): Promise<void>` — POST `/api/crypto/lock`.
+
+- [ ] **Step 1:** Implement `cryptoCopy.ts` — plain-language strings for: why-encryption explainer (3–4 sentences matching the spec's framing), passphrase step (label, helper, strength hint), recovery step (warning that it's shown once), encrypting step, unlock screen, errors. Keep voice consistent with `features/auth/authCopy.ts`.
+
+- [ ] **Step 2:** Implement `unlockFlow.ts` using `clientCrypto`:
+
+```ts
+// features/crypto/lib/unlockFlow.ts
+import {
+  derivePassphraseKek,
+  parseRecoveryCode,
+  recoveryHkdfKey,
+  toBase64,
+  unwrapDek,
+  fromBase64,
+} from './clientCrypto';
+
+type Material = {
+  passSalt: string;
+  argonParams: { m: number; t: number; p: number };
+  wrapPassphrase: string;
+  wrapRecovery: string;
+};
+
+const getMaterial = async (): Promise<Material> => {
+  const res = await fetch('/api/crypto/material');
+  if (!res.ok) throw new Error('Encryption is not set up.');
+  return res.json();
+};
+
+export const postDek = async (dek: Uint8Array): Promise<void> => {
+  const res = await fetch('/api/crypto/unlock', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dek: toBase64(dek) }),
+  });
+  if (!res.ok) {
+    const { error } = await res.json().catch(() => ({ error: 'Unlock failed' }));
+    throw new Error(error ?? 'Unlock failed');
+  }
+};
+
+export const unlockWithPassphrase = async (passphrase: string): Promise<void> => {
+  const m = await getMaterial();
+  const kek = await derivePassphraseKek(passphrase, fromBase64(m.passSalt), m.argonParams);
+  const dek = await unwrapDek(m.wrapPassphrase, kek).catch(() => {
+    throw new Error('Incorrect passphrase.');
+  });
+  await postDek(dek);
+};
+
+export const unlockWithRecovery = async (code: string): Promise<void> => {
+  const m = await getMaterial();
+  const kek = await recoveryHkdfKey(parseRecoveryCode(code));
+  const dek = await unwrapDek(m.wrapRecovery, kek).catch(() => {
+    throw new Error('Incorrect recovery code.');
+  });
+  await postDek(dek);
+};
+
+export const lock = async (): Promise<void> => {
+  await fetch('/api/crypto/lock', { method: 'POST' });
+};
+```
+
+- [ ] **Step 3:** Test `unlockFlow.ts` by mocking `fetch` (assert it derives + posts the DEK on the happy path, and surfaces "Incorrect passphrase." when the wrap doesn't match). Use a real `clientCrypto` round-trip to build the material fixture so the test exercises actual unwrap.
+
+- [ ] **Step 4: Commit** `git add features/crypto/cryptoCopy.ts features/crypto/lib/unlockFlow.ts features/crypto/lib/unlockFlow.test.ts && git commit -m "feat(crypto): unlock/lock client orchestration + copy"`
+
+---
+
+## Task 8: Unlock screen UI (`/crypto/unlock`)
+
+**Files:** Create `app/crypto/unlock/page.tsx`, `features/crypto/UnlockScreen.tsx`.
+
+**This is a design task — pair with superpowers' frontend-design guidance and match `features/auth/AuthScreen.tsx`.** The logic is fixed; the visual must live in the `au-*` system.
+
+- [ ] **Step 1:** `app/crypto/unlock/page.tsx` — a server page that `requireUser()`s and renders `<UnlockScreen/>`. Chrome-free (the gate + AppShell `isCryptoPath` handle that).
+- [ ] **Step 2:** `UnlockScreen.tsx` (`'use client'`):
+  - **Logic (fixed):** passphrase field → on submit call `unlockWithPassphrase` → on success `window.location.assign(callbackUrl ?? '/dashboard')` (hard nav so the gate re-evaluates as `ready`). A "Use recovery code instead" toggle swaps to a recovery-code field calling `unlockWithRecovery`. Disable inputs while in-flight; show errors via `au-error`.
+  - **Design (acceptance):** reuse the `AuthScreen` two-column shell (`au`, `au-glow`, `au-layer`, `BrandPanel` or a crypto-specific editorial panel), `au-card`, `au-input`, `au-label`, `au-btn--primary`, `au-rise` entrance, Fraunces heading via `au-grad ff-display`. Visually indistinguishable in quality from sign-in. Heading/body from `cryptoCopy`.
+- [ ] **Step 3: Acceptance check** — `pnpm dev`, sign in as an encryption-enabled+locked user, confirm `/crypto/unlock` renders in the au-* style, a correct passphrase unlocks and lands on the app, a wrong one shows "Incorrect passphrase.", and the recovery-code path works. (Manual; note results in the report. Add a light component test if feasible, but the manual au-* visual check is the gate.)
+- [ ] **Step 4: Commit** `git add app/crypto/unlock features/crypto/UnlockScreen.tsx && git commit -m "feat(crypto): per-session unlock screen (au-* design)"`
+
+---
+
+## Task 9: Setup wizard UI (`/crypto/setup`)
+
+**Files:** Create `app/crypto/setup/page.tsx`, `features/crypto/SetupWizard.tsx` (+ step subcomponents).
+
+**Design task — pair with frontend-design; match `AuthScreen`.** Multi-step, fixed orchestration:
+
+- [ ] **Step 1:** `app/crypto/setup/page.tsx` — server page, `requireUser()`, renders `<SetupWizard/>`. Chrome-free.
+- [ ] **Step 2:** `SetupWizard.tsx` (`'use client'`) — a 4-step state machine in the `au-*` shell:
+  1. **Why** — `cryptoCopy` explainer + "Get started" (`au-btn--primary`).
+  2. **Passphrase** — passphrase + confirm (`au-input`), client-side match + min-length check, strength hint.
+  3. **Recovery code** — on entering this step, run the **setup orchestration** (below); display the generated recovery code grouped (`au-card`, `ff-mono`, copy + download buttons), require an "I've saved it" checkbox before continuing.
+  4. **Encrypting** — call `finalizeEncryption()`; show progress/spinner; on success `window.location.assign('/dashboard')` (hard nav → gate sees `ready`).
+- [ ] **Step 3: Setup orchestration (fixed logic, runs between steps 2→3):**
+
+```ts
+// inside SetupWizard (client), on advancing from passphrase to recovery step:
+import { generateDek, derivePassphraseKek, wrapDek, recoveryHkdfKey, generateRecoveryCode, toBase64 } from '@/features/crypto/lib/clientCrypto';
+import { postDek } from '@/features/crypto/lib/unlockFlow';
+import { setupCrypto } from '@/features/crypto/actions/setupCrypto';
+
+const ARGON = { m: 65536, t: 3, p: 1 };
+
+async function runSetup(passphrase: string): Promise<string> {
+  const dek = generateDek();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const { code, bytes } = generateRecoveryCode();
+  const wrapPassphrase = await wrapDek(dek, await derivePassphraseKek(passphrase, salt, ARGON));
+  const wrapRecovery = await wrapDek(dek, await recoveryHkdfKey(bytes));
+
+  const res = await setupCrypto({
+    wrapPassphrase, passSalt: toBase64(salt), argonParams: ARGON, wrapRecovery,
+  });
+  if (!res.ok) throw new Error(res.error);
+
+  await postDek(dek); // unlock this session so migration can run
+  return code; // show once
+}
+// Step 4 then calls finalizeEncryption() to migrate.
+```
+
+  Hold `dek`/`code` only in component state; never persist. After step 4 success, drop them (component unmounts on navigation).
+- [ ] **Step 4: Acceptance check** — `pnpm dev` as a fresh (un-set-up) user: signing in redirects to `/crypto/setup`; the wizard walks Why → passphrase → recovery (code shown once, copy/download work, gated by the checkbox) → encrypting; afterward the journal reports still render (now backed by ciphertext in Garage); the recovery code and passphrase each unlock a fresh session. Confirm the au-* visual quality matches sign-in. Note results in the report.
+- [ ] **Step 5: Commit** `git add app/crypto/setup features/crypto/SetupWizard.tsx features/crypto/Step*.tsx 2>/dev/null && git commit -m "feat(crypto): gated onboarding wizard with journal migration (au-* design)"`
+
+---
+
+## Task 10: Lock control + drop DEK on sign-out
+
+**Files:** Create `features/crypto/LockButton.tsx`; modify the header/user-menu to include it (e.g. `components/Header/AppHeader.tsx` user `DropdownMenu`); modify the sign-out call site (`lib/auth-client.ts` consumers or wherever `signOut` is invoked) to POST `/api/crypto/lock` first.
+
+- [ ] **Step 1:** `LockButton.tsx` (`'use client'`) — calls `lock()` from `unlockFlow`, then `window.location.assign('/crypto/unlock')`. Style as a small ghost button / dropdown item consistent with the header.
+- [ ] **Step 2:** Place it in the user `DropdownMenu` in `AppHeader` (near sign-out). Only meaningful for encryption-enabled users — render it unconditionally is fine (a locked/unset user simply won't reach the app chrome).
+- [ ] **Step 3:** On sign-out, drop the DEK: wrap the existing `signOut` call so it `await fetch('/api/crypto/lock', { method: 'POST' })` (best-effort, ignore failure) before signing out. Find the current sign-out invocation (header dropdown) and adjust.
+- [ ] **Step 4: Acceptance check** — `pnpm dev`: Lock drops to `/crypto/unlock` and the app then requires re-unlock; sign-out + sign-in requires re-unlock (DEK dropped). Note in report.
+- [ ] **Step 5: Commit** `git add features/crypto/LockButton.tsx components/Header/AppHeader.tsx lib/auth-client.ts 2>/dev/null && git commit -m "feat(crypto): manual Lock control + drop DEK on sign-out"`
+
+---
+
+## Task 11: Full-suite + end-to-end verification
+
+**Files:** none (verification + any fixups).
+
+- [ ] **Step 1:** `pnpm test` — full suite green (existing 467 + new crypto tests). `pnpm type-check` clean. `pnpm lint` clean.
+- [ ] **Step 2:** End-to-end manual smoke in `pnpm dev` with a real Postgres + `STORAGE_BACKEND` configured: fresh user → forced setup → wizard → migration → reports render → Lock → unlock (passphrase) → Lock → unlock (recovery) → sign-out → sign-in → unlock. Confirm Garage/local files are ciphertext (`LEJ1`) at rest and the app behaves identically to before once unlocked.
+- [ ] **Step 3:** Confirm a NOT-yet-migrated user (no `userCrypto`) is redirected to setup and cannot reach app pages; confirm an unauthenticated user still goes to `/sign-in` (proxy unchanged).
+- [ ] **Step 4: Commit** any fixups with appropriate `fix(crypto): …` messages.
+
+---
+
+## Out of scope for P2 (later)
+
+- **P3:** Settings → Security (change passphrase, rotate recovery code, reset encryption).
+- **Fast-follow:** passkey-PRF unlock (`passkeyPrfWrap` table + WebAuthn PRF).
+- Deferred P1 Minors still open: add a 32-byte guard in `fileCrypto`; freeze the exported `MAGIC`. Fold these in during P2 if a crypto task touches `fileCrypto`; otherwise carry to P3.
+
+## Self-Review
+
+**Spec coverage (P2 slice of `2026-06-25-encrypted-journals-v2-design.md`):**
+- Client-side DEK gen + Argon2id passphrase KEK + recovery-code HKDF + AES-GCM wrap/unwrap → Task 2. ✓
+- Setup stores only opaque wraps (zero-knowledge) → Task 3. ✓
+- Plaintext→ciphertext migration, idempotent → Task 4. ✓
+- Unlock material + finalize → Task 5. ✓
+- Gated routing (setup/unlock), data-layer backstop → Task 6. ✓
+- Unlock orchestration + copy → Task 7. ✓
+- Per-session unlock screen (au-*) → Task 8. ✓
+- Gated onboarding wizard (Why → passphrase → recovery → encrypt), au-* design matching sign-in → Task 9. ✓
+- Manual Lock + drop-on-sign-out → Task 10. ✓
+- Recovery code shown once, copy/download, gated continue → Task 9 step 2/3. ✓
+
+**Placeholder scan:** UI Tasks 8–9 intentionally specify fixed orchestration code + exact copy source + au-* acceptance rather than dictating full JSX (beautiful UI is iterative; implementer pairs with frontend-design). All logic/crypto/server/gate tasks carry complete code. No TBDs.
+
+**Type consistency:** `generateDek`/`derivePassphraseKek`/`wrapDek`/`unwrapDek`/`recoveryHkdfKey`/`generateRecoveryCode`/`parseRecoveryCode`/`toBase64`/`fromBase64` (Task 2) consumed by Tasks 7 & 9; `setupCrypto` (Task 3) by Task 9; `enableEncryption` (Task 4) by `finalizeEncryption` (Task 5) by Task 9; `cryptoStatus`/`isCryptoPath` (Task 6) by the gate; `unlockWithPassphrase`/`unlockWithRecovery`/`postDek`/`lock` (Task 7) by Tasks 8/9/10. P1 imports (`DEK_BYTES`, `getUserCryptoRepository`, `getSessionDek`/`hasSessionDek`/`dropSessionDek`/`LockedError`, `encryptFile`/`isCiphertext`, `decodeDek` contract) referenced as they exist on `main`. ✓
+
+**Known verification points for implementers (flagged, not placeholders):** (a) whether Vitest `node` env exposes `crypto.subtle` or the client-crypto test needs `jsdom` — Task 2 Step 4; (b) how the `journalService` singleton reaches the test DB / MemoryObjectStore in Task 4 — mirror the existing `service.test.ts`; (c) whether `hash-wasm` needs any turbopack WASM flag — Task 1 Step 3.

--- a/features/crypto/LockButton.tsx
+++ b/features/crypto/LockButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { LockIcon } from 'lucide-react';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { lock } from '@/features/crypto/lib/unlockFlow';
+
+export const LockButton = () => {
+  const handleLock = async () => {
+    await lock();
+    window.location.assign('/crypto/unlock');
+  };
+
+  return (
+    <DropdownMenuItem onClick={handleLock}>
+      <LockIcon /> Lock vault
+    </DropdownMenuItem>
+  );
+};

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -488,7 +488,9 @@ function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
     const a = document.createElement('a');
     a.href = url;
     a.download = 'ledger-recovery-code.txt';
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
   }
 
@@ -664,12 +666,20 @@ export function SetupWizard() {
   const [step, setStep] = useState<Step>('why');
   const [recoveryCode, setRecoveryCode] = useState<string | null>(null);
   const [fatalError, setFatalError] = useState<string | null>(null);
+  const [fatalRetryStep, setFatalRetryStep] = useState<Step>('passphrase');
 
   // Advance from passphrase → recovery: runs the full orchestration.
   async function handlePassphraseNext(passphrase: string) {
-    const code = await runSetup(passphrase);
-    setRecoveryCode(code);
-    setStep('recovery');
+    try {
+      const code = await runSetup(passphrase);
+      setRecoveryCode(code);
+      setStep('recovery');
+    } catch (err) {
+      setFatalRetryStep('passphrase');
+      setFatalError(
+        err instanceof Error ? err.message : CRYPTO_COPY.errors.setupFailed
+      );
+    }
   }
 
   // Advance from recovery → encrypting: kick off finalization.
@@ -678,12 +688,14 @@ export function SetupWizard() {
     try {
       const result = await finalizeEncryption();
       if (!result.ok) {
+        setFatalRetryStep('recovery');
         setFatalError(result.error ?? CRYPTO_COPY.errors.setupFailed);
         return;
       }
       // Hard navigate so the session gate sees `ready`.
       window.location.assign('/dashboard');
     } catch (err) {
+      setFatalRetryStep('recovery');
       setFatalError(
         err instanceof Error ? err.message : CRYPTO_COPY.errors.generic
       );
@@ -743,7 +755,7 @@ export function SetupWizard() {
                     className="au-btn au-btn--ghost"
                     onClick={() => {
                       setFatalError(null);
-                      setStep('recovery');
+                      setStep(fatalRetryStep);
                     }}
                   >
                     Retry

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -40,10 +40,14 @@ const mono = JetBrains_Mono({
 
 const ARGON = { m: 65536, t: 3, p: 1 } as const;
 
-// Fixed setup orchestration — runs exactly once on advancing from step 2 → 3.
-// Generates DEK client-side, derives both wrapping keys, posts to server,
-// unlocks the session, and returns the one-time recovery code.
-async function runSetup(passphrase: string): Promise<string> {
+// Fixed setup orchestration — runs on advancing from step 2 → 3.
+// Generates DEK client-side, derives both wrapping keys, and persists the
+// wrapped keys server-side. Returns the raw DEK and the one-time recovery code
+// so the caller can surface the code immediately and unlock the session
+// separately — a failure to unlock must not discard the recovery secret.
+async function runSetup(
+  passphrase: string
+): Promise<{ dek: Uint8Array; code: string }> {
   const dek = generateDek();
   const salt = crypto.getRandomValues(new Uint8Array(16));
   const { code, bytes } = generateRecoveryCode();
@@ -59,8 +63,7 @@ async function runSetup(passphrase: string): Promise<string> {
     wrapRecovery,
   });
   if (!res.ok) throw new Error(res.error);
-  await postDek(dek); // unlock this session so migration can run
-  return code;
+  return { dek, code };
 }
 
 type Step = 'why' | 'passphrase' | 'recovery' | 'encrypting';
@@ -667,11 +670,18 @@ export function SetupWizard() {
   const [recoveryCode, setRecoveryCode] = useState<string | null>(null);
   const [fatalError, setFatalError] = useState<string | null>(null);
   const [fatalRetryStep, setFatalRetryStep] = useState<Step>('passphrase');
+  // Held in memory so a transient unlock failure can be retried at finalize
+  // time without re-running setupCrypto (which would now reject with
+  // "already set up" and orphan the displayed recovery code).
+  const dekRef = useRef<Uint8Array | null>(null);
 
-  // Advance from passphrase → recovery: runs the full orchestration.
+  // Advance from passphrase → recovery: persists the wrapped keys, then
+  // surfaces the recovery code. The session unlock (postDek) is deferred to
+  // finalize so a network blip here can never discard the one-time code.
   async function handlePassphraseNext(passphrase: string) {
     try {
-      const code = await runSetup(passphrase);
+      const { dek, code } = await runSetup(passphrase);
+      dekRef.current = dek;
       setRecoveryCode(code);
       setStep('recovery');
     } catch (err) {
@@ -682,10 +692,19 @@ export function SetupWizard() {
     }
   }
 
-  // Advance from recovery → encrypting: kick off finalization.
+  // Advance from recovery → encrypting: unlock the session, then finalize.
+  // Both steps are idempotent and safe to re-run on "Retry".
   async function handleRecoveryNext() {
+    const dek = dekRef.current;
+    if (!dek) {
+      // Lost the in-memory DEK (e.g. a reload landed back here) — the row
+      // already exists, so route through the normal unlock flow instead.
+      window.location.assign('/crypto/unlock');
+      return;
+    }
     setStep('encrypting');
     try {
+      await postDek(dek); // unlock this session so migration can run
       const result = await finalizeEncryption();
       if (!result.ok) {
         setFatalRetryStep('recovery');

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -1,0 +1,767 @@
+'use client';
+
+import {
+  KeyRound,
+  Copy,
+  Download,
+  CheckCircle2,
+  Loader2,
+  ShieldCheck,
+} from 'lucide-react';
+import { type FormEvent, useState, useRef } from 'react';
+import '@/features/auth/auth.css';
+import { finalizeEncryption } from '@/features/crypto/actions/finalizeEncryption';
+import { setupCrypto } from '@/features/crypto/actions/setupCrypto';
+import { CRYPTO_COPY } from '@/features/crypto/cryptoCopy';
+import {
+  generateDek,
+  derivePassphraseKek,
+  wrapDek,
+  recoveryHkdfKey,
+  generateRecoveryCode,
+  toBase64,
+} from '@/features/crypto/lib/clientCrypto';
+import { postDek } from '@/features/crypto/lib/unlockFlow';
+import { APP_NAME } from '@/lib/app';
+import { Fraunces, JetBrains_Mono } from 'next/font/google';
+import Link from 'next/link';
+
+const display = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+  style: ['normal', 'italic'],
+});
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
+
+const ARGON = { m: 65536, t: 3, p: 1 } as const;
+
+// Fixed setup orchestration — runs exactly once on advancing from step 2 → 3.
+// Generates DEK client-side, derives both wrapping keys, posts to server,
+// unlocks the session, and returns the one-time recovery code.
+async function runSetup(passphrase: string): Promise<string> {
+  const dek = generateDek();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const { code, bytes } = generateRecoveryCode();
+  const wrapPassphrase = await wrapDek(
+    dek,
+    await derivePassphraseKek(passphrase, salt, ARGON)
+  );
+  const wrapRecovery = await wrapDek(dek, await recoveryHkdfKey(bytes));
+  const res = await setupCrypto({
+    wrapPassphrase,
+    passSalt: toBase64(salt),
+    argonParams: ARGON,
+    wrapRecovery,
+  });
+  if (!res.ok) throw new Error(res.error);
+  await postDek(dek); // unlock this session so migration can run
+  return code;
+}
+
+type Step = 'why' | 'passphrase' | 'recovery' | 'encrypting';
+
+// ── decorative bars (echoes CryptoBrandPanel in UnlockScreen) ──
+const LOCK_TICKS = [14, 22, 18, 28, 20, 32, 16, 26, 24, 30] as const;
+
+function SetupBrandPanel() {
+  return (
+    <aside className="relative hidden flex-col justify-between overflow-hidden border-r border-[var(--line-soft)] bg-[var(--ink-2)]/40 p-10 lg:flex lg:p-12">
+      {/* wordmark */}
+      <Link
+        href="/"
+        className="au-rise relative z-10 flex items-center gap-2.5"
+        style={{ ['--d' as string]: '0.05s' }}
+        aria-label={`${APP_NAME} home`}
+      >
+        <span className="au-mark ff-mono text-sm">L</span>
+        <span className="text-lg font-semibold tracking-tight">{APP_NAME}</span>
+      </Link>
+
+      {/* editorial centre */}
+      <div className="relative z-10 max-w-md space-y-8">
+        <span
+          className="au-rise au-chip ff-mono"
+          style={{ ['--d' as string]: '0.12s' }}
+        >
+          <span className="au-chip__dot" />
+          SETUP ENCRYPTION
+        </span>
+
+        <h2
+          className="au-rise ff-display text-[clamp(2.25rem,3.4vw,3.25rem)] leading-[1.04]"
+          style={{ ['--d' as string]: '0.2s' }}
+        >
+          Keep your finances private. Always.
+        </h2>
+
+        {/* mock terminal card */}
+        <div
+          className="au-rise au-card au-card--lit p-0"
+          style={{ ['--d' as string]: '0.3s' }}
+        >
+          <div className="flex items-center gap-2 border-b border-[var(--line)] px-4 py-2.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--red)]/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--gold)]/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--em)]/70" />
+            <span className="ff-mono ml-2 text-xs text-[color:var(--txt-faint)]">
+              journal.ledger
+            </span>
+            <ShieldCheck
+              className="ml-auto size-3.5 text-[color:var(--em)]"
+              aria-hidden
+            />
+          </div>
+          <div className="ff-mono px-5 py-4 text-[0.78rem] leading-relaxed">
+            <p className="text-[color:var(--txt-faint)]">
+              ; encrypting with AES-256-GCM
+            </p>
+            <p className="mt-1 text-[color:var(--gold)]">2026/06/25</p>
+            <p className="mt-0.5 text-[color:var(--txt-dim)]">
+              {'  '}Assets:Checking
+              {'   '}
+              <span className="text-[color:var(--em)]">$ 4,800.00</span>
+            </p>
+            <p className="mt-0.5 text-[color:var(--txt-dim)]">
+              {'  '}Income:Salary
+            </p>
+          </div>
+        </div>
+
+        {/* decorative bars */}
+        <div
+          className="au-rise au-bars"
+          style={{ ['--d' as string]: '0.38s' }}
+          aria-hidden
+        >
+          {LOCK_TICKS.map((h, i) => (
+            <span key={i} style={{ height: `${h}px` }} />
+          ))}
+        </div>
+      </div>
+
+      {/* feature ticks */}
+      <ul
+        className="au-rise relative z-10 space-y-2.5"
+        style={{ ['--d' as string]: '0.46s' }}
+      >
+        {(
+          [
+            'Client-side key generation',
+            'Zero-knowledge server',
+            'Passphrase + recovery code',
+          ] as const
+        ).map((f) => (
+          <li key={f} className="au-tick">
+            <KeyRound className="size-4" aria-hidden />
+            {f}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+// ── Step indicator ──────────────────────────────────────────────────────────
+
+const STEP_LABELS: Record<Step, string> = {
+  why: 'Why',
+  passphrase: 'Passphrase',
+  recovery: 'Recovery code',
+  encrypting: 'Encrypting',
+};
+const STEP_ORDER: Step[] = ['why', 'passphrase', 'recovery', 'encrypting'];
+
+function StepIndicator({ current }: { current: Step }) {
+  const currentIdx = STEP_ORDER.indexOf(current);
+  return (
+    <div className="flex items-center gap-1.5 mb-8" aria-label="Setup progress">
+      {STEP_ORDER.map((step, i) => {
+        const done = i < currentIdx;
+        const active = i === currentIdx;
+        return (
+          <div key={step} className="flex items-center gap-1.5">
+            <div
+              className="flex items-center justify-center rounded-full transition-all duration-300"
+              style={{
+                width: '1.4rem',
+                height: '1.4rem',
+                background: done
+                  ? 'var(--em)'
+                  : active
+                    ? 'linear-gradient(180deg, var(--em), var(--em-deep))'
+                    : 'var(--card)',
+                border: active || done ? 'none' : '1px solid var(--line)',
+                boxShadow: active
+                  ? '0 0 0 3px oklch(78% 0.15 165 / 0.2)'
+                  : 'none',
+              }}
+              aria-current={active ? 'step' : undefined}
+            >
+              {done ? (
+                <CheckCircle2
+                  className="size-3"
+                  style={{ color: 'oklch(20% 0.04 165)' }}
+                  aria-hidden
+                />
+              ) : (
+                <span
+                  className="ff-mono text-[0.6rem] font-bold"
+                  style={{
+                    color: active ? 'oklch(20% 0.04 165)' : 'var(--txt-faint)',
+                  }}
+                >
+                  {i + 1}
+                </span>
+              )}
+            </div>
+            {i < STEP_ORDER.length - 1 && (
+              <div
+                style={{
+                  width: '1.5rem',
+                  height: '1px',
+                  background: done ? 'var(--em)' : 'var(--line)',
+                  transition: 'background 0.3s ease',
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+      <span className="ml-2 text-xs text-[color:var(--txt-faint)] ff-mono">
+        {STEP_LABELS[current]}
+      </span>
+    </div>
+  );
+}
+
+// ── Step 1: Why ─────────────────────────────────────────────────────────────
+
+function WhyStep({ onNext }: { onNext: () => void }) {
+  const copy = CRYPTO_COPY.explainer;
+  return (
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)] leading-relaxed">
+          {copy.body}
+        </p>
+      </div>
+
+      <div className="au-card p-5 space-y-3">
+        {[
+          'Your DEK is generated in your browser — never sent to the server.',
+          'We store only the encrypted wrapped key, not your passphrase.',
+          'Recovery code is shown exactly once; save it before continuing.',
+        ].map((point) => (
+          <div key={point} className="flex items-start gap-3">
+            <span
+              className="mt-0.5 size-4 flex-none rounded-full flex items-center justify-center"
+              style={{
+                background: 'oklch(78% 0.15 165 / 0.15)',
+                border: '1px solid oklch(78% 0.15 165 / 0.3)',
+              }}
+            >
+              <span
+                className="block rounded-full"
+                style={{
+                  width: '0.35rem',
+                  height: '0.35rem',
+                  background: 'var(--em)',
+                }}
+              />
+            </span>
+            <p className="text-sm text-[color:var(--txt-dim)] leading-relaxed">
+              {point}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <button type="button" className="au-btn au-btn--primary" onClick={onNext}>
+        Get started
+      </button>
+    </div>
+  );
+}
+
+// ── Step 2: Passphrase ───────────────────────────────────────────────────────
+
+function strengthLabel(pass: string): { label: string; color: string } | null {
+  if (!pass) return null;
+  const len = pass.length;
+  const wordCount = pass.trim().split(/\s+/).filter(Boolean).length;
+  if (len < 8) return { label: 'Too short', color: 'oklch(72% 0.17 25)' };
+  if (len < 12 && wordCount < 3)
+    return { label: 'Weak', color: 'oklch(82% 0.14 55)' };
+  if (len < 16 && wordCount < 4) return { label: 'Fair', color: 'var(--gold)' };
+  if (len >= 16 || wordCount >= 4)
+    return { label: 'Strong', color: 'var(--em)' };
+  return null;
+}
+
+function PassphraseStep({
+  onNext,
+}: {
+  onNext: (pass: string) => Promise<void>;
+}) {
+  const copy = CRYPTO_COPY.passphrase;
+  const [pass, setPass] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const strength = strengthLabel(pass);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    if (pass.length < 8) {
+      setError('Passphrase must be at least 8 characters.');
+      return;
+    }
+    if (pass !== confirm) {
+      setError('Passphrases do not match.');
+      return;
+    }
+    setPending(true);
+    try {
+      await onNext(pass);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : CRYPTO_COPY.errors.setupFailed
+      );
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)]">
+          {copy.helper}
+        </p>
+      </div>
+
+      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+        <div>
+          <label className="au-label" htmlFor="setup-pass">
+            {copy.label}
+          </label>
+          <input
+            id="setup-pass"
+            className="au-input"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={pass}
+            onChange={(e) => setPass(e.target.value)}
+            placeholder="Enter a strong passphrase"
+            disabled={pending}
+            autoFocus
+          />
+          {/* strength hint */}
+          {strength && (
+            <div className="mt-2 flex items-center gap-2">
+              <div
+                className="h-1 flex-1 rounded-full overflow-hidden"
+                style={{ background: 'var(--line)' }}
+              >
+                <div
+                  className="h-full rounded-full transition-all duration-500"
+                  style={{
+                    width:
+                      strength.label === 'Too short'
+                        ? '20%'
+                        : strength.label === 'Weak'
+                          ? '40%'
+                          : strength.label === 'Fair'
+                            ? '65%'
+                            : '100%',
+                    background: strength.color,
+                  }}
+                />
+              </div>
+              <span
+                className="text-xs ff-mono"
+                style={{ color: strength.color, minWidth: '4rem' }}
+              >
+                {strength.label}
+              </span>
+            </div>
+          )}
+          <p className="mt-1.5 text-xs text-[color:var(--txt-faint)]">
+            {copy.strengthHint}
+          </p>
+        </div>
+
+        <div>
+          <label className="au-label" htmlFor="setup-confirm">
+            {copy.confirmLabel}
+          </label>
+          <input
+            id="setup-confirm"
+            className="au-input"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            placeholder="Confirm passphrase"
+            disabled={pending}
+          />
+          {confirm && pass !== confirm && (
+            <p
+              className="mt-1.5 text-xs"
+              style={{ color: 'oklch(72% 0.17 25)' }}
+            >
+              Passphrases do not match.
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          className="au-btn au-btn--primary"
+          disabled={pending || !pass || !confirm}
+        >
+          {pending ? (
+            <>
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              Setting up…
+            </>
+          ) : (
+            copy.submitLabel
+          )}
+        </button>
+
+        <p className="au-error" aria-live="polite" aria-atomic="true">
+          {error ?? ''}
+        </p>
+      </form>
+    </div>
+  );
+}
+
+// ── Step 3: Recovery code ────────────────────────────────────────────────────
+
+function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
+  const copy = CRYPTO_COPY.recovery;
+  const [copied, setCopied] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Format code into groups of 4 separated by dashes
+  const groups = code.split('-');
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      if (copyTimeout.current) clearTimeout(copyTimeout.current);
+      copyTimeout.current = setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // ignore clipboard errors — user can still copy manually
+    }
+  }
+
+  function handleDownload() {
+    const blob = new Blob(
+      [
+        `${APP_NAME} Recovery Code\n`,
+        `Generated: ${new Date().toISOString()}\n\n`,
+        code,
+        '\n\nStore this safely. This code is shown once and cannot be retrieved later.\n',
+      ],
+      { type: 'text/plain' }
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'ledger-recovery-code.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)]">
+          {copy.warning}
+        </p>
+      </div>
+
+      {/* recovery code display */}
+      <div
+        className="au-card p-5 space-y-4"
+        role="region"
+        aria-label="Recovery code"
+      >
+        <div className="flex flex-wrap gap-2 justify-center py-1">
+          {groups.map((group, i) => (
+            <span
+              key={i}
+              className="ff-mono select-all"
+              style={{
+                fontSize: '1.05rem',
+                letterSpacing: '0.12em',
+                color: 'var(--em)',
+                background: 'oklch(78% 0.15 165 / 0.08)',
+                border: '1px solid oklch(78% 0.15 165 / 0.2)',
+                borderRadius: '0.5rem',
+                padding: '0.35rem 0.6rem',
+                fontWeight: 600,
+              }}
+            >
+              {group}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="au-btn au-btn--ghost flex-1"
+            style={{ height: '2.5rem', fontSize: '0.85rem' }}
+            onClick={handleCopy}
+            aria-label="Copy recovery code to clipboard"
+          >
+            <Copy className="size-3.5" aria-hidden />
+            {copied ? copy.copiedLabel : copy.copyLabel}
+          </button>
+          <button
+            type="button"
+            className="au-btn au-btn--ghost flex-1"
+            style={{ height: '2.5rem', fontSize: '0.85rem' }}
+            onClick={handleDownload}
+            aria-label="Download recovery code as text file"
+          >
+            <Download className="size-3.5" aria-hidden />
+            Download
+          </button>
+        </div>
+      </div>
+
+      <p className="text-sm text-[color:var(--txt-faint)] leading-relaxed">
+        {copy.instruction}
+      </p>
+
+      {/* "I've saved it" gate */}
+      <label className="flex cursor-pointer items-start gap-3">
+        <input
+          type="checkbox"
+          checked={saved}
+          onChange={(e) => setSaved(e.target.checked)}
+          className="mt-0.5 size-4 cursor-pointer accent-[var(--em)]"
+          aria-label={copy.confirmPrompt}
+        />
+        <span className="text-sm text-[color:var(--txt-dim)] select-none">
+          {copy.confirmPrompt}
+        </span>
+      </label>
+
+      <button
+        type="button"
+        className="au-btn au-btn--primary"
+        disabled={!saved}
+        onClick={onNext}
+      >
+        {copy.submitLabel}
+      </button>
+    </div>
+  );
+}
+
+// ── Step 4: Encrypting ───────────────────────────────────────────────────────
+
+function EncryptingStep() {
+  const copy = CRYPTO_COPY.encrypting;
+  return (
+    <div className="flex flex-col items-center gap-8 py-4 text-center">
+      {/* animated shield */}
+      <div
+        className="au-icon-tile"
+        style={{
+          width: '4rem',
+          height: '4rem',
+          borderRadius: '1.2rem',
+          boxShadow: '0 0 0 8px oklch(78% 0.15 165 / 0.1)',
+        }}
+      >
+        <Loader2
+          className="size-7 animate-spin text-[color:var(--em)]"
+          aria-hidden
+        />
+      </div>
+
+      <div className="space-y-2">
+        <h1
+          className="ff-display text-[clamp(1.75rem,3.5vw,2.4rem)] leading-[1.1]"
+          style={{ color: 'var(--txt)' }}
+        >
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)]">
+          {copy.body}
+        </p>
+      </div>
+
+      {/* decorative progress bars */}
+      <div className="w-full space-y-2.5 max-w-xs">
+        {[
+          { label: 'Wrapping keys', done: true },
+          { label: 'Encrypting journal', done: false },
+        ].map(({ label, done }) => (
+          <div key={label} className="space-y-1">
+            <div className="flex justify-between text-xs text-[color:var(--txt-faint)] ff-mono">
+              <span>{label}</span>
+              {done && <span style={{ color: 'var(--em)' }}>✓</span>}
+            </div>
+            <div
+              className="h-1 rounded-full overflow-hidden"
+              style={{ background: 'var(--line)' }}
+            >
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: done ? '100%' : '45%',
+                  background: done ? 'var(--em)' : 'var(--gold)',
+                  animation: done
+                    ? undefined
+                    : 'auEncryptPulse 1.8s ease-in-out infinite',
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes auEncryptPulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ── Root wizard ──────────────────────────────────────────────────────────────
+
+export function SetupWizard() {
+  const [step, setStep] = useState<Step>('why');
+  const [recoveryCode, setRecoveryCode] = useState<string | null>(null);
+  const [fatalError, setFatalError] = useState<string | null>(null);
+
+  // Advance from passphrase → recovery: runs the full orchestration.
+  async function handlePassphraseNext(passphrase: string) {
+    const code = await runSetup(passphrase);
+    setRecoveryCode(code);
+    setStep('recovery');
+  }
+
+  // Advance from recovery → encrypting: kick off finalization.
+  async function handleRecoveryNext() {
+    setStep('encrypting');
+    try {
+      const result = await finalizeEncryption();
+      if (!result.ok) {
+        setFatalError(result.error ?? CRYPTO_COPY.errors.setupFailed);
+        return;
+      }
+      // Hard navigate so the session gate sees `ready`.
+      window.location.assign('/dashboard');
+    } catch (err) {
+      setFatalError(
+        err instanceof Error ? err.message : CRYPTO_COPY.errors.generic
+      );
+    }
+  }
+
+  return (
+    <main className={`au ${display.variable} ${mono.variable}`}>
+      {/* atmosphere glows */}
+      <span
+        className="au-glow"
+        style={{ width: 560, height: 560, top: -180, left: '-6%' }}
+        aria-hidden
+      />
+      <span
+        className="au-glow"
+        style={{
+          width: 420,
+          height: 420,
+          bottom: -200,
+          left: '20%',
+          opacity: 0.3,
+        }}
+        aria-hidden
+      />
+
+      <div className="au-layer grid min-h-svh grid-cols-1 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+        <SetupBrandPanel />
+
+        {/* form side */}
+        <div className="flex min-w-0 flex-col px-6 py-8 sm:px-10 lg:px-14">
+          {/* compact wordmark — only visible on mobile */}
+          <Link
+            href="/"
+            className="au-rise flex items-center gap-2.5 lg:invisible"
+            style={{ ['--d' as string]: '0.05s' }}
+            aria-label={`${APP_NAME} home`}
+          >
+            <span className="au-mark ff-mono text-sm">L</span>
+            <span className="text-[0.95rem] font-semibold tracking-tight">
+              {APP_NAME}
+            </span>
+          </Link>
+
+          <div className="flex flex-1 items-center justify-center py-10">
+            <div
+              className="au-rise w-full max-w-sm"
+              style={{ ['--d' as string]: '0.18s' }}
+            >
+              <StepIndicator current={step} />
+
+              {fatalError ? (
+                <div className="flex flex-col gap-4">
+                  <p className="au-error">{fatalError}</p>
+                  <button
+                    type="button"
+                    className="au-btn au-btn--ghost"
+                    onClick={() => {
+                      setFatalError(null);
+                      setStep('recovery');
+                    }}
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : step === 'why' ? (
+                <WhyStep onNext={() => setStep('passphrase')} />
+              ) : step === 'passphrase' ? (
+                <PassphraseStep onNext={handlePassphraseNext} />
+              ) : step === 'recovery' && recoveryCode ? (
+                <RecoveryStep code={recoveryCode} onNext={handleRecoveryNext} />
+              ) : step === 'encrypting' ? (
+                <EncryptingStep />
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/features/crypto/UnlockScreen.tsx
+++ b/features/crypto/UnlockScreen.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { KeyRound, ShieldCheck } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+import '@/features/auth/auth.css';
+import { CRYPTO_COPY } from '@/features/crypto/cryptoCopy';
+import {
+  unlockWithPassphrase,
+  unlockWithRecovery,
+} from '@/features/crypto/lib/unlockFlow';
+import { APP_NAME } from '@/lib/app';
+import { Fraunces, JetBrains_Mono } from 'next/font/google';
+import Link from 'next/link';
+
+// Same display + mono pairing as the auth screen so the unlock page reads
+// with the same deep-green editorial voice.
+const display = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+  style: ['normal', 'italic'],
+});
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
+
+const copy = CRYPTO_COPY.unlock;
+
+// Decorative lock-tick marks that echo the brand panel's sparkbars —
+// visual motif communicating "encrypted / secure state".
+const LOCK_TICKS = [12, 20, 16, 26, 22, 32, 18, 28, 24, 30] as const;
+
+function CryptoBrandPanel() {
+  return (
+    <aside className="relative hidden flex-col justify-between overflow-hidden border-r border-[var(--line-soft)] bg-[var(--ink-2)]/40 p-10 lg:flex lg:p-12">
+      {/* wordmark */}
+      <Link
+        href="/"
+        className="au-rise relative z-10 flex items-center gap-2.5"
+        style={{ ['--d' as string]: '0.05s' }}
+        aria-label={`${APP_NAME} home`}
+      >
+        <span className="au-mark ff-mono text-sm">L</span>
+        <span className="text-lg font-semibold tracking-tight">{APP_NAME}</span>
+      </Link>
+
+      {/* editorial center */}
+      <div className="relative z-10 max-w-md space-y-8">
+        <span
+          className="au-rise au-chip ff-mono"
+          style={{ ['--d' as string]: '0.12s' }}
+        >
+          <span className="au-chip__dot" />
+          END-TO-END ENCRYPTED
+        </span>
+
+        <h2
+          className="au-rise ff-display text-[clamp(2.25rem,3.4vw,3.25rem)] leading-[1.04]"
+          style={{ ['--d' as string]: '0.2s' }}
+        >
+          Your journal. Encrypted. Only you hold the key.
+        </h2>
+
+        {/* Key / lock illustration card */}
+        <div
+          className="au-rise au-card au-card--lit p-0"
+          style={{ ['--d' as string]: '0.3s' }}
+        >
+          <div className="flex items-center gap-2 border-b border-[var(--line)] px-4 py-2.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--red)]/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--gold)]/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--em)]/70" />
+            <span className="ff-mono ml-2 text-xs text-[color:var(--txt-faint)]">
+              journal.ledger
+            </span>
+            <ShieldCheck
+              className="ml-auto size-3.5 text-[color:var(--em)]"
+              aria-hidden
+            />
+          </div>
+          <div className="ff-mono px-5 py-4 text-[0.78rem] leading-relaxed">
+            <p className="text-[color:var(--txt-faint)]">
+              ; encrypted with AES-256-GCM
+            </p>
+            <p className="mt-1 text-[color:var(--gold)]">2026/06/01</p>
+            <p className="mt-0.5 text-[color:var(--txt-dim)]">
+              {'  '}Assets:Checking
+              {'   '}
+              <span className="text-[color:var(--em)]">$ 6,200.00</span>
+            </p>
+            <p className="mt-0.5 text-[color:var(--txt-dim)]">
+              {'  '}Income:Salary
+            </p>
+          </div>
+        </div>
+
+        {/* decorative lock bars — echoes the sparkbars on BrandPanel */}
+        <div
+          className="au-rise au-bars"
+          style={{ ['--d' as string]: '0.38s' }}
+          aria-hidden
+        >
+          {LOCK_TICKS.map((h, i) => (
+            <span key={i} style={{ height: `${h}px` }} />
+          ))}
+        </div>
+      </div>
+
+      {/* security feature ticks */}
+      <ul
+        className="au-rise relative z-10 space-y-2.5"
+        style={{ ['--d' as string]: '0.46s' }}
+      >
+        {(
+          [
+            'Client-side encryption',
+            'Zero-knowledge',
+            'Passphrase-protected',
+          ] as const
+        ).map((f) => (
+          <li key={f} className="au-tick">
+            <KeyRound className="size-4" aria-hidden />
+            {f}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+function resolveCallback(): string {
+  if (typeof window === 'undefined') return '/dashboard';
+  const fromQuery = new URLSearchParams(window.location.search).get(
+    'callbackUrl'
+  );
+  if (fromQuery?.startsWith('/') && !fromQuery.startsWith('//')) {
+    return fromQuery;
+  }
+  return '/dashboard';
+}
+
+function UnlockForm() {
+  const [mode, setMode] = useState<'passphrase' | 'recovery'>('passphrase');
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    try {
+      if (mode === 'passphrase') {
+        await unlockWithPassphrase(value);
+      } else {
+        await unlockWithRecovery(value);
+      }
+      window.location.assign(resolveCallback());
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : CRYPTO_COPY.errors.unlockFailed
+      );
+      setPending(false);
+    }
+  }
+
+  function toggleMode() {
+    setMode((m) => (m === 'passphrase' ? 'recovery' : 'passphrase'));
+    setValue('');
+    setError(null);
+  }
+
+  const isPassphrase = mode === 'passphrase';
+
+  return (
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)]">
+          {copy.subheading}
+        </p>
+      </div>
+
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <div>
+          <label className="au-label" htmlFor="unlock-value">
+            {isPassphrase ? CRYPTO_COPY.passphrase.label : 'Recovery code'}
+          </label>
+          <input
+            id="unlock-value"
+            key={mode}
+            className="au-input"
+            type={isPassphrase ? 'password' : 'text'}
+            required
+            autoComplete={isPassphrase ? 'current-password' : 'off'}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={
+              isPassphrase
+                ? copy.passphrasePlaceholder
+                : copy.recoveryPlaceholder
+            }
+            disabled={pending}
+            autoFocus
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="au-btn au-btn--primary"
+          disabled={pending}
+        >
+          {pending ? copy.unlockingLabel : copy.submitLabel}
+        </button>
+
+        {error && (
+          <p className="au-error" aria-live="polite">
+            {error}
+          </p>
+        )}
+      </form>
+
+      <p className="text-sm text-[color:var(--txt-faint)]">
+        <button
+          type="button"
+          className="au-link cursor-pointer bg-transparent border-0 p-0 text-sm"
+          onClick={toggleMode}
+          disabled={pending}
+        >
+          {isPassphrase ? copy.switchToRecovery : copy.switchToPassphrase}
+        </button>
+      </p>
+    </div>
+  );
+}
+
+export function UnlockScreen() {
+  return (
+    <main className={`au ${display.variable} ${mono.variable}`}>
+      {/* atmosphere — emerald glow bleeding in from the brand side */}
+      <span
+        className="au-glow"
+        style={{ width: 560, height: 560, top: -180, left: '-6%' }}
+        aria-hidden
+      />
+      <span
+        className="au-glow"
+        style={{
+          width: 420,
+          height: 420,
+          bottom: -200,
+          left: '20%',
+          opacity: 0.3,
+        }}
+        aria-hidden
+      />
+
+      <div className="au-layer grid min-h-svh grid-cols-1 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+        <CryptoBrandPanel />
+
+        {/* form side */}
+        <div className="flex min-w-0 flex-col px-6 py-8 sm:px-10 lg:px-14">
+          {/* compact wordmark — only visible on mobile (brand panel hidden) */}
+          <Link
+            href="/"
+            className="au-rise flex items-center gap-2.5 lg:invisible"
+            style={{ ['--d' as string]: '0.05s' }}
+            aria-label={`${APP_NAME} home`}
+          >
+            <span className="au-mark ff-mono text-sm">L</span>
+            <span className="text-[0.95rem] font-semibold tracking-tight">
+              {APP_NAME}
+            </span>
+          </Link>
+
+          <div className="flex flex-1 items-center justify-center py-10">
+            <div
+              className="au-rise w-full max-w-sm"
+              style={{ ['--d' as string]: '0.18s' }}
+            >
+              <UnlockForm />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/features/crypto/UnlockScreen.tsx
+++ b/features/crypto/UnlockScreen.tsx
@@ -160,11 +160,12 @@ function UnlockForm() {
       }
       // Reconcile any journal that was left plaintext-at-rest if a prior setup
       // was abandoned after the userCrypto row was written but before the bulk
-      // migration ran. enableEncryption is idempotent — it short-circuits on
-      // already-ciphertext files via the LEJ1 magic — so this is a cheap no-op
-      // for the common already-encrypted case. Best-effort: a failure here
-      // must not block entry, since the DEK is now in-session and the data
-      // layer re-encrypts on the next mutating push regardless.
+      // migration ran. finalizeEncryption short-circuits on the persisted
+      // `migratedAt` flag, so for the common already-migrated case this is a
+      // single DB read with no journal pull/push. Only the rare partial-setup
+      // user pays the one-time migration cost. Best-effort: a failure here must
+      // not block entry, since the DEK is now in-session and the data layer
+      // re-encrypts on the next mutating push regardless.
       await finalizeEncryption().catch(() => {});
       window.location.assign(resolveCallback());
     } catch (err) {

--- a/features/crypto/UnlockScreen.tsx
+++ b/features/crypto/UnlockScreen.tsx
@@ -188,7 +188,9 @@ function UnlockForm() {
       <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
         <div>
           <label className="au-label" htmlFor="unlock-value">
-            {isPassphrase ? CRYPTO_COPY.passphrase.label : 'Recovery code'}
+            {isPassphrase
+              ? CRYPTO_COPY.passphrase.label
+              : CRYPTO_COPY.recovery.label}
           </label>
           <input
             id="unlock-value"
@@ -217,11 +219,9 @@ function UnlockForm() {
           {pending ? copy.unlockingLabel : copy.submitLabel}
         </button>
 
-        {error && (
-          <p className="au-error" aria-live="polite">
-            {error}
-          </p>
-        )}
+        <p className="au-error" aria-live="polite" aria-atomic="true">
+          {error ?? ''}
+        </p>
       </form>
 
       <p className="text-sm text-[color:var(--txt-faint)]">

--- a/features/crypto/UnlockScreen.tsx
+++ b/features/crypto/UnlockScreen.tsx
@@ -3,6 +3,7 @@
 import { KeyRound, ShieldCheck } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
 import '@/features/auth/auth.css';
+import { finalizeEncryption } from '@/features/crypto/actions/finalizeEncryption';
 import { CRYPTO_COPY } from '@/features/crypto/cryptoCopy';
 import {
   unlockWithPassphrase,
@@ -157,6 +158,14 @@ function UnlockForm() {
       } else {
         await unlockWithRecovery(value);
       }
+      // Reconcile any journal that was left plaintext-at-rest if a prior setup
+      // was abandoned after the userCrypto row was written but before the bulk
+      // migration ran. enableEncryption is idempotent — it short-circuits on
+      // already-ciphertext files via the LEJ1 magic — so this is a cheap no-op
+      // for the common already-encrypted case. Best-effort: a failure here
+      // must not block entry, since the DEK is now in-session and the data
+      // layer re-encrypts on the next mutating push regardless.
+      await finalizeEncryption().catch(() => {});
       window.location.assign(resolveCallback());
     } catch (err) {
       setError(

--- a/features/crypto/actions/finalizeEncryption.ts
+++ b/features/crypto/actions/finalizeEncryption.ts
@@ -1,0 +1,23 @@
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { LockedError } from '@/lib/crypto/sessionKeys';
+import { journalService } from '@/lib/journal';
+
+export async function finalizeEncryption(): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  const user = await requireUser();
+  try {
+    await journalService.enableEncryption(user.id);
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof LockedError)
+      return { ok: false, error: 'Session is locked; unlock and retry.' };
+    console.error('finalizeEncryption failed', e);
+    return {
+      ok: false,
+      error: 'Could not encrypt your journal. Please retry.',
+    };
+  }
+}

--- a/features/crypto/actions/finalizeEncryption.ts
+++ b/features/crypto/actions/finalizeEncryption.ts
@@ -1,5 +1,6 @@
 'use server';
 import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
 import { LockedError } from '@/lib/crypto/sessionKeys';
 import { journalService } from '@/lib/journal';
 
@@ -8,8 +9,15 @@ export async function finalizeEncryption(): Promise<{
   error?: string;
 }> {
   const user = await requireUser();
+  const repo = getUserCryptoRepository();
+  // Already migrated: short-circuit before any storage I/O. This is the common
+  // case on every unlock — gating on the persisted flag avoids a full journal
+  // pull+push (pushFromLocal re-uploads every file with no content/etag
+  // short-circuit) for users whose journal is already ciphertext at rest.
+  if (await repo.hasMigrated(user.id)) return { ok: true };
   try {
     await journalService.enableEncryption(user.id);
+    await repo.markMigrated(user.id);
     return { ok: true };
   } catch (e) {
     if (e instanceof LockedError)

--- a/features/crypto/actions/setupCrypto.test.ts
+++ b/features/crypto/actions/setupCrypto.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupCrypto } from './setupCrypto';
+import { UserCryptoRepository } from '@/lib/crypto';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+const repoHolder: { repo: UserCryptoRepository | null } = { repo: null };
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice' })),
+}));
+vi.mock('@/lib/crypto', async (orig) => ({
+  ...(await orig<typeof import('@/lib/crypto')>()),
+  getUserCryptoRepository: () => repoHolder.repo,
+}));
+
+const VALID = {
+  wrapPassphrase: 'd2FwUA==',
+  passSalt: 'c2FsdA==',
+  argonParams: { m: 65536, t: 3, p: 1 },
+  wrapRecovery: 'd2FwUg==',
+};
+
+describe('setupCrypto', () => {
+  let ctx: TestDbContext;
+  beforeEach(async () => {
+    ctx = await setupTestDb('setup-crypto-');
+    await ctx.insertUser('alice');
+    repoHolder.repo = new UserCryptoRepository(ctx.db);
+  });
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.clearAllMocks();
+  });
+
+  it('creates the userCrypto row', async () => {
+    const res = await setupCrypto(VALID);
+    expect(res.ok).toBe(true);
+    expect(await repoHolder.repo!.exists('alice')).toBe(true);
+  });
+
+  it('rejects a second setup', async () => {
+    await setupCrypto(VALID);
+    const res = await setupCrypto(VALID);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a malformed payload', async () => {
+    const res = await setupCrypto({
+      ...VALID,
+      argonParams: { m: -1, t: 3, p: 1 },
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/features/crypto/actions/setupCrypto.test.ts
+++ b/features/crypto/actions/setupCrypto.test.ts
@@ -54,4 +54,14 @@ describe('setupCrypto', () => {
     });
     expect(res.ok).toBe(false);
   });
+
+  it('rejects a non-base64 wrap blob', async () => {
+    const res = await setupCrypto({ ...VALID, wrapPassphrase: 'not base64!' });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects an over-long salt', async () => {
+    const res = await setupCrypto({ ...VALID, passSalt: 'A'.repeat(65) });
+    expect(res.ok).toBe(false);
+  });
 });

--- a/features/crypto/actions/setupCrypto.ts
+++ b/features/crypto/actions/setupCrypto.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { setupCryptoSchema } from '@/lib/crypto/setupSchema';
+
+type Result = { ok: true } | { ok: false; error: string };
+
+export async function setupCrypto(input: unknown): Promise<Result> {
+  const user = await requireUser();
+  const parsed = setupCryptoSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: 'Invalid setup payload' };
+
+  const repo = getUserCryptoRepository();
+  if (await repo.exists(user.id)) {
+    return { ok: false, error: 'Encryption is already set up' };
+  }
+  await repo.create({
+    userId: user.id,
+    wrapPassphrase: parsed.data.wrapPassphrase,
+    passSalt: parsed.data.passSalt,
+    argonParams: parsed.data.argonParams,
+    wrapRecovery: parsed.data.wrapRecovery,
+  });
+  return { ok: true };
+}

--- a/features/crypto/cryptoCopy.ts
+++ b/features/crypto/cryptoCopy.ts
@@ -30,6 +30,7 @@ export const CRYPTO_COPY = {
   // ── Recovery-code step ──────────────────────────────────────────────────────
   recovery: {
     heading: 'Save your recovery code',
+    label: 'Recovery code',
     warning:
       'This code is shown once. Write it down or store it in a password manager — you cannot retrieve it later.',
     instruction:

--- a/features/crypto/cryptoCopy.ts
+++ b/features/crypto/cryptoCopy.ts
@@ -1,0 +1,72 @@
+// All user-visible strings for the encryption wizard and unlock screen.
+// Keep voice consistent with features/auth/authCopy.ts — plain, friendly, no jargon.
+
+export const CRYPTO_COPY = {
+  // ── Why-encryption explainer ────────────────────────────────────────────────
+  explainer: {
+    heading: 'Protect your journal',
+    body: [
+      'Your financial journal is stored in plain text on this server.',
+      'Encrypting it means only you can read it — not the server, not us.',
+      'You unlock it with a passphrase you choose; a recovery code lets you in if you forget.',
+      'Encryption is optional but strongly recommended if your data is sensitive.',
+    ].join(' '),
+  },
+
+  // ── Passphrase step ─────────────────────────────────────────────────────────
+  passphrase: {
+    heading: 'Choose a passphrase',
+    label: 'Passphrase',
+    helper:
+      'Pick something long and memorable — a phrase, not a word. It is never sent to the server.',
+    strengthHint:
+      'Use at least 4 words or 16 characters. Mix letters and numbers for extra strength.',
+    confirmLabel: 'Confirm passphrase',
+    confirmHelper:
+      'Type the same passphrase again to make sure you got it right.',
+    submitLabel: 'Continue',
+  },
+
+  // ── Recovery-code step ──────────────────────────────────────────────────────
+  recovery: {
+    heading: 'Save your recovery code',
+    warning:
+      'This code is shown once. Write it down or store it in a password manager — you cannot retrieve it later.',
+    instruction:
+      'If you forget your passphrase, this code is the only way to regain access to your journal.',
+    copyLabel: 'Copy code',
+    copiedLabel: 'Copied!',
+    confirmPrompt: 'I have saved my recovery code',
+    submitLabel: 'Enable encryption',
+  },
+
+  // ── Encrypting / progress step ──────────────────────────────────────────────
+  encrypting: {
+    heading: 'Encrypting your journal…',
+    body: 'This may take a moment. Do not close this page.',
+  },
+
+  // ── Unlock screen ───────────────────────────────────────────────────────────
+  unlock: {
+    heading: 'Your journal is locked',
+    subheading: 'Enter your passphrase or recovery code to continue.',
+    passphrasePlaceholder: 'Passphrase',
+    recoveryPlaceholder: 'Recovery code  (e.g. ABCD-EFGH-…)',
+    submitLabel: 'Unlock',
+    unlockingLabel: 'Unlocking…',
+    switchToRecovery: 'Use recovery code instead',
+    switchToPassphrase: 'Use passphrase instead',
+  },
+
+  // ── Error messages ──────────────────────────────────────────────────────────
+  errors: {
+    incorrectPassphrase: 'Incorrect passphrase.',
+    incorrectRecovery: 'Incorrect recovery code.',
+    notSetUp: 'Encryption is not set up.',
+    unlockFailed: 'Unlock failed. Please try again.',
+    setupFailed: 'Encryption setup failed. Please try again.',
+    generic: 'Something went wrong. Please try again.',
+  },
+} as const;
+
+export type CryptoCopy = typeof CRYPTO_COPY;

--- a/features/crypto/lib/clientCrypto.test.ts
+++ b/features/crypto/lib/clientCrypto.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  derivePassphraseKek,
+  generateDek,
+  generateRecoveryCode,
+  parseRecoveryCode,
+  recoveryHkdfKey,
+  unwrapDek,
+  wrapDek,
+} from './clientCrypto';
+
+const PARAMS = { m: 512, t: 2, p: 1 }; // small for test speed
+
+describe('clientCrypto', () => {
+  it('generates a 32-byte DEK', () => {
+    expect(generateDek().length).toBe(32);
+  });
+
+  it('passphrase wrap/unwrap round-trips and is deterministic for same salt+params', async () => {
+    const dek = generateDek();
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const kek1 = await derivePassphraseKek('correct horse', salt, PARAMS);
+    const wrap = await wrapDek(dek, kek1);
+    const kek2 = await derivePassphraseKek('correct horse', salt, PARAMS);
+    const out = await unwrapDek(wrap, kek2);
+    expect([...out]).toEqual([...dek]);
+  });
+
+  it('wrong passphrase fails to unwrap', async () => {
+    const dek = generateDek();
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const wrap = await wrapDek(
+      dek,
+      await derivePassphraseKek('right', salt, PARAMS)
+    );
+    const wrongKek = await derivePassphraseKek('wrong', salt, PARAMS);
+    await expect(unwrapDek(wrap, wrongKek)).rejects.toBeTruthy();
+  });
+
+  it('recovery code round-trips and unwraps the DEK', async () => {
+    const dek = generateDek();
+    const { code, bytes } = generateRecoveryCode();
+    expect(parseRecoveryCode(code)).toEqual(bytes);
+    const wrap = await wrapDek(dek, await recoveryHkdfKey(bytes));
+    const out = await unwrapDek(
+      wrap,
+      await recoveryHkdfKey(parseRecoveryCode(code))
+    );
+    expect([...out]).toEqual([...dek]);
+  });
+
+  it('recovery code is grouped Base32 of 256 bits', () => {
+    const { code, bytes } = generateRecoveryCode();
+    expect(bytes.length).toBe(32);
+    expect(code).toMatch(/^[A-Z2-7]{4}(-[A-Z2-7]{4})+$/);
+  });
+});

--- a/features/crypto/lib/clientCrypto.ts
+++ b/features/crypto/lib/clientCrypto.ts
@@ -1,0 +1,139 @@
+import { argon2id } from 'hash-wasm';
+
+const GCM_NONCE = 12;
+const RECOVERY_INFO = new TextEncoder().encode('ledger-recovery-v1');
+
+export const toBase64 = (b: Uint8Array): string =>
+  btoa(String.fromCharCode(...b));
+export const fromBase64 = (s: string): Uint8Array =>
+  Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+
+export const generateDek = (): Uint8Array =>
+  crypto.getRandomValues(new Uint8Array(32));
+
+export const derivePassphraseKek = async (
+  passphrase: string,
+  salt: Uint8Array,
+  params: { m: number; t: number; p: number }
+): Promise<CryptoKey> => {
+  const rawBuf = await argon2id({
+    password: passphrase,
+    salt: new Uint8Array(salt) as Uint8Array<ArrayBuffer>,
+    parallelism: params.p,
+    iterations: params.t,
+    memorySize: params.m, // KiB
+    hashLength: 32,
+    outputType: 'binary',
+  });
+  return crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(rawBuf) as Uint8Array<ArrayBuffer>,
+    'AES-GCM',
+    false,
+    ['encrypt', 'decrypt']
+  );
+};
+
+export const recoveryHkdfKey = async (
+  recovery: Uint8Array
+): Promise<CryptoKey> => {
+  const base = await crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(recovery) as Uint8Array<ArrayBuffer>,
+    'HKDF',
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0) as Uint8Array<ArrayBuffer>,
+      info: RECOVERY_INFO,
+    },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+};
+
+export const wrapDek = async (
+  dek: Uint8Array,
+  kek: CryptoKey
+): Promise<string> => {
+  const iv = new Uint8Array(GCM_NONCE) as Uint8Array<ArrayBuffer>;
+  crypto.getRandomValues(iv);
+  const ct = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      kek,
+      new Uint8Array(dek) as Uint8Array<ArrayBuffer>
+    )
+  );
+  const blob = new Uint8Array(iv.length + ct.length);
+  blob.set(iv, 0);
+  blob.set(ct, iv.length);
+  return toBase64(blob);
+};
+
+export const unwrapDek = async (
+  wrapB64: string,
+  kek: CryptoKey
+): Promise<Uint8Array> => {
+  const blob = fromBase64(wrapB64);
+  const iv = new Uint8Array(
+    blob.subarray(0, GCM_NONCE)
+  ) as Uint8Array<ArrayBuffer>;
+  const ct = new Uint8Array(
+    blob.subarray(GCM_NONCE)
+  ) as Uint8Array<ArrayBuffer>;
+  return new Uint8Array(
+    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, kek, ct)
+  );
+};
+
+// RFC 4648 Base32, grouped XXXX-XXXX for readability.
+const B32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const base32Encode = (bytes: Uint8Array): string => {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const b of bytes) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) {
+      out += B32[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += B32[(value << (5 - bits)) & 31];
+  return out;
+};
+const base32Decode = (s: string): Uint8Array => {
+  const clean = s.replace(/-/g, '').toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of clean) {
+    const idx = B32.indexOf(ch);
+    if (idx < 0) throw new Error('Invalid recovery code character');
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Uint8Array.from(out);
+};
+
+export const generateRecoveryCode = (): { code: string; bytes: Uint8Array } => {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  const raw = base32Encode(bytes); // 52 chars for 256 bits
+  const code = (raw.match(/.{1,4}/g) ?? []).join('-');
+  return { code, bytes };
+};
+
+export const parseRecoveryCode = (code: string): Uint8Array =>
+  base32Decode(code).subarray(0, 32);

--- a/features/crypto/lib/unlockFlow.test.ts
+++ b/features/crypto/lib/unlockFlow.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  derivePassphraseKek,
+  generateDek,
+  generateRecoveryCode,
+  recoveryHkdfKey,
+  toBase64,
+  wrapDek,
+} from './clientCrypto';
+import {
+  lock,
+  postDek,
+  unlockWithPassphrase,
+  unlockWithRecovery,
+} from './unlockFlow';
+
+// Low-cost Argon2id params so tests finish fast.
+const PARAMS = { m: 512, t: 1, p: 1 };
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a real Material fixture via a clientCrypto round-trip. */
+async function buildMaterial(passphrase: string) {
+  const dek = generateDek();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const kekPass = await derivePassphraseKek(passphrase, salt, PARAMS);
+
+  const { code, bytes: recoveryBytes } = generateRecoveryCode();
+  const kekRecovery = await recoveryHkdfKey(recoveryBytes);
+
+  const wrapPassphrase = await wrapDek(dek, kekPass);
+  const wrapRecovery = await wrapDek(dek, kekRecovery);
+
+  return {
+    dek,
+    code,
+    material: {
+      passSalt: toBase64(salt),
+      argonParams: PARAMS,
+      wrapPassphrase,
+      wrapRecovery,
+    },
+  };
+}
+
+// ── fetch mock helpers ───────────────────────────────────────────────────────
+
+function mockFetch(materialPayload: object) {
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const path = typeof url === 'string' ? url : url.toString();
+
+    if (
+      path === '/api/crypto/material' &&
+      (!init || !init.method || init.method === 'GET')
+    ) {
+      return new Response(JSON.stringify(materialPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (path === '/api/crypto/unlock' && init?.method === 'POST') {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (path === '/api/crypto/lock' && init?.method === 'POST') {
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+    });
+  });
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('unlockFlow', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ── postDek ────────────────────────────────────────────────────────────────
+
+  describe('postDek', () => {
+    it('posts the DEK as base64 to /api/crypto/unlock', async () => {
+      const dek = generateDek();
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      await postDek(dek);
+
+      expect(fetchSpy).toHaveBeenCalledWith('/api/crypto/unlock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: expect.stringContaining('"dek"'),
+      });
+
+      // Verify the posted body is valid JSON with a base64 dek field.
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string) as {
+        dek: string;
+      };
+      expect(typeof body.dek).toBe('string');
+      expect(body.dek.length).toBeGreaterThan(0);
+    });
+
+    it('throws the server error message on non-ok response', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Session expired' }), {
+          status: 409,
+        })
+      );
+
+      await expect(postDek(generateDek())).rejects.toThrow('Session expired');
+    });
+
+    it('falls back to "Unlock failed" when error response has no message', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response('not json', { status: 500 }));
+
+      await expect(postDek(generateDek())).rejects.toThrow('Unlock failed');
+    });
+  });
+
+  // ── unlockWithPassphrase ───────────────────────────────────────────────────
+
+  describe('unlockWithPassphrase', () => {
+    it('happy path: derives KEK, unwraps DEK, posts it', async () => {
+      const passphrase = 'correct horse battery staple';
+      const { dek, material } = await buildMaterial(passphrase);
+
+      fetchSpy = mockFetch(material);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await unlockWithPassphrase(passphrase);
+
+      // Two fetches: GET /api/crypto/material, POST /api/crypto/unlock
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls[0][0]).toBe('/api/crypto/material');
+      expect(fetchSpy.mock.calls[1][0]).toBe('/api/crypto/unlock');
+
+      // Confirm the posted DEK matches the original.
+      const postedBody = JSON.parse(
+        fetchSpy.mock.calls[1][1].body as string
+      ) as { dek: string };
+      const postedDekBytes = Uint8Array.from(atob(postedBody.dek), (c) =>
+        c.charCodeAt(0)
+      );
+      expect([...postedDekBytes]).toEqual([...dek]);
+    });
+
+    it('throws "Incorrect passphrase." when passphrase is wrong', async () => {
+      const { material } = await buildMaterial('right passphrase');
+
+      fetchSpy = mockFetch(material);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await expect(unlockWithPassphrase('wrong passphrase')).rejects.toThrow(
+        'Incorrect passphrase.'
+      );
+
+      // Should NOT call /api/crypto/unlock on a bad unwrap.
+      const unlockCalls = fetchSpy.mock.calls.filter(
+        (args: unknown[]) => args[0] === '/api/crypto/unlock'
+      );
+      expect(unlockCalls).toHaveLength(0);
+    });
+
+    it('throws "Encryption is not set up." when material fetch fails', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+      await expect(unlockWithPassphrase('any')).rejects.toThrow(
+        'Encryption is not set up.'
+      );
+    });
+  });
+
+  // ── unlockWithRecovery ─────────────────────────────────────────────────────
+
+  describe('unlockWithRecovery', () => {
+    it('happy path: derives KEK from recovery code, unwraps DEK, posts it', async () => {
+      const { dek, code, material } = await buildMaterial('some passphrase');
+
+      fetchSpy = mockFetch(material);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await unlockWithRecovery(code);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      const postedBody = JSON.parse(
+        fetchSpy.mock.calls[1][1].body as string
+      ) as { dek: string };
+      const postedDekBytes = Uint8Array.from(atob(postedBody.dek), (c) =>
+        c.charCodeAt(0)
+      );
+      expect([...postedDekBytes]).toEqual([...dek]);
+    });
+
+    it('throws "Incorrect recovery code." when code is wrong', async () => {
+      const { material } = await buildMaterial('some passphrase');
+      const { code: wrongCode } = generateRecoveryCode(); // different random code
+
+      fetchSpy = mockFetch(material);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await expect(unlockWithRecovery(wrongCode)).rejects.toThrow(
+        'Incorrect recovery code.'
+      );
+    });
+  });
+
+  // ── lock ───────────────────────────────────────────────────────────────────
+
+  describe('lock', () => {
+    it('posts to /api/crypto/lock', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await lock();
+
+      expect(fetchSpy).toHaveBeenCalledWith('/api/crypto/lock', {
+        method: 'POST',
+      });
+    });
+  });
+});

--- a/features/crypto/lib/unlockFlow.ts
+++ b/features/crypto/lib/unlockFlow.ts
@@ -1,0 +1,63 @@
+import {
+  derivePassphraseKek,
+  fromBase64,
+  parseRecoveryCode,
+  recoveryHkdfKey,
+  toBase64,
+  unwrapDek,
+} from './clientCrypto';
+
+type Material = {
+  passSalt: string;
+  argonParams: { m: number; t: number; p: number };
+  wrapPassphrase: string;
+  wrapRecovery: string;
+};
+
+const getMaterial = async (): Promise<Material> => {
+  const res = await fetch('/api/crypto/material');
+  if (!res.ok) throw new Error('Encryption is not set up.');
+  return res.json() as Promise<Material>;
+};
+
+export const postDek = async (dek: Uint8Array): Promise<void> => {
+  const res = await fetch('/api/crypto/unlock', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dek: toBase64(dek) }),
+  });
+  if (!res.ok) {
+    const { error } = await res
+      .json()
+      .catch(() => ({ error: 'Unlock failed' }));
+    throw new Error(error ?? 'Unlock failed');
+  }
+};
+
+export const unlockWithPassphrase = async (
+  passphrase: string
+): Promise<void> => {
+  const m = await getMaterial();
+  const kek = await derivePassphraseKek(
+    passphrase,
+    fromBase64(m.passSalt),
+    m.argonParams
+  );
+  const dek = await unwrapDek(m.wrapPassphrase, kek).catch(() => {
+    throw new Error('Incorrect passphrase.');
+  });
+  await postDek(dek);
+};
+
+export const unlockWithRecovery = async (code: string): Promise<void> => {
+  const m = await getMaterial();
+  const kek = await recoveryHkdfKey(parseRecoveryCode(code));
+  const dek = await unwrapDek(m.wrapRecovery, kek).catch(() => {
+    throw new Error('Incorrect recovery code.');
+  });
+  await postDek(dek);
+};
+
+export const lock = async (): Promise<void> => {
+  await fetch('/api/crypto/lock', { method: 'POST' });
+};

--- a/features/crypto/lib/unlockFlow.ts
+++ b/features/crypto/lib/unlockFlow.ts
@@ -6,18 +6,12 @@ import {
   toBase64,
   unwrapDek,
 } from './clientCrypto';
+import type { CryptoMaterial } from '@/lib/crypto/setupSchema';
 
-type Material = {
-  passSalt: string;
-  argonParams: { m: number; t: number; p: number };
-  wrapPassphrase: string;
-  wrapRecovery: string;
-};
-
-const getMaterial = async (): Promise<Material> => {
+const getMaterial = async (): Promise<CryptoMaterial> => {
   const res = await fetch('/api/crypto/material');
   if (!res.ok) throw new Error('Encryption is not set up.');
-  return res.json() as Promise<Material>;
+  return res.json() as Promise<CryptoMaterial>;
 };
 
 export const postDek = async (dek: Uint8Array): Promise<void> => {

--- a/lib/crypto/gate.test.ts
+++ b/lib/crypto/gate.test.ts
@@ -1,0 +1,33 @@
+import { randomBytes } from 'crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cryptoStatus } from './gate';
+import {
+  __resetSessionKeysForTest,
+  setSessionDek,
+} from '@/lib/crypto/sessionKeys';
+
+const existsMock = vi.fn();
+vi.mock('@/lib/crypto', () => ({
+  getUserCryptoRepository: () => ({ exists: existsMock }),
+}));
+
+afterEach(() => {
+  __resetSessionKeysForTest();
+  vi.clearAllMocks();
+});
+
+describe('cryptoStatus', () => {
+  it('unset when no row', async () => {
+    existsMock.mockResolvedValue(false);
+    expect(await cryptoStatus('a')).toBe('unset');
+  });
+  it('locked when row but no DEK', async () => {
+    existsMock.mockResolvedValue(true);
+    expect(await cryptoStatus('a')).toBe('locked');
+  });
+  it('ready when row and DEK', async () => {
+    existsMock.mockResolvedValue(true);
+    setSessionDek('a', randomBytes(32));
+    expect(await cryptoStatus('a')).toBe('ready');
+  });
+});

--- a/lib/crypto/gate.ts
+++ b/lib/crypto/gate.ts
@@ -1,0 +1,10 @@
+import 'server-only';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { hasSessionDek } from '@/lib/crypto/sessionKeys';
+
+export type CryptoStatus = 'unset' | 'locked' | 'ready';
+
+export const cryptoStatus = async (userId: string): Promise<CryptoStatus> => {
+  if (!(await getUserCryptoRepository().exists(userId))) return 'unset';
+  return hasSessionDek(userId) ? 'ready' : 'locked';
+};

--- a/lib/crypto/journalCipher.test.ts
+++ b/lib/crypto/journalCipher.test.ts
@@ -46,4 +46,14 @@ describe('journalCipher', () => {
       LockedError
     );
   });
+
+  it('encryptForUpload does not re-wrap already-ciphertext bytes', () => {
+    const dek = randomBytes(32);
+    setSessionDek('alice', dek);
+    const plaintext = Buffer.from('2026/01/01 Payee\n');
+    const ct = encryptFile(dek, 'main.ledger', plaintext);
+    // Passing already-ciphertext through encryptForUpload must return it unchanged
+    const out = encryptForUpload('alice', 'main.ledger', ct);
+    expect(out.equals(ct)).toBe(true);
+  });
 });

--- a/lib/crypto/journalCipher.ts
+++ b/lib/crypto/journalCipher.ts
@@ -10,6 +10,7 @@ export const encryptForUpload = (
   relPath: string,
   plaintext: Buffer
 ): Buffer => {
+  if (isCiphertext(plaintext)) return plaintext; // never double-wrap already-ciphertext
   const dek = getSessionDek(userId);
   return dek ? encryptFile(dek, relPath, plaintext) : plaintext;
 };

--- a/lib/crypto/setupSchema.ts
+++ b/lib/crypto/setupSchema.ts
@@ -21,3 +21,11 @@ export const setupCryptoSchema = z.object({
   wrapRecovery: b64(2000),
 });
 export type SetupCryptoInput = z.infer<typeof setupCryptoSchema>;
+
+// Wrapped key-material the server hands back to the client (GET /api/crypto/material).
+// Same opaque blobs as setup, minus the server-owned userId. Derived from the
+// schema so the route and its client consumer can't drift out of sync.
+export type CryptoMaterial = Pick<
+  SetupCryptoInput,
+  'passSalt' | 'argonParams' | 'wrapPassphrase' | 'wrapRecovery'
+>;

--- a/lib/crypto/setupSchema.ts
+++ b/lib/crypto/setupSchema.ts
@@ -1,14 +1,23 @@
 import { z } from 'zod';
 
-const b64 = z.string().min(1).max(2000);
+// Opaque base64 blob: non-empty, length-bounded, and charset-restricted to
+// standard base64 so obviously-malformed input is rejected before storage.
+const b64 = (max: number) =>
+  z
+    .string()
+    .min(1)
+    .max(max)
+    .regex(/^[A-Za-z0-9+/]+={0,2}$/, 'Invalid base64');
+
 export const setupCryptoSchema = z.object({
-  wrapPassphrase: b64,
-  passSalt: b64,
+  wrapPassphrase: b64(2000),
+  // Argon2 salt is 16-32 bytes (~24-44 base64 chars); cap tightly.
+  passSalt: b64(64),
   argonParams: z.object({
     m: z.number().int().positive(),
     t: z.number().int().positive(),
     p: z.number().int().positive(),
   }),
-  wrapRecovery: b64,
+  wrapRecovery: b64(2000),
 });
 export type SetupCryptoInput = z.infer<typeof setupCryptoSchema>;

--- a/lib/crypto/setupSchema.ts
+++ b/lib/crypto/setupSchema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const b64 = z.string().min(1).max(2000);
+export const setupCryptoSchema = z.object({
+  wrapPassphrase: b64,
+  passSalt: b64,
+  argonParams: z.object({
+    m: z.number().int().positive(),
+    t: z.number().int().positive(),
+    p: z.number().int().positive(),
+  }),
+  wrapRecovery: b64,
+});
+export type SetupCryptoInput = z.infer<typeof setupCryptoSchema>;

--- a/lib/crypto/userCryptoRepository.test.ts
+++ b/lib/crypto/userCryptoRepository.test.ts
@@ -39,4 +39,33 @@ describe('UserCryptoRepository', () => {
   it('exists is false for an unknown user', async () => {
     expect(await repo.exists('nobody')).toBe(false);
   });
+
+  it('hasMigrated is false until markMigrated stamps the row', async () => {
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'd2FwUA==',
+      passSalt: 'c2FsdA==',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'd2FwUg==',
+    });
+    expect(await repo.hasMigrated('alice')).toBe(false);
+    expect((await repo.get('alice'))?.migratedAt).toBeNull();
+
+    await repo.markMigrated('alice');
+    expect(await repo.hasMigrated('alice')).toBe(true);
+    expect((await repo.get('alice'))?.migratedAt).toBeInstanceOf(Date);
+  });
+
+  it('markMigrated is idempotent', async () => {
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'd2FwUA==',
+      passSalt: 'c2FsdA==',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'd2FwUg==',
+    });
+    await repo.markMigrated('alice');
+    await repo.markMigrated('alice');
+    expect(await repo.hasMigrated('alice')).toBe(true);
+  });
 });

--- a/lib/crypto/userCryptoRepository.ts
+++ b/lib/crypto/userCryptoRepository.ts
@@ -21,4 +21,18 @@ export class UserCryptoRepository {
   async create(input: NewUserCrypto): Promise<void> {
     await this.db.insert(userCrypto).values(input);
   }
+
+  /** True once the bulk journal migration has completed for this user. */
+  async hasMigrated(userId: string): Promise<boolean> {
+    const row = await this.get(userId);
+    return row?.migratedAt != null;
+  }
+
+  /** Stamp the row as migrated. Idempotent — re-stamping is a harmless no-op. */
+  async markMigrated(userId: string): Promise<void> {
+    await this.db
+      .update(userCrypto)
+      .set({ migratedAt: new Date() })
+      .where(eq(userCrypto.userId, userId));
+  }
 }

--- a/lib/journal/service.enableEncryption.test.ts
+++ b/lib/journal/service.enableEncryption.test.ts
@@ -1,0 +1,70 @@
+// lib/journal/service.enableEncryption.test.ts
+import { randomBytes } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isCiphertext } from '@/lib/crypto/fileCrypto';
+import {
+  LockedError,
+  __resetSessionKeysForTest,
+  setSessionDek,
+} from '@/lib/crypto/sessionKeys';
+import { journalService } from '@/lib/journal';
+import { getJournalDir } from '@/lib/journal/layout';
+import { resetObjectStore, getObjectStore, push } from '@/lib/storage';
+import { keyFor } from '@/lib/storage/manifest';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+// resetObjectStore() + STORAGE_BACKEND=memory (default when not 's3') forces a
+// fresh MemoryObjectStore for each test — mirrors quota-enforcement.test.ts.
+
+describe('JournalService.enableEncryption', () => {
+  let ctx: TestDbContext;
+  beforeEach(async () => {
+    ctx = await setupTestDb('enable-enc-');
+    await ctx.insertUser('alice');
+    resetObjectStore();
+  });
+  afterEach(async () => {
+    __resetSessionKeysForTest();
+    await teardownTestDb(ctx);
+  });
+
+  it('re-encrypts existing plaintext files and is idempotent', async () => {
+    const userId = 'alice';
+    const dir = getJournalDir(userId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'main.ledger'),
+      '2026/01/01 Opening\n  Assets:Cash  $10\n'
+    );
+
+    // Push the plaintext file to remote first (simulates pre-encryption state:
+    // user already has unencrypted files on the remote store).
+    await push(userId);
+
+    setSessionDek(userId, randomBytes(32));
+    const r1 = await journalService.enableEncryption(userId);
+    expect(r1.encrypted).toBe(1);
+
+    const remote = await getObjectStore().get(keyFor(userId, 'main.ledger'));
+    expect(isCiphertext(remote.body)).toBe(true);
+
+    // idempotent: pulling decrypts to plaintext locally; re-running re-encrypts the same content
+    const r2 = await journalService.enableEncryption(userId);
+    expect(r2.encrypted + r2.alreadyCiphertext).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws LockedError when no session DEK', async () => {
+    const dir = getJournalDir('alice');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.ledger'), 'x');
+    await expect(
+      journalService.enableEncryption('alice')
+    ).rejects.toBeInstanceOf(LockedError);
+  });
+});

--- a/lib/journal/service.enableEncryption.test.ts
+++ b/lib/journal/service.enableEncryption.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@/lib/crypto/sessionKeys';
 import { journalService } from '@/lib/journal';
 import { getJournalDir } from '@/lib/journal/layout';
-import { resetObjectStore, getObjectStore, push } from '@/lib/storage';
+import { resetObjectStore, getObjectStore, push, pull } from '@/lib/storage';
 import { keyFor } from '@/lib/storage/manifest';
 import {
   setupTestDb,
@@ -53,6 +53,12 @@ describe('JournalService.enableEncryption', () => {
 
     const remote = await getObjectStore().get(keyFor(userId, 'main.ledger'));
     expect(isCiphertext(remote.body)).toBe(true);
+
+    // Round-trip: wipe local, pull, assert original plaintext is recoverable (catches double-encryption)
+    await fs.unlink(path.join(dir, 'main.ledger'));
+    await pull(userId);
+    const recovered = await fs.readFile(path.join(dir, 'main.ledger'), 'utf8');
+    expect(recovered).toBe('2026/01/01 Opening\n  Assets:Cash  $10\n');
 
     // idempotent: pulling decrypts to plaintext locally; re-running re-encrypts the same content
     const r2 = await journalService.enableEncryption(userId);

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -20,7 +20,10 @@ import { getJournalDirSize, journalQuotaBytes, journalQuotaMb } from './quota';
 import { JournalRepository } from './repository';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
+import { encryptFile, isCiphertext } from '@/lib/crypto/fileCrypto';
+import { getSessionDek, LockedError } from '@/lib/crypto/sessionKeys';
 import { pull, pullLocked, push, StorageConflictError } from '@/lib/storage';
+import { listLocalRelPaths } from '@/lib/storage/manifest';
 import {
   formatTransaction,
   transactionDraftSchema,
@@ -539,6 +542,31 @@ export class JournalService {
     }
     invalidateCache(userId);
     return { ok: true };
+  }
+
+  async enableEncryption(
+    userId: string
+  ): Promise<{ encrypted: number; alreadyCiphertext: number }> {
+    return withUserLock(userId, async () => {
+      const dek = getSessionDek(userId);
+      if (!dek) throw new LockedError();
+      await pull(userId); // bring canonical down (decrypts any already-ciphertext)
+      const dir = getJournalDir(userId);
+      let encrypted = 0;
+      let alreadyCiphertext = 0;
+      for (const rel of await listLocalRelPaths(dir)) {
+        const abs = path.join(dir, rel);
+        const body = await fs.readFile(abs);
+        if (isCiphertext(body)) {
+          alreadyCiphertext++;
+          continue;
+        }
+        await fs.writeFile(abs, encryptFile(dek, rel, body));
+        encrypted++;
+      }
+      await push(userId); // re-encrypts on the seam too (DEK present) — uploads ciphertext
+      return { encrypted, alreadyCiphertext };
+    });
   }
 
   private async backfillFile(filePath: string): Promise<BackfillFileResult> {

--- a/lib/security/headers.test.ts
+++ b/lib/security/headers.test.ts
@@ -8,6 +8,13 @@ describe('buildSecurityHeaders', () => {
     expect(csp).toContain("script-src 'self' 'nonce-abc123' 'strict-dynamic'");
   });
 
+  it("allows wasm-unsafe-eval (for the encryption wizard's hash-wasm Argon2id) but not unsafe-eval", () => {
+    const csp = buildSecurityHeaders('n')['Content-Security-Policy'];
+    expect(csp).toContain("'wasm-unsafe-eval'");
+    // The narrow WASM keyword must NOT bring in general JS eval.
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+
   it('sets the core directives and static headers', () => {
     const csp = buildSecurityHeaders('n')['Content-Security-Policy'];
     expect(csp).toContain("default-src 'self'");

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -5,11 +5,16 @@
  * style-src keeps 'unsafe-inline' because Recharts and Base UI write inline
  * `style=` attributes that a nonce cannot cover; injected CSS is far lower-risk
  * than injected script, which 'nonce' + 'strict-dynamic' fully gate.
+ *
+ * script-src adds 'wasm-unsafe-eval' so the client-side encryption wizard can
+ * instantiate the hash-wasm Argon2id WebAssembly module. This keyword permits
+ * WASM compilation ONLY — it does NOT enable JS eval()/'unsafe-eval', so the
+ * strict-dynamic + nonce protection against injected script is fully preserved.
  */
 export function buildSecurityHeaders(nonce: string): Record<string, string> {
   const csp = [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'`,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data:",
     "font-src 'self'",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "drizzle-orm": "^0.45.2",
+    "hash-wasm": "^4.12.0",
     "lucide-react": "^1.16.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.3)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(kysely@0.28.17)(postgres@3.4.9)
+      hash-wasm:
+        specifier: ^4.12.0
+        version: 4.12.0
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)
@@ -3852,6 +3855,9 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  hash-wasm@4.12.0:
+    resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -9650,6 +9656,8 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.0.3
+
+  hash-wasm@4.12.0: {}
 
   hasown@2.0.2:
     dependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -16,6 +16,7 @@ function withSecurityHeaders(req: NextRequest): NextResponse {
   // own bootstrap <script> tags.
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('x-pathname', req.nextUrl.pathname);
   requestHeaders.set(
     'Content-Security-Policy',
     headers['Content-Security-Policy']


### PR DESCRIPTION
Builds on P1 (#28) to make **zero-knowledge encryption real and usable**. After this, a user is gated into a setup wizard that generates their key client-side, sets a passphrase + recovery code, and encrypts their existing journal; subsequent sessions require an unlock.

> ⚠️ **Live e2e/visual acceptance is pending** (see checklist) — this needs a real Postgres + Garage `pnpm dev` env, which the build worktree lacks. All static verification (495 tests, type-check, lint) is green and the whole-branch review is clean.

## What's here
- **Client crypto** (`features/crypto/lib/clientCrypto.ts`): 32-byte DEK generation, Argon2id passphrase KEK (`hash-wasm`), recovery-code HKDF KEK, AES-GCM wrap/unwrap (WebCrypto), grouped Base32 recovery codes. The passphrase/recovery code **never leave the browser**; only opaque wraps are uploaded; only the raw DEK is POSTed (over TLS) to P1's `/api/crypto/unlock`.
- **Setup** (`setupCrypto` action + `setupSchema`) stores only opaque wraps in `userCrypto`.
- **Migration** (`JournalService.enableEncryption`, under `withUserLock`): re-encrypts the existing plaintext journal, idempotent via the `LEJ1` magic, **provably round-trips** back to the original plaintext (test wipes local → pulls → asserts byte-identical).
- **The gate**: `proxy.ts` forwards `x-pathname`; `CryptoGate` (root-layout server component) redirects un-set-up → `/crypto/setup`, locked → `/crypto/unlock`; loop-free; `LockedError` at the data layer is the hard backstop.
- **UI (au-* design, matches sign-in)**: 4-step setup wizard (Why → passphrase → recovery code shown once → encrypting), per-session unlock screen (passphrase + recovery), Lock control in the header, drop-DEK-on-sign-out.

## Notable fixes caught in review
- **Double-encryption bug (data-loss-level)**: the migration wrote ciphertext then `push`ed, and P1's `encryptForUpload` seam had no `isCiphertext` guard → double-wrapped, unrecoverable journals. Fixed with a guard (`lib/crypto/journalCipher.ts`), proven by a wipe+pull round-trip test (also hardens P1's seam generally).
- **CSP blocked WebAssembly**: P1's strict nonce CSP had no `'wasm-unsafe-eval'`, which would have made `hash-wasm` Argon2id throw in-browser — the wizard wouldn't work at all. Added the narrow keyword (permits WASM compile only, **not** JS `eval`; strict-dynamic/nonce JS protection preserved).

## Verification
Built TDD via subagent-driven development — 11 tasks, each implemented + independently reviewed, plus a whole-branch opus review: **Ready to merge, 0 Critical / 0 Important.** Full suite **495 tests passing**, type-check + lint clean.

## Your e2e acceptance checklist (before merge)
- [ ] Fresh un-set-up user → gated to `/crypto/setup`; wizard walks Why → passphrase → recovery (shown once, copy + download, "I've saved it" gates Continue) → encrypting → lands on dashboard.
- [ ] **CSP/WASM**: no console CSP error during Argon2id (the fix above should cover it — confirm).
- [ ] Journal reports still render after setup; the object at rest in Garage carries the `LEJ1` magic (ciphertext).
- [ ] Lock → routed to `/crypto/unlock`; **passphrase** unlocks; **recovery code** also unlocks (fresh session each).
- [ ] Sign out → sign in → re-unlock required.
- [ ] Wizard visual quality matches sign-in / unlock.

## Non-blocking follow-ups (P3 candidates)
- Partial-setup recoverability: if `setupCrypto` succeeds but `postDek` fails, "Retry" gets stuck (gate no-ops on `/crypto/*`). Recommend the gate redirect already-set-up users away from `/crypto/setup`.
- P1 carryover: 32-byte `dek` guard in `fileCrypto`; freeze the exported `MAGIC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)