### PR TITLE
feat(crypto): encrypted journals P3 — Settings → Security

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,13 +1,15 @@
 import { Settings } from '@/features/settings';
 import { requireUser } from '@/lib/auth/require-user';
+import { cryptoStatus } from '@/lib/crypto/gate';
 import { env } from '@/lib/env';
 import { getAvailableCurrencies, userSettingRepository } from '@/lib/settings';
 
 const SettingsPage = async () => {
   const user = await requireUser();
-  const [{ currencies, base }, row] = await Promise.all([
+  const [{ currencies, base }, row, status] = await Promise.all([
     getAvailableCurrencies(),
     userSettingRepository.get(user.id),
+    cryptoStatus(user.id),
   ]);
   return (
     <Settings
@@ -15,6 +17,7 @@ const SettingsPage = async () => {
       currencies={currencies}
       savedDefault={row?.baseCurrency ?? null}
       envFallback={env.DEFAULT_CURRENCY}
+      encryptionEnabled={status !== 'unset'}
     />
   );
 };

--- a/db/migrations/0004_tough_guardian.sql
+++ b/db/migrations/0004_tough_guardian.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "encryptionResetChallenge" (
+	"userId" text PRIMARY KEY NOT NULL,
+	"codeHash" text NOT NULL,
+	"expiresAt" timestamp NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "encryptionResetChallenge" ADD CONSTRAINT "encryptionResetChallenge_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/db/migrations/meta/0004_snapshot.json
+++ b/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,571 @@
+{
+  "id": "15ef547e-8656-49e6-8259-b10d89a00005",
+  "prevId": "76bc8ac3-0bd3-4a3d-87a2-e19560a0a6d6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accountDeletionChallenge": {
+      "name": "accountDeletionChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accountDeletionChallenge_userId_user_id_fk": {
+          "name": "accountDeletionChallenge_userId_user_id_fk",
+          "tableFrom": "accountDeletionChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commodity_price": {
+      "name": "commodity_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_date": {
+          "name": "fetched_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commodity_price_unique_per_day": {
+          "name": "commodity_price_unique_per_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol",
+            "quote",
+            "fetched_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryptionResetChallenge": {
+      "name": "encryptionResetChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryptionResetChallenge_userId_user_id_fk": {
+          "name": "encryptionResetChallenge_userId_user_id_fk",
+          "tableFrom": "encryptionResetChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_fetch_run": {
+      "name": "price_fetch_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbols_fetched": {
+          "name": "symbols_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "symbols_failed": {
+          "name": "symbols_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savedView": {
+      "name": "savedView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPath": {
+          "name": "targetPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "savedView_user_name": {
+          "name": "savedView_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savedView_userId_user_id_fk": {
+          "name": "savedView_userId_user_id_fk",
+          "tableFrom": "savedView",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_user_name": {
+          "name": "template_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_userId_user_id_fk": {
+          "name": "template_userId_user_id_fk",
+          "tableFrom": "template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userCrypto": {
+      "name": "userCrypto",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wrapPassphrase": {
+          "name": "wrapPassphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passSalt": {
+          "name": "passSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argonParams": {
+          "name": "argonParams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapRecovery": {
+          "name": "wrapRecovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recoveryCreatedAt": {
+          "name": "recoveryCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kdfVersion": {
+          "name": "kdfVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "migratedAt": {
+          "name": "migratedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userCrypto_userId_user_id_fk": {
+          "name": "userCrypto_userId_user_id_fk",
+          "tableFrom": "userCrypto",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "baseCurrency": {
+          "name": "baseCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journalMain": {
+          "name": "journalMain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main.ledger'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSetting_userId_user_id_fk": {
+          "name": "userSetting_userId_user_id_fk",
+          "tableFrom": "userSetting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1782391793514,
       "tag": "0003_thankful_tag",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782395825605,
+      "tag": "0004_tough_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/encryptionResetChallenge.ts
+++ b/db/schema/encryptionResetChallenge.ts
@@ -1,0 +1,20 @@
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+// One active encryption-reset challenge per user (PK = userId; re-requesting
+// a code upserts this row). Holds only a hash of the 6-digit code — never plaintext.
+export const encryptionResetChallenge = pgTable('encryptionResetChallenge', {
+  userId: text('userId')
+    .primaryKey()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  codeHash: text('codeHash').notNull(),
+  expiresAt: timestamp('expiresAt').notNull(),
+  attempts: integer('attempts').notNull().default(0),
+  createdAt: timestamp('createdAt')
+    .notNull()
+    .default(sql`now()`),
+});
+
+export type EncryptionResetChallenge =
+  typeof encryptionResetChallenge.$inferSelect;

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -2,6 +2,10 @@ export {
   accountDeletionChallenge,
   type AccountDeletionChallenge,
 } from './accountDeletionChallenge';
+export {
+  encryptionResetChallenge,
+  type EncryptionResetChallenge,
+} from './encryptionResetChallenge';
 export { commodityPrice, type CommodityPrice } from './commodityPrice';
 export { priceFetchRun, type PriceFetchRun } from './priceFetchRun';
 export { savedView, type SavedView } from './savedView';

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -6,5 +6,10 @@ export { commodityPrice, type CommodityPrice } from './commodityPrice';
 export { priceFetchRun, type PriceFetchRun } from './priceFetchRun';
 export { savedView, type SavedView } from './savedView';
 export { template, type Template } from './template';
-export { userCrypto, type NewUserCrypto, type UserCrypto } from './userCrypto';
+export {
+  userCrypto,
+  type ArgonParams,
+  type NewUserCrypto,
+  type UserCrypto,
+} from './userCrypto';
 export { userSetting, type UserSetting } from './userSetting';

--- a/docs/superpowers/plans/2026-06-25-encrypted-journals-p3.md
+++ b/docs/superpowers/plans/2026-06-25-encrypted-journals-p3.md
@@ -1,0 +1,444 @@
+# Encrypted Journals — P3: Settings → Security — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. The UI task pairs with frontend-design and the shadcn settings conventions.
+
+**Goal:** Let a user manage their encryption from Settings → Security: change passphrase (with a recovery-code fallback for "forgot passphrase"), rotate the recovery code, and reset encryption (destructive).
+
+**Architecture:** All re-wrapping is **client-side** and zero-knowledge: to change the passphrase or rotate the recovery code, the browser re-obtains the DEK by unwrapping it with the user's *current* passphrase (or recovery code) — exactly as unlock does — then wraps the same DEK under a new KEK and uploads only the new opaque wrap. The DEK never changes, so journal data is never re-encrypted. The server stores only opaque wraps; the in-RAM session DEK is unaffected by a re-wrap. Reset-encryption wipes the (now-unreadable) ciphertext journal + the `userCrypto` row and recreates an empty journal, without deleting the account.
+
+**Tech Stack:** TypeScript, Next.js 16, WebCrypto + `hash-wasm` (reused from P2), Drizzle + Postgres, Vitest. UI in the shadcn system used by the rest of `/settings` (NOT au-*).
+
+## Global Constraints
+
+- **Zero-knowledge preserved:** the current/new passphrase and recovery code never leave the browser; only opaque wraps (+ salt + Argon params) are uploaded. Never log secrets/DEK/wraps. The DEK is re-obtained client-side by unwrapping with a user secret — the server never hands the DEK back.
+- **The DEK never changes** across passphrase change / recovery rotation — only the wrap of it changes; no journal re-encryption.
+- **Re-wrap requires proof of the current secret:** change-passphrase and rotate-recovery require the user to enter their current passphrase OR recovery code (to unwrap the DEK). A wrong secret fails the unwrap → friendly error, no server mutation.
+- **Reuse P2 verbatim:** `getMaterial` (GET `/api/crypto/material` → `{passSalt, argonParams, wrapPassphrase, wrapRecovery}`), `derivePassphraseKek`, `recoveryHkdfKey`, `unwrapDek`, `wrapDek`, `generateRecoveryCode`, `parseRecoveryCode`, `toBase64`/`fromBase64` from `features/crypto/lib/`. `getUserCryptoRepository()` from `@/lib/crypto`. Argon params for new wraps: `{ m: 65536, t: 3, p: 1 }`, 16-byte salt.
+- **Reset is destructive and irreversible:** it deletes the encrypted journal (unreadable without the key) + the `userCrypto` row → user returns to `cryptoStatus === 'unset'` and the gate routes them to `/crypto/setup`. Rate-limit with `DESTRUCTIVE`; gate behind a typed-confirmation dialog. **(Open decision — see end of plan: typed-confirmation vs the email-code flow used by account deletion.)**
+- **Reset must NOT delete the user account** (unlike `purgeUserData`); model on it but stop short of `db.delete(user)`.
+- Server actions: `requireUser` → rate-limit → validate → mutate → `revalidatePath('/', 'layout')` → discriminated result. Follow `features/settings/actions/setSavedBaseCurrency.ts`.
+- **Test command:** `pnpm test`. **Type-check:** `pnpm type-check`. **Lint:** `pnpm lint`. Pre-commit husky + commitlint (lowercase subjects). No live dev env in the worktree (no `DATABASE_URL`) — UI visual + e2e acceptance is deferred to the user; verify in-worktree via tests + type-check + lint.
+
+## File Structure
+
+**Create:**
+- `lib/crypto/rewrapSchema.ts` — Zod schemas for the change-passphrase / rotate-recovery payloads (shared with the actions).
+- `features/crypto/lib/rewrapFlow.ts` — client orchestration: `obtainDek(authorizer)`, `changePassphrase(authorizer, newPassphrase)`, `rotateRecovery(authorizer)`.
+- `lib/crypto/resetEncryption.ts` — server `resetUserEncryption(userId, deps?)` (clearRemote + rm dir + repo.delete + ensureLayout + dropSessionDek).
+- `features/settings/actions/changePassphrase.ts`, `features/settings/actions/rotateRecovery.ts`, `features/settings/actions/resetEncryption.ts` — server actions.
+- `features/settings/SecuritySection.tsx` (+ `ChangePassphraseCard.tsx`, `RotateRecoveryCard.tsx`, `ResetEncryptionCard.tsx`) — the Security UI.
+- Tests alongside each.
+
+**Modify:**
+- `lib/crypto/userCryptoRepository.ts` — add `updateWrapPassphrase`, `updateWrapRecovery`, `delete`.
+- `features/settings/actions/index.ts` — export the new actions.
+- `features/settings/Settings.tsx` — render `<SecuritySection/>`.
+- `app/settings/page.tsx` — pass whether the user is encryption-enabled (so the Security section renders only when set up).
+
+---
+
+## Task 1: `userCryptoRepository` re-wrap + delete methods
+
+**Files:** Modify `lib/crypto/userCryptoRepository.ts`; extend `lib/crypto/userCryptoRepository.test.ts`.
+
+**Interfaces — Produces:**
+- `updateWrapPassphrase(userId: string, wrapPassphrase: string, passSalt: string, argonParams: ArgonParams): Promise<void>`
+- `updateWrapRecovery(userId: string, wrapRecovery: string): Promise<void>` (also bumps `recoveryCreatedAt` to now)
+- `delete(userId: string): Promise<void>`
+
+- [ ] **Step 1: Write the failing tests** (append to the existing describe in `userCryptoRepository.test.ts`)
+
+```ts
+it('updateWrapPassphrase replaces the passphrase wrap fields', async () => {
+  await repo.create({
+    userId: 'alice', wrapPassphrase: 'w1', passSalt: 's1',
+    argonParams: { m: 65536, t: 3, p: 1 }, wrapRecovery: 'r1',
+  });
+  await repo.updateWrapPassphrase('alice', 'w2', 's2', { m: 19456, t: 2, p: 1 });
+  const row = await repo.get('alice');
+  expect(row?.wrapPassphrase).toBe('w2');
+  expect(row?.passSalt).toBe('s2');
+  expect(row?.argonParams).toEqual({ m: 19456, t: 2, p: 1 });
+  expect(row?.wrapRecovery).toBe('r1'); // recovery wrap untouched
+});
+
+it('updateWrapRecovery replaces the recovery wrap and bumps recoveryCreatedAt', async () => {
+  await repo.create({
+    userId: 'alice', wrapPassphrase: 'w1', passSalt: 's1',
+    argonParams: { m: 65536, t: 3, p: 1 }, wrapRecovery: 'r1',
+  });
+  const before = (await repo.get('alice'))!.recoveryCreatedAt;
+  await repo.updateWrapRecovery('alice', 'r2');
+  const row = await repo.get('alice');
+  expect(row?.wrapRecovery).toBe('r2');
+  expect(row?.wrapPassphrase).toBe('w1'); // passphrase wrap untouched
+  expect(row!.recoveryCreatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+});
+
+it('delete removes the row', async () => {
+  await repo.create({
+    userId: 'alice', wrapPassphrase: 'w1', passSalt: 's1',
+    argonParams: { m: 65536, t: 3, p: 1 }, wrapRecovery: 'r1',
+  });
+  await repo.delete('alice');
+  expect(await repo.exists('alice')).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** `pnpm test lib/crypto/userCryptoRepository.test.ts`.
+
+- [ ] **Step 3: Implement** — add to `UserCryptoRepository` (import `ArgonParams` from `@/db/schema/userCrypto`; `eq`/`userCrypto` already imported):
+
+```ts
+async updateWrapPassphrase(
+  userId: string,
+  wrapPassphrase: string,
+  passSalt: string,
+  argonParams: ArgonParams
+): Promise<void> {
+  await this.db
+    .update(userCrypto)
+    .set({ wrapPassphrase, passSalt, argonParams })
+    .where(eq(userCrypto.userId, userId));
+}
+
+async updateWrapRecovery(userId: string, wrapRecovery: string): Promise<void> {
+  await this.db
+    .update(userCrypto)
+    .set({ wrapRecovery, recoveryCreatedAt: new Date() })
+    .where(eq(userCrypto.userId, userId));
+}
+
+async delete(userId: string): Promise<void> {
+  await this.db.delete(userCrypto).where(eq(userCrypto.userId, userId));
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**, then **Commit** `git add lib/crypto/userCryptoRepository.ts lib/crypto/userCryptoRepository.test.ts && git commit -m "feat(crypto): userCrypto re-wrap + delete repository methods"`
+
+---
+
+## Task 2: Client re-wrap orchestration (`features/crypto/lib/rewrapFlow.ts`)
+
+**Files:** Create `features/crypto/lib/rewrapFlow.ts`, `features/crypto/lib/rewrapFlow.test.ts`.
+
+**Interfaces — Produces:**
+- `type Authorizer = { kind: 'passphrase'; passphrase: string } | { kind: 'recovery'; code: string }`
+- `obtainDek(authorizer: Authorizer): Promise<Uint8Array>` — fetch material, derive KEK from the authorizer, unwrap the DEK. Throws `'Incorrect passphrase.'` / `'Incorrect recovery code.'` on failure.
+- `changePassphrase(authorizer: Authorizer, newPassphrase: string): Promise<{ wrapPassphrase: string; passSalt: string; argonParams: {m:number;t:number;p:number} }>` — obtain DEK, derive new KEK, wrap, return the new wrap material (the caller posts it via the action).
+- `rotateRecovery(authorizer: Authorizer): Promise<{ wrapRecovery: string; code: string }>` — obtain DEK, generate a new recovery code, wrap, return `{ wrapRecovery, code }` (code shown once).
+
+- [ ] **Step 1: Write the failing test** (build the material fixture with a REAL clientCrypto round-trip so unwrap is genuinely exercised; mock `fetch` for `getMaterial`)
+
+```ts
+// features/crypto/lib/rewrapFlow.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  derivePassphraseKek, fromBase64, generateDek, generateRecoveryCode,
+  recoveryHkdfKey, toBase64, unwrapDek, wrapDek,
+} from './clientCrypto';
+import { changePassphrase, obtainDek, rotateRecovery } from './rewrapFlow';
+
+const ARGON = { m: 512, t: 2, p: 1 };
+
+async function fixtureMaterial(dek: Uint8Array, passphrase: string, recoveryBytes: Uint8Array) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const wrapPassphrase = await wrapDek(dek, await derivePassphraseKek(passphrase, salt, ARGON));
+  const wrapRecovery = await wrapDek(dek, await recoveryHkdfKey(recoveryBytes));
+  return { passSalt: toBase64(salt), argonParams: ARGON, wrapPassphrase, wrapRecovery };
+}
+function stubFetch(material: unknown) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url === '/api/crypto/material') return new Response(JSON.stringify(material), { status: 200 });
+    return new Response(null, { status: 204 }); // unused here
+  }));
+}
+afterEach(() => vi.unstubAllGlobals());
+
+describe('rewrapFlow', () => {
+  it('obtainDek returns the DEK for a correct passphrase', async () => {
+    const dek = generateDek();
+    const { code, bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'right', bytes));
+    const out = await obtainDek({ kind: 'passphrase', passphrase: 'right' });
+    expect([...out]).toEqual([...dek]);
+    void code;
+  });
+
+  it('obtainDek throws on a wrong passphrase', async () => {
+    const dek = generateDek();
+    const { bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'right', bytes));
+    await expect(obtainDek({ kind: 'passphrase', passphrase: 'wrong' })).rejects.toThrow('Incorrect passphrase.');
+  });
+
+  it('changePassphrase produces a wrap the new passphrase can unwrap to the same DEK', async () => {
+    const dek = generateDek();
+    const { bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'old', bytes));
+    const next = await changePassphrase({ kind: 'passphrase', passphrase: 'old' }, 'brand-new');
+    const kek = await derivePassphraseKek('brand-new', fromBase64(next.passSalt), next.argonParams);
+    expect([...(await unwrapDek(next.wrapPassphrase, kek))]).toEqual([...dek]);
+  });
+
+  it('rotateRecovery produces a new code+wrap that unwraps the same DEK', async () => {
+    const dek = generateDek();
+    const { bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'pw', bytes));
+    const { wrapRecovery, code } = await rotateRecovery({ kind: 'passphrase', passphrase: 'pw' });
+    const { parseRecoveryCode } = await import('./clientCrypto');
+    const kek = await recoveryHkdfKey(parseRecoveryCode(code));
+    expect([...(await unwrapDek(wrapRecovery, kek))]).toEqual([...dek]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** `pnpm test features/crypto/lib/rewrapFlow.test.ts`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// features/crypto/lib/rewrapFlow.ts
+import {
+  derivePassphraseKek, generateRecoveryCode, parseRecoveryCode,
+  recoveryHkdfKey, toBase64, unwrapDek, wrapDek, fromBase64,
+} from './clientCrypto';
+
+const ARGON = { m: 65536, t: 3, p: 1 } as const;
+
+type Material = {
+  passSalt: string;
+  argonParams: { m: number; t: number; p: number };
+  wrapPassphrase: string;
+  wrapRecovery: string;
+};
+
+export type Authorizer =
+  | { kind: 'passphrase'; passphrase: string }
+  | { kind: 'recovery'; code: string };
+
+const getMaterial = async (): Promise<Material> => {
+  const res = await fetch('/api/crypto/material');
+  if (!res.ok) throw new Error('Encryption is not set up.');
+  return res.json();
+};
+
+/** Re-obtain the DEK client-side by unwrapping with the current secret. */
+export const obtainDek = async (authorizer: Authorizer): Promise<Uint8Array> => {
+  const m = await getMaterial();
+  if (authorizer.kind === 'passphrase') {
+    const kek = await derivePassphraseKek(authorizer.passphrase, fromBase64(m.passSalt), m.argonParams);
+    return unwrapDek(m.wrapPassphrase, kek).catch(() => {
+      throw new Error('Incorrect passphrase.');
+    });
+  }
+  const kek = await recoveryHkdfKey(parseRecoveryCode(authorizer.code));
+  return unwrapDek(m.wrapRecovery, kek).catch(() => {
+    throw new Error('Incorrect recovery code.');
+  });
+};
+
+export const changePassphrase = async (
+  authorizer: Authorizer,
+  newPassphrase: string
+): Promise<{ wrapPassphrase: string; passSalt: string; argonParams: { m: number; t: number; p: number } }> => {
+  const dek = await obtainDek(authorizer);
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const wrapPassphrase = await wrapDek(dek, await derivePassphraseKek(newPassphrase, salt, ARGON));
+  return { wrapPassphrase, passSalt: toBase64(salt), argonParams: { ...ARGON } };
+};
+
+export const rotateRecovery = async (
+  authorizer: Authorizer
+): Promise<{ wrapRecovery: string; code: string }> => {
+  const dek = await obtainDek(authorizer);
+  const { code, bytes } = generateRecoveryCode();
+  const wrapRecovery = await wrapDek(dek, await recoveryHkdfKey(bytes));
+  return { wrapRecovery, code };
+};
+```
+
+- [ ] **Step 4: Run — expect PASS**, then **Commit** `git add features/crypto/lib/rewrapFlow.ts features/crypto/lib/rewrapFlow.test.ts && git commit -m "feat(crypto): client re-wrap orchestration (change passphrase, rotate recovery)"`
+
+---
+
+## Task 3: Change-passphrase + rotate-recovery server actions
+
+**Files:** Create `lib/crypto/rewrapSchema.ts`, `features/settings/actions/changePassphrase.ts`, `features/settings/actions/rotateRecovery.ts`, and a test for each; modify `features/settings/actions/index.ts`.
+
+**Interfaces — Produces:**
+- `changePassphraseAction(input): Promise<{ ok: true } | { ok: false; message: string }>` — validates `{wrapPassphrase, passSalt, argonParams}`, `requireUser`, `WRITE` rate-limit, requires an existing `userCrypto` row, calls `updateWrapPassphrase`, `revalidatePath`.
+- `rotateRecoveryAction(input): Promise<{ ok: true } | { ok: false; message: string }>` — validates `{wrapRecovery}`, same gating, calls `updateWrapRecovery`.
+
+- [ ] **Step 1: Schema**
+
+```ts
+// lib/crypto/rewrapSchema.ts
+import { z } from 'zod';
+
+const b64 = z.string().regex(/^[A-Za-z0-9+/]+={0,2}$/).min(1).max(512);
+export const changePassphraseSchema = z.object({
+  wrapPassphrase: b64,
+  passSalt: z.string().regex(/^[A-Za-z0-9+/]+={0,2}$/).min(1).max(64),
+  argonParams: z.object({
+    m: z.number().int().positive(),
+    t: z.number().int().positive(),
+    p: z.number().int().positive(),
+  }),
+});
+export const rotateRecoverySchema = z.object({ wrapRecovery: b64 });
+```
+
+- [ ] **Step 2: Failing tests** (mirror `setupCrypto.test.ts`: `setupTestDb`, mock `requireUser` + `getUserCryptoRepository` to a test-DB-backed repo; assert the row's wrap fields change, and that a missing row / malformed payload is rejected). Write one test file per action. Example assertions: after `repo.create(...)`, calling `changePassphraseAction(valid)` updates `wrapPassphrase`/`passSalt`/`argonParams`; calling it for a user with no row returns `{ok:false}`.
+
+- [ ] **Step 3: Implement actions**
+
+```ts
+// features/settings/actions/changePassphrase.ts
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { changePassphraseSchema } from '@/lib/crypto/rewrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function changePassphraseAction(input: unknown): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = changePassphraseSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  const repo = getUserCryptoRepository();
+  if (!(await repo.exists(user.id))) return { ok: false, message: 'Encryption is not set up.' };
+  await repo.updateWrapPassphrase(user.id, parsed.data.wrapPassphrase, parsed.data.passSalt, parsed.data.argonParams);
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+```
+
+```ts
+// features/settings/actions/rotateRecovery.ts
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { rotateRecoverySchema } from '@/lib/crypto/rewrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function rotateRecoveryAction(input: unknown): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = rotateRecoverySchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  const repo = getUserCryptoRepository();
+  if (!(await repo.exists(user.id))) return { ok: false, message: 'Encryption is not set up.' };
+  await repo.updateWrapRecovery(user.id, parsed.data.wrapRecovery);
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+```
+
+Export both from `features/settings/actions/index.ts`.
+
+- [ ] **Step 4: Run tests — expect PASS**, type-check, **Commit** `git add lib/crypto/rewrapSchema.ts features/settings/actions/changePassphrase.ts features/settings/actions/rotateRecovery.ts features/settings/actions/*.test.ts features/settings/actions/index.ts && git commit -m "feat(crypto): change-passphrase + rotate-recovery server actions"`
+
+---
+
+## Task 4: Reset-encryption (service + action)
+
+**Files:** Create `lib/crypto/resetEncryption.ts`, `features/settings/actions/resetEncryption.ts`, and tests; export the action from the actions barrel.
+
+**Interfaces — Produces:**
+- `resetUserEncryption(userId: string, db: DbInstance, deps?: {...}): Promise<void>` — `clearRemote(userId)` + `fs.rm(getJournalDir(userId), {recursive,force})` + `userCryptoRepository.delete(userId)` (via a repo bound to `db`) + `dropSessionDek(userId)` + `journalRepository.ensureLayout(userId)` (recreate empty stub). Inject `clearRemote`/`removeLocalJournal` for tests (mirror `purgeUserData`'s `PurgeDeps`).
+- `resetEncryptionAction(confirm: unknown): Promise<{ ok: true } | { ok: false; reason: 'too-many-attempts' | 'not-confirmed' | 'not-set-up' }>` — `requireUser`, `DESTRUCTIVE` rate-limit, require the typed confirmation phrase, run the reset.
+
+- [ ] **Step 1: Failing test for `resetUserEncryption`** (setupTestDb; create a userCrypto row + a journal dir; inject a fake `clearRemote`/`removeLocalJournal`; assert the row is gone, the injected wipes were called, the DEK dropped, and an empty stub journal exists afterward).
+
+- [ ] **Step 2: Implement `resetUserEncryption`**
+
+```ts
+// lib/crypto/resetEncryption.ts
+import { promises as fs } from 'fs';
+import { UserCryptoRepository } from './userCryptoRepository';
+import { dropSessionDek } from './sessionKeys';
+import { clearRemote as clearRemoteDefault } from '@/lib/storage/sync';
+import { getJournalDir } from '@/lib/journal/layout';
+import { journalRepository } from '@/lib/journal';
+import type { DbInstance } from '@/lib/db/connection';
+
+type ResetDeps = {
+  clearRemote?: (userId: string) => Promise<void>;
+  removeLocalJournal?: (userId: string) => Promise<void>;
+};
+
+export async function resetUserEncryption(
+  userId: string,
+  db: DbInstance,
+  deps: ResetDeps = {}
+): Promise<void> {
+  const clearRemote = deps.clearRemote ?? clearRemoteDefault;
+  const removeLocalJournal =
+    deps.removeLocalJournal ??
+    ((id: string) => fs.rm(getJournalDir(id), { recursive: true, force: true }));
+
+  await clearRemote(userId);                      // wipe encrypted objects in Garage
+  await removeLocalJournal(userId);               // wipe local working dir
+  await new UserCryptoRepository(db).delete(userId); // remove crypto metadata → status 'unset'
+  dropSessionDek(userId);                         // clear any in-RAM DEK
+  await journalRepository.ensureLayout(userId);   // recreate an empty plaintext stub
+}
+```
+
+> **Note for reviewer:** order matters — delete the `userCrypto` row (so `cryptoStatus` is `'unset'`) and drop the DEK BEFORE the user navigates; `ensureLayout` recreates a plaintext stub so the (now un-encrypted) account renders an empty journal and the gate routes to `/crypto/setup`.
+
+- [ ] **Step 3: Implement `resetEncryptionAction`** — `requireUser`; `DESTRUCTIVE` rate-limit; require the confirmation phrase (e.g. the schema accepts the literal string the UI asks the user to type, like `'RESET'`); reject if no `userCrypto` row; call `resetUserEncryption(user.id, db)`; `revalidatePath('/', 'layout')`. Return the discriminated result.
+
+- [ ] **Step 4: Test the action** (mock `requireUser`; assert wrong/absent confirmation → `{ok:false, reason:'not-confirmed'}`; correct confirmation triggers the reset). Run, type-check, **Commit** `git add lib/crypto/resetEncryption.ts features/settings/actions/resetEncryption.ts lib/crypto/resetEncryption.test.ts features/settings/actions/resetEncryption.test.ts features/settings/actions/index.ts && git commit -m "feat(crypto): reset-encryption service + action"`
+
+---
+
+## Task 5: Settings → Security UI
+
+**Files:** Create `features/settings/SecuritySection.tsx` + `ChangePassphraseCard.tsx` + `RotateRecoveryCard.tsx` + `ResetEncryptionCard.tsx`; modify `features/settings/Settings.tsx` + `app/settings/page.tsx`.
+
+**Design task — shadcn (match the existing `Settings.tsx`/`DangerZone.tsx` conventions, NOT au-*). Pair with frontend-design for polish.**
+
+- [ ] **Step 1:** `app/settings/page.tsx` — also fetch `cryptoStatus(user.id)` (from `@/lib/crypto/gate`) or `getUserCryptoRepository().exists(user.id)` and pass `encryptionEnabled` to `<Settings>`. (When `false`, the Security section can show a short "encryption not set up" note or hide — but in practice the gate forces setup, so an authenticated settings visitor is always enabled; render the section when enabled.)
+- [ ] **Step 2:** `Settings.tsx` — render `<SecuritySection enabled={encryptionEnabled} />` below the base-currency card and above `<DangerZone/>`.
+- [ ] **Step 3:** `SecuritySection.tsx` — a `<Card>` titled "Security" containing the three cards/sub-forms:
+  - **ChangePassphraseCard** — fields: current passphrase (with a "Forgot? use recovery code" toggle that swaps to a recovery-code field), new passphrase + confirm (match + min-length, reuse the wizard's strength hint if cheap). On submit: build the authorizer, call `changePassphrase(authorizer, newPassphrase)` (Task 2), then `changePassphraseAction(result)` (Task 3); show success/error via `Alert`/toast. Errors from `obtainDek` ("Incorrect passphrase." / "Incorrect recovery code.") surface inline.
+  - **RotateRecoveryCard** — authorizer field (current passphrase, with recovery toggle) → on submit call `rotateRecovery(authorizer)` then `rotateRecoveryAction({wrapRecovery})`; on success display the NEW recovery code once (grouped, copy + download, like the wizard's recovery step) with a "I've saved it" acknowledgement.
+  - **ResetEncryptionCard** — a destructive card (model on `DangerZone`): explains it permanently deletes the encrypted journal and cannot be undone; a confirm dialog requires typing the confirmation phrase; on confirm call `resetEncryptionAction(phrase)`; on success `window.location.assign('/crypto/setup')` (hard nav so the gate re-routes).
+- [ ] **Step 4: Verify (no live env):** `pnpm type-check` clean, `pnpm lint` clean, `pnpm test` (full suite — confirm no regression from the settings-page change). The live visual + e2e acceptance (each flow against a real unlocked session) is the user's pass — note it in the report.
+- [ ] **Step 5: Commit** `git add features/settings/SecuritySection.tsx features/settings/ChangePassphraseCard.tsx features/settings/RotateRecoveryCard.tsx features/settings/ResetEncryptionCard.tsx features/settings/Settings.tsx app/settings/page.tsx && git commit -m "feat(crypto): settings security section (change passphrase, rotate recovery, reset)"`
+
+---
+
+## Task 6: Full-suite + acceptance handoff
+
+- [ ] **Step 1:** `pnpm test` (full suite green), `pnpm type-check`, `pnpm lint` clean.
+- [ ] **Step 2:** End-to-end manual smoke (USER, live env): change passphrase (via current, and via recovery "forgot" path) → re-unlock with the new passphrase; rotate recovery → old code rejected, new code unlocks; reset encryption → journal wiped, routed to `/crypto/setup`, can re-set-up. Confirm the DEK/journal data integrity (a passphrase change does NOT re-encrypt or corrupt the journal — reports render identically after).
+- [ ] **Step 3:** Commit any fixups (`fix(crypto): …`).
+
+---
+
+## Open decision (confirm before/while implementing)
+
+**Reset-encryption confirmation strength.** This plan defaults to a **typed-confirmation dialog** (type a phrase) + `DESTRUCTIVE` rate-limit. Reset destroys all journal data irreversibly (the ciphertext is unreadable without the key being discarded). Account deletion uses a stronger **emailed 6-digit code** flow. If you want reset to be equally guarded, swap Task 4's confirmation for the account-deletion challenge pattern (`requestAccountDeletion`/`verifyAndDelete` analog). Default = typed confirmation; upgrade on request.
+
+## Out of scope (later)
+
+- Passkey-PRF unlock (the remaining fast-follow): add/remove passkey would also belong in this Security section once PRF lands.
+
+## Self-Review
+
+**Spec coverage (P3 slice of the v2 design):** change passphrase → Tasks 2/3/5; forgot-passphrase (recovery) → folded into change-passphrase's recovery authorizer (Tasks 2/5); rotate recovery code → Tasks 2/3/5; reset encryption → Task 4/5. Re-wrap keeps the DEK unchanged (no journal re-encryption) → Task 2 design. ✓
+
+**Placeholder scan:** Task 3 Step 2 and Task 4 Steps 1/3 describe test/impl shape with concrete assertions and full action code; the UI task specifies fixed orchestration (which client+action functions each card calls) + shadcn acceptance rather than full JSX (iterative UI, paired with frontend-design). No TBDs.
+
+**Type consistency:** `updateWrapPassphrase`/`updateWrapRecovery`/`delete` (Task 1) consumed by Tasks 3/4; `obtainDek`/`changePassphrase`/`rotateRecovery`/`Authorizer` (Task 2) consumed by Task 5; `changePassphraseAction`/`rotateRecoveryAction` (Task 3) + `resetEncryptionAction` (Task 4) consumed by Task 5; reuses P2's `clientCrypto`/`getMaterial`, `getUserCryptoRepository`, `dropSessionDek`, `clearRemote`, `getJournalDir`, `journalRepository.ensureLayout`, `purgeUserData`-style `PurgeDeps` injection — all as they exist on the P2 branch (incl. the user's `migratedAt` additions; reset deletes the row so `migratedAt` is cleared with it). ✓
+
+**Verification points for implementers:** (a) confirm `journalRepository` is exported from `@/lib/journal` and `ensureLayout` recreates the stub; (b) confirm the `DbInstance` reachable by `resetEncryptionAction` (production `db` from `@/lib/db`) and how the singleton is exercised in the action test (mirror `setupCrypto.test.ts` / `purge` tests).

--- a/docs/superpowers/plans/2026-06-25-encrypted-journals-p3.md
+++ b/docs/superpowers/plans/2026-06-25-encrypted-journals-p3.md
@@ -24,8 +24,9 @@
 **Create:**
 - `lib/crypto/rewrapSchema.ts` — Zod schemas for the change-passphrase / rotate-recovery payloads (shared with the actions).
 - `features/crypto/lib/rewrapFlow.ts` — client orchestration: `obtainDek(authorizer)`, `changePassphrase(authorizer, newPassphrase)`, `rotateRecovery(authorizer)`.
-- `lib/crypto/resetEncryption.ts` — server `resetUserEncryption(userId, deps?)` (clearRemote + rm dir + repo.delete + ensureLayout + dropSessionDek).
-- `features/settings/actions/changePassphrase.ts`, `features/settings/actions/rotateRecovery.ts`, `features/settings/actions/resetEncryption.ts` — server actions.
+- `lib/crypto/resetEncryption.ts` — server `resetUserEncryption(userId, db, deps?)` (clearRemote + rm dir + repo.delete + dropSessionDek + ensureLayout).
+- `db/schema/encryptionResetChallenge.ts` (+ migration) and `lib/crypto/resetChallenge/` (repository + service + schema) — emailed-code challenge for reset, modelled on `lib/account-deletion/`.
+- `features/settings/actions/changePassphrase.ts`, `rotateRecovery.ts`, `requestEncryptionReset.ts`, `confirmEncryptionReset.ts` — server actions.
 - `features/settings/SecuritySection.tsx` (+ `ChangePassphraseCard.tsx`, `RotateRecoveryCard.tsx`, `ResetEncryptionCard.tsx`) — the Security UI.
 - Tests alongside each.
 
@@ -347,13 +348,12 @@ Export both from `features/settings/actions/index.ts`.
 
 ---
 
-## Task 4: Reset-encryption (service + action)
+## Task 4: Reset-encryption — wipe service (`resetUserEncryption`)
 
-**Files:** Create `lib/crypto/resetEncryption.ts`, `features/settings/actions/resetEncryption.ts`, and tests; export the action from the actions barrel.
+**Files:** Create `lib/crypto/resetEncryption.ts`, `lib/crypto/resetEncryption.test.ts`.
 
 **Interfaces — Produces:**
 - `resetUserEncryption(userId: string, db: DbInstance, deps?: {...}): Promise<void>` — `clearRemote(userId)` + `fs.rm(getJournalDir(userId), {recursive,force})` + `userCryptoRepository.delete(userId)` (via a repo bound to `db`) + `dropSessionDek(userId)` + `journalRepository.ensureLayout(userId)` (recreate empty stub). Inject `clearRemote`/`removeLocalJournal` for tests (mirror `purgeUserData`'s `PurgeDeps`).
-- `resetEncryptionAction(confirm: unknown): Promise<{ ok: true } | { ok: false; reason: 'too-many-attempts' | 'not-confirmed' | 'not-set-up' }>` — `requireUser`, `DESTRUCTIVE` rate-limit, require the typed confirmation phrase, run the reset.
 
 - [ ] **Step 1: Failing test for `resetUserEncryption`** (setupTestDb; create a userCrypto row + a journal dir; inject a fake `clearRemote`/`removeLocalJournal`; assert the row is gone, the injected wipes were called, the DEK dropped, and an empty stub journal exists afterward).
 
@@ -392,11 +392,27 @@ export async function resetUserEncryption(
 }
 ```
 
-> **Note for reviewer:** order matters — delete the `userCrypto` row (so `cryptoStatus` is `'unset'`) and drop the DEK BEFORE the user navigates; `ensureLayout` recreates a plaintext stub so the (now un-encrypted) account renders an empty journal and the gate routes to `/crypto/setup`.
+> **Note for reviewer:** order matters — delete the `userCrypto` row (so `cryptoStatus` is `'unset'`) and drop the DEK; `ensureLayout` recreates a plaintext stub so the (now un-encrypted) account renders an empty journal and the gate routes to `/crypto/setup`. Deleting the row also clears `migratedAt`.
 
-- [ ] **Step 3: Implement `resetEncryptionAction`** — `requireUser`; `DESTRUCTIVE` rate-limit; require the confirmation phrase (e.g. the schema accepts the literal string the UI asks the user to type, like `'RESET'`); reject if no `userCrypto` row; call `resetUserEncryption(user.id, db)`; `revalidatePath('/', 'layout')`. Return the discriminated result.
+- [ ] **Step 3: Run — expect PASS**, **Commit** `git add lib/crypto/resetEncryption.ts lib/crypto/resetEncryption.test.ts && git commit -m "feat(crypto): resetUserEncryption wipe service (keeps account)"`
 
-- [ ] **Step 4: Test the action** (mock `requireUser`; assert wrong/absent confirmation → `{ok:false, reason:'not-confirmed'}`; correct confirmation triggers the reset). Run, type-check, **Commit** `git add lib/crypto/resetEncryption.ts features/settings/actions/resetEncryption.ts lib/crypto/resetEncryption.test.ts features/settings/actions/resetEncryption.test.ts features/settings/actions/index.ts && git commit -m "feat(crypto): reset-encryption service + action"`
+---
+
+## Task 4b: Reset-encryption — emailed-code challenge + actions
+
+**Decision (locked):** reset is guarded by an **emailed 6-digit code**, equal in strength to account deletion. Build a **parallel, self-contained** challenge modelled on `lib/account-deletion/` — do NOT reuse `accountDeletionChallenge` (a deletion code must not authorize a reset) and do NOT modify the shipped account-deletion feature.
+
+**Files:** Create `db/schema/encryptionResetChallenge.ts` (+ barrel export + drizzle migration), `lib/crypto/resetChallenge/` (`repository.ts`, `service.ts`, `schema.ts`, `index.ts` + tests), `features/settings/actions/requestEncryptionReset.ts`, `features/settings/actions/confirmEncryptionReset.ts` (+ tests); modify `features/settings/actions/index.ts`.
+
+**Model precisely on these existing files** (read them; mirror structure, hashing, expiry, attempt-cap, and the email transport):
+- `db/schema/accountDeletionChallenge.ts` → `encryptionResetChallenge` (identical columns: `userId` PK→user cascade, `codeHash`, `expiresAt`, `attempts`, `createdAt`).
+- `lib/account-deletion/{schema.ts,repository.ts,service.ts}` → the reset-challenge schema (6-digit `resetCodeSchema`), repository (upsert challenge / get / increment attempts / delete), and service (`requestReset` = generate code → hash → upsert → email; `verifyAndReset` = load → check expiry/attempts/hash → on success call `resetUserEncryption(userId, db)` from Task 4 → delete challenge; on failure increment attempts, return remaining). Reuse the SAME pure code-gen + hashing helpers account-deletion uses (import them if exported; otherwise mirror).
+- `features/settings/actions/requestAccountDeletion.ts` + `deleteAccount.ts` → `requestEncryptionResetAction()` (`requireUser`, `DESTRUCTIVE` rate-limit, require a `userCrypto` row exists, call `resetChallengeService.requestReset(user.id, user.email)`) and `confirmEncryptionResetAction(code)` (`requireUser`, `DESTRUCTIVE` rate-limit, validate code, call `verifyAndReset` → returns `{ ok:true } | { ok:false, reason:'too-many-attempts'|'invalid'|'not-set-up', remaining? }`). `revalidatePath('/', 'layout')` after a successful reset.
+
+- [ ] **Step 1:** Create the `encryptionResetChallenge` schema (mirror `accountDeletionChallenge.ts`), export from `db/schema/index.ts`, add to `drizzle.config.ts` `tablesFilter`, run `pnpm db:generate`, confirm the migration creates only that table.
+- [ ] **Step 2:** Write the reset-challenge schema/repository/service with failing tests first, mirroring `lib/account-deletion/` (request → hashed code stored + emailed; verify → expiry/attempt/hash checks → `resetUserEncryption` on success). Use the injected-deps pattern from `account-deletion/service.test.ts` so tests don't send real email and don't wipe real storage.
+- [ ] **Step 3:** Write the two actions with tests (mock `requireUser`; assert request is gated on an existing `userCrypto` row + rate-limited; confirm rejects bad/expired codes and, on a valid code, invokes the reset).
+- [ ] **Step 4:** Run tests + type-check, **Commit** `git add db/schema/encryptionResetChallenge.ts db/schema/index.ts drizzle.config.ts db/migrations lib/crypto/resetChallenge features/settings/actions/requestEncryptionReset.ts features/settings/actions/confirmEncryptionReset.ts features/settings/actions/*.test.ts features/settings/actions/index.ts && git commit -m "feat(crypto): emailed-code challenge for reset-encryption"`
 
 ---
 
@@ -411,7 +427,7 @@ export async function resetUserEncryption(
 - [ ] **Step 3:** `SecuritySection.tsx` — a `<Card>` titled "Security" containing the three cards/sub-forms:
   - **ChangePassphraseCard** — fields: current passphrase (with a "Forgot? use recovery code" toggle that swaps to a recovery-code field), new passphrase + confirm (match + min-length, reuse the wizard's strength hint if cheap). On submit: build the authorizer, call `changePassphrase(authorizer, newPassphrase)` (Task 2), then `changePassphraseAction(result)` (Task 3); show success/error via `Alert`/toast. Errors from `obtainDek` ("Incorrect passphrase." / "Incorrect recovery code.") surface inline.
   - **RotateRecoveryCard** — authorizer field (current passphrase, with recovery toggle) → on submit call `rotateRecovery(authorizer)` then `rotateRecoveryAction({wrapRecovery})`; on success display the NEW recovery code once (grouped, copy + download, like the wizard's recovery step) with a "I've saved it" acknowledgement.
-  - **ResetEncryptionCard** — a destructive card (model on `DangerZone`): explains it permanently deletes the encrypted journal and cannot be undone; a confirm dialog requires typing the confirmation phrase; on confirm call `resetEncryptionAction(phrase)`; on success `window.location.assign('/crypto/setup')` (hard nav so the gate re-routes).
+  - **ResetEncryptionCard** — a destructive card modelled on `DangerZone`'s **two-phase emailed-code** flow: explains it permanently deletes the encrypted journal and cannot be undone; "Reset encryption" → calls `requestEncryptionResetAction()` (emails a code) → reveals a 6-digit code input + Resend; on confirm calls `confirmEncryptionResetAction(code)`; on success `window.location.assign('/crypto/setup')` (hard nav so the gate re-routes). Surface `too-many-attempts`/`invalid`/remaining-attempts inline like `DangerZone`.
 - [ ] **Step 4: Verify (no live env):** `pnpm type-check` clean, `pnpm lint` clean, `pnpm test` (full suite — confirm no regression from the settings-page change). The live visual + e2e acceptance (each flow against a real unlocked session) is the user's pass — note it in the report.
 - [ ] **Step 5: Commit** `git add features/settings/SecuritySection.tsx features/settings/ChangePassphraseCard.tsx features/settings/RotateRecoveryCard.tsx features/settings/ResetEncryptionCard.tsx features/settings/Settings.tsx app/settings/page.tsx && git commit -m "feat(crypto): settings security section (change passphrase, rotate recovery, reset)"`
 
@@ -425,9 +441,9 @@ export async function resetUserEncryption(
 
 ---
 
-## Open decision (confirm before/while implementing)
+## Resolved decision
 
-**Reset-encryption confirmation strength.** This plan defaults to a **typed-confirmation dialog** (type a phrase) + `DESTRUCTIVE` rate-limit. Reset destroys all journal data irreversibly (the ciphertext is unreadable without the key being discarded). Account deletion uses a stronger **emailed 6-digit code** flow. If you want reset to be equally guarded, swap Task 4's confirmation for the account-deletion challenge pattern (`requestAccountDeletion`/`verifyAndDelete` analog). Default = typed confirmation; upgrade on request.
+**Reset-encryption confirmation = emailed 6-digit code** (locked by the user) — equal in strength to account deletion. Implemented as a parallel, self-contained challenge in Task 4b (do not reuse the account-deletion challenge; do not modify account deletion).
 
 ## Out of scope (later)
 
@@ -435,7 +451,7 @@ export async function resetUserEncryption(
 
 ## Self-Review
 
-**Spec coverage (P3 slice of the v2 design):** change passphrase → Tasks 2/3/5; forgot-passphrase (recovery) → folded into change-passphrase's recovery authorizer (Tasks 2/5); rotate recovery code → Tasks 2/3/5; reset encryption → Task 4/5. Re-wrap keeps the DEK unchanged (no journal re-encryption) → Task 2 design. ✓
+**Spec coverage (P3 slice of the v2 design):** change passphrase → Tasks 2/3/5; forgot-passphrase (recovery) → folded into change-passphrase's recovery authorizer (Tasks 2/5); rotate recovery code → Tasks 2/3/5; reset encryption (emailed-code, wipe-but-keep-account) → Tasks 4 (wipe service) + 4b (challenge + actions) + 5 (two-phase card). Re-wrap keeps the DEK unchanged (no journal re-encryption) → Task 2 design. ✓
 
 **Placeholder scan:** Task 3 Step 2 and Task 4 Steps 1/3 describe test/impl shape with concrete assertions and full action code; the UI task specifies fixed orchestration (which client+action functions each card calls) + shadcn acceptance rather than full JSX (iterative UI, paired with frontend-design). No TBDs.
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
     'commodity_price',
     'price_fetch_run',
     'savedView',
+    'encryptionResetChallenge',
   ],
 });

--- a/features/crypto/lib/cryptoMaterial.ts
+++ b/features/crypto/lib/cryptoMaterial.ts
@@ -1,0 +1,12 @@
+import type { CryptoMaterial } from '@/lib/crypto/setupSchema';
+
+/**
+ * Fetch the wrapped key-material the server hands back (GET /api/crypto/material).
+ * Single source of truth for the `/api/crypto/material` contract so the unlock
+ * and rewrap unwrap paths can't drift.
+ */
+export const getMaterial = async (): Promise<CryptoMaterial> => {
+  const res = await fetch('/api/crypto/material');
+  if (!res.ok) throw new Error('Encryption is not set up.');
+  return res.json() as Promise<CryptoMaterial>;
+};

--- a/features/crypto/lib/rewrapFlow.test.ts
+++ b/features/crypto/lib/rewrapFlow.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  derivePassphraseKek,
+  fromBase64,
+  generateDek,
+  generateRecoveryCode,
+  recoveryHkdfKey,
+  toBase64,
+  unwrapDek,
+  wrapDek,
+} from './clientCrypto';
+import { changePassphrase, obtainDek, rotateRecovery } from './rewrapFlow';
+
+const ARGON = { m: 512, t: 2, p: 1 };
+
+async function fixtureMaterial(
+  dek: Uint8Array,
+  passphrase: string,
+  recoveryBytes: Uint8Array
+) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const wrapPassphrase = await wrapDek(
+    dek,
+    await derivePassphraseKek(passphrase, salt, ARGON)
+  );
+  const wrapRecovery = await wrapDek(dek, await recoveryHkdfKey(recoveryBytes));
+  return {
+    passSalt: toBase64(salt),
+    argonParams: ARGON,
+    wrapPassphrase,
+    wrapRecovery,
+  };
+}
+function stubFetch(material: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      if (url === '/api/crypto/material')
+        return new Response(JSON.stringify(material), { status: 200 });
+      return new Response(null, { status: 204 }); // unused here
+    })
+  );
+}
+afterEach(() => vi.unstubAllGlobals());
+
+describe('rewrapFlow', () => {
+  it('obtainDek returns the DEK for a correct passphrase', async () => {
+    const dek = generateDek();
+    const { code, bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'right', bytes));
+    const out = await obtainDek({ kind: 'passphrase', passphrase: 'right' });
+    expect([...out]).toEqual([...dek]);
+    void code;
+  });
+
+  it('obtainDek throws on a wrong passphrase', async () => {
+    const dek = generateDek();
+    const { bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'right', bytes));
+    await expect(
+      obtainDek({ kind: 'passphrase', passphrase: 'wrong' })
+    ).rejects.toThrow('Incorrect passphrase.');
+  });
+
+  it('changePassphrase produces a wrap the new passphrase can unwrap to the same DEK', async () => {
+    const dek = generateDek();
+    const { bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'old', bytes));
+    const next = await changePassphrase(
+      { kind: 'passphrase', passphrase: 'old' },
+      'brand-new'
+    );
+    const kek = await derivePassphraseKek(
+      'brand-new',
+      fromBase64(next.passSalt),
+      next.argonParams
+    );
+    expect([...(await unwrapDek(next.wrapPassphrase, kek))]).toEqual([...dek]);
+  });
+
+  it('rotateRecovery produces a new code+wrap that unwraps the same DEK', async () => {
+    const dek = generateDek();
+    const { bytes } = generateRecoveryCode();
+    stubFetch(await fixtureMaterial(dek, 'pw', bytes));
+    const { wrapRecovery, code } = await rotateRecovery({
+      kind: 'passphrase',
+      passphrase: 'pw',
+    });
+    const { parseRecoveryCode } = await import('./clientCrypto');
+    const kek = await recoveryHkdfKey(parseRecoveryCode(code));
+    expect([...(await unwrapDek(wrapRecovery, kek))]).toEqual([...dek]);
+  });
+});

--- a/features/crypto/lib/rewrapFlow.ts
+++ b/features/crypto/lib/rewrapFlow.ts
@@ -1,0 +1,80 @@
+import {
+  derivePassphraseKek,
+  generateRecoveryCode,
+  parseRecoveryCode,
+  recoveryHkdfKey,
+  toBase64,
+  unwrapDek,
+  wrapDek,
+  fromBase64,
+} from './clientCrypto';
+
+const ARGON = { m: 65536, t: 3, p: 1 } as const;
+
+type Material = {
+  passSalt: string;
+  argonParams: { m: number; t: number; p: number };
+  wrapPassphrase: string;
+  wrapRecovery: string;
+};
+
+export type Authorizer =
+  | { kind: 'passphrase'; passphrase: string }
+  | { kind: 'recovery'; code: string };
+
+const getMaterial = async (): Promise<Material> => {
+  const res = await fetch('/api/crypto/material');
+  if (!res.ok) throw new Error('Encryption is not set up.');
+  return res.json();
+};
+
+/** Re-obtain the DEK client-side by unwrapping with the current secret. */
+export const obtainDek = async (
+  authorizer: Authorizer
+): Promise<Uint8Array> => {
+  const m = await getMaterial();
+  if (authorizer.kind === 'passphrase') {
+    const kek = await derivePassphraseKek(
+      authorizer.passphrase,
+      fromBase64(m.passSalt),
+      m.argonParams
+    );
+    return unwrapDek(m.wrapPassphrase, kek).catch(() => {
+      throw new Error('Incorrect passphrase.');
+    });
+  }
+  const kek = await recoveryHkdfKey(parseRecoveryCode(authorizer.code));
+  return unwrapDek(m.wrapRecovery, kek).catch(() => {
+    throw new Error('Incorrect recovery code.');
+  });
+};
+
+export const changePassphrase = async (
+  authorizer: Authorizer,
+  newPassphrase: string
+): Promise<{
+  wrapPassphrase: string;
+  passSalt: string;
+  argonParams: { m: number; t: number; p: number };
+}> => {
+  const dek = await obtainDek(authorizer);
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const wrapPassphrase = await wrapDek(
+    dek,
+    await derivePassphraseKek(newPassphrase, salt, ARGON)
+  );
+  return {
+    wrapPassphrase,
+    passSalt: toBase64(salt),
+    argonParams: { ...ARGON },
+  };
+};
+
+export const rotateRecovery = async (
+  authorizer: Authorizer
+): Promise<{ wrapRecovery: string; code: string }> => {
+  const dek = await obtainDek(authorizer);
+  const { code, bytes } = generateRecoveryCode();
+  const wrapRecovery = await wrapDek(dek, await recoveryHkdfKey(bytes));
+  return { wrapRecovery, code };
+};

--- a/features/crypto/lib/rewrapFlow.ts
+++ b/features/crypto/lib/rewrapFlow.ts
@@ -8,25 +8,13 @@ import {
   wrapDek,
   fromBase64,
 } from './clientCrypto';
+import { getMaterial } from './cryptoMaterial';
 
 const ARGON = { m: 65536, t: 3, p: 1 } as const;
-
-type Material = {
-  passSalt: string;
-  argonParams: { m: number; t: number; p: number };
-  wrapPassphrase: string;
-  wrapRecovery: string;
-};
 
 export type Authorizer =
   | { kind: 'passphrase'; passphrase: string }
   | { kind: 'recovery'; code: string };
-
-const getMaterial = async (): Promise<Material> => {
-  const res = await fetch('/api/crypto/material');
-  if (!res.ok) throw new Error('Encryption is not set up.');
-  return res.json();
-};
 
 /** Re-obtain the DEK client-side by unwrapping with the current secret. */
 export const obtainDek = async (

--- a/features/crypto/lib/unlockFlow.ts
+++ b/features/crypto/lib/unlockFlow.ts
@@ -6,13 +6,7 @@ import {
   toBase64,
   unwrapDek,
 } from './clientCrypto';
-import type { CryptoMaterial } from '@/lib/crypto/setupSchema';
-
-const getMaterial = async (): Promise<CryptoMaterial> => {
-  const res = await fetch('/api/crypto/material');
-  if (!res.ok) throw new Error('Encryption is not set up.');
-  return res.json() as Promise<CryptoMaterial>;
-};
+import { getMaterial } from './cryptoMaterial';
 
 export const postDek = async (dek: Uint8Array): Promise<void> => {
   const res = await fetch('/api/crypto/unlock', {

--- a/features/settings/ChangePassphraseCard.tsx
+++ b/features/settings/ChangePassphraseCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 import { changePassphraseAction } from './actions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -22,7 +22,6 @@ const ChangePassphraseCard = () => {
   const [confirmPass, setConfirmPass] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  const formRef = useRef<HTMLFormElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -74,11 +73,7 @@ const ChangePassphraseCard = () => {
         <CardTitle>Change passphrase</CardTitle>
       </CardHeader>
       <CardContent>
-        <form
-          ref={formRef}
-          onSubmit={handleSubmit}
-          className="flex flex-col gap-4"
-        >
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
             <div className="flex items-center justify-between">
               <Label htmlFor="current-secret">

--- a/features/settings/ChangePassphraseCard.tsx
+++ b/features/settings/ChangePassphraseCard.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { toast } from 'sonner';
+import { changePassphraseAction } from './actions';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  changePassphrase,
+  type Authorizer,
+} from '@/features/crypto/lib/rewrapFlow';
+
+const MIN_LENGTH = 8;
+
+const ChangePassphraseCard = () => {
+  const [useForgot, setUseForgot] = useState(false);
+  const [currentSecret, setCurrentSecret] = useState('');
+  const [newPass, setNewPass] = useState('');
+  const [confirmPass, setConfirmPass] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (newPass.length < MIN_LENGTH) {
+      setError(`New passphrase must be at least ${MIN_LENGTH} characters.`);
+      return;
+    }
+    if (newPass !== confirmPass) {
+      setError('Passphrases do not match.');
+      return;
+    }
+
+    const authorizer: Authorizer = useForgot
+      ? { kind: 'recovery', code: currentSecret }
+      : { kind: 'passphrase', passphrase: currentSecret };
+
+    setPending(true);
+    try {
+      const wrap = await changePassphrase(authorizer, newPass);
+      const res = await changePassphraseAction(wrap);
+      if (!res.ok) {
+        setError(
+          res.message ?? 'Could not update passphrase. Please try again.'
+        );
+        return;
+      }
+      toast.success('Passphrase updated.');
+      setCurrentSecret('');
+      setNewPass('');
+      setConfirmPass('');
+      setUseForgot(false);
+    } catch (err) {
+      // obtainDek throws 'Incorrect passphrase.' / 'Incorrect recovery code.'
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Something went wrong. Please try again.'
+      );
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Change passphrase</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form
+          ref={formRef}
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="current-secret">
+                {useForgot ? 'Recovery code' : 'Current passphrase'}
+              </Label>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline transition-colors"
+                onClick={() => {
+                  setUseForgot((v) => !v);
+                  setCurrentSecret('');
+                  setError(null);
+                }}
+              >
+                {useForgot
+                  ? 'Use passphrase instead'
+                  : 'Forgot? Use recovery code'}
+              </button>
+            </div>
+            <Input
+              id="current-secret"
+              type={useForgot ? 'text' : 'password'}
+              autoComplete={useForgot ? 'off' : 'current-password'}
+              placeholder={useForgot ? 'xxxx-xxxx-xxxx-xxxx-xxxx' : ''}
+              value={currentSecret}
+              onChange={(e) => setCurrentSecret(e.target.value)}
+              disabled={pending}
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-pass">New passphrase</Label>
+            <Input
+              id="new-pass"
+              type="password"
+              autoComplete="new-password"
+              value={newPass}
+              onChange={(e) => setNewPass(e.target.value)}
+              disabled={pending}
+              required
+              minLength={MIN_LENGTH}
+            />
+            {newPass.length > 0 && newPass.length < MIN_LENGTH && (
+              <p className="text-muted-foreground text-xs">
+                At least {MIN_LENGTH} characters required (
+                {MIN_LENGTH - newPass.length} more).
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="confirm-pass">Confirm new passphrase</Label>
+            <Input
+              id="confirm-pass"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPass}
+              onChange={(e) => setConfirmPass(e.target.value)}
+              disabled={pending}
+              required
+            />
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button
+            type="submit"
+            size="sm"
+            className="w-fit"
+            disabled={pending || !currentSecret || !newPass || !confirmPass}
+          >
+            {pending ? 'Updating…' : 'Update passphrase'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ChangePassphraseCard;

--- a/features/settings/ResetEncryptionCard.tsx
+++ b/features/settings/ResetEncryptionCard.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  requestEncryptionResetAction,
+  confirmEncryptionResetAction,
+} from './actions';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type Phase = 'idle' | 'code-sent';
+
+const ResetEncryptionCard = () => {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const sendCode = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await requestEncryptionResetAction();
+      if (!res.ok) {
+        if (res.reason === 'throttled') {
+          toast.error('Please wait a moment before requesting another code.');
+        } else if (res.reason === 'not-set-up') {
+          toast.error('Encryption is not set up for this account.');
+        } else {
+          toast.error('Could not send a verification code. Please try again.');
+        }
+        return;
+      }
+      setPhase('code-sent');
+      toast.success('Verification code sent to your email.');
+    } catch {
+      // The server logs the real cause (e.g. email transport down); surface a
+      // generic failure so the user knows the request did not go through.
+      toast.error('Could not send a verification code. Please try again.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const confirmReset = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await confirmEncryptionResetAction(code);
+      if (res.ok) {
+        // Hard nav so the crypto gate sees the reset state and re-routes to setup.
+        window.location.assign('/crypto/setup');
+        return;
+      }
+      switch (res.reason) {
+        case 'no-code':
+          setError('Request a new code.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'expired':
+          setError('That code expired. Request a new one.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'too-many-attempts':
+          setError('Too many attempts. Request a new code.');
+          setPhase('idle');
+          setCode('');
+          break;
+        case 'invalid':
+          setError(
+            res.remaining > 0
+              ? `Incorrect code. ${res.remaining} attempt(s) left.`
+              : 'Enter the 6-digit code from your email.'
+          );
+          break;
+      }
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Card className="border-destructive/50">
+      <CardHeader>
+        <CardTitle className="text-destructive">Reset encryption</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <Alert variant="destructive">
+          <AlertTitle>This action is irreversible</AlertTitle>
+          <AlertDescription>
+            Resetting encryption permanently deletes your encrypted journal and
+            all its data. You will need to set up encryption again from scratch.
+            This cannot be undone.
+          </AlertDescription>
+        </Alert>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {phase === 'idle' ? (
+          <Button
+            variant="destructive"
+            size="sm"
+            className="w-fit"
+            disabled={pending}
+            onClick={sendCode}
+          >
+            Email me a verification code
+          </Button>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="reset-code">
+                Enter the 6-digit code from your email
+              </Label>
+              <Input
+                id="reset-code"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={6}
+                value={code}
+                onChange={(e) =>
+                  setCode(e.target.value.replace(/\D/g, '').slice(0, 6))
+                }
+                className="w-40 tracking-[0.3em]"
+                disabled={pending}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={pending || code.length !== 6}
+                onClick={confirmReset}
+              >
+                Confirm reset
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={pending}
+                onClick={sendCode}
+              >
+                Resend
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ResetEncryptionCard;

--- a/features/settings/RotateRecoveryCard.tsx
+++ b/features/settings/RotateRecoveryCard.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { Copy, Download, Check } from 'lucide-react';
+import { useState, useRef } from 'react';
+import { toast } from 'sonner';
+import { rotateRecoveryAction } from './actions';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  rotateRecovery,
+  type Authorizer,
+} from '@/features/crypto/lib/rewrapFlow';
+
+const RotateRecoveryCard = () => {
+  const [useForgot, setUseForgot] = useState(false);
+  const [secret, setSecret] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  // Revealed only after confirmed server-side persist
+  const [newCode, setNewCode] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const authorizer: Authorizer = useForgot
+      ? { kind: 'recovery', code: secret }
+      : { kind: 'passphrase', passphrase: secret };
+
+    setPending(true);
+    try {
+      const { wrapRecovery, code } = await rotateRecovery(authorizer);
+      const res = await rotateRecoveryAction({ wrapRecovery });
+      if (!res.ok) {
+        // Do NOT reveal code — rotation did not persist.
+        setError(
+          res.message ?? 'Could not rotate recovery code. Please try again.'
+        );
+        return;
+      }
+      // Only reveal after confirmed persist.
+      setNewCode(code);
+      setSaved(false);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Something went wrong. Please try again.'
+      );
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!newCode) return;
+    try {
+      await navigator.clipboard.writeText(newCode);
+      setCopied(true);
+      if (copyTimeout.current) clearTimeout(copyTimeout.current);
+      copyTimeout.current = setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // ignore clipboard errors — user can still copy manually
+    }
+  };
+
+  const handleDownload = () => {
+    if (!newCode) return;
+    const blob = new Blob(
+      [
+        'Ledger Recovery Code\n',
+        `Generated: ${new Date().toISOString()}\n\n`,
+        newCode,
+        '\n\nStore this safely. This code is shown once and cannot be retrieved later.\n',
+      ],
+      { type: 'text/plain' }
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'ledger-recovery-code.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDone = () => {
+    setNewCode(null);
+    setSaved(false);
+    setSecret('');
+    setUseForgot(false);
+    toast.success('Recovery code rotated. Keep the new code safe.');
+  };
+
+  if (newCode) {
+    const groups = newCode.split('-');
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>New recovery code</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Alert>
+            <AlertDescription>
+              This is your new recovery code. It is shown{' '}
+              <strong>once only</strong>. Save it somewhere safe before
+              continuing.
+            </AlertDescription>
+          </Alert>
+
+          <div className="rounded-md border bg-muted/50 p-4 flex flex-col gap-3">
+            <div className="flex flex-wrap gap-2 justify-center">
+              {groups.map((group, i) => (
+                <span
+                  key={i}
+                  className="font-mono text-sm font-semibold tracking-widest select-all rounded px-2 py-1 bg-background border"
+                >
+                  {group}
+                </span>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={handleCopy}
+              >
+                {copied ? (
+                  <>
+                    <Check className="mr-1.5 size-3.5" />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="mr-1.5 size-3.5" />
+                    Copy
+                  </>
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={handleDownload}
+              >
+                <Download className="mr-1.5 size-3.5" />
+                Download
+              </Button>
+            </div>
+          </div>
+
+          <label className="flex cursor-pointer items-start gap-2.5">
+            <input
+              type="checkbox"
+              checked={saved}
+              onChange={(e) => setSaved(e.target.checked)}
+              className="mt-0.5 size-4 cursor-pointer"
+            />
+            <span className="text-sm select-none">
+              I&apos;ve saved my recovery code in a safe place.
+            </span>
+          </label>
+
+          <Button
+            type="button"
+            size="sm"
+            className="w-fit"
+            disabled={!saved}
+            onClick={handleDone}
+          >
+            Done
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Rotate recovery code</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <p className="text-muted-foreground text-sm">
+            Generate a new recovery code. Your current recovery code will be
+            invalidated immediately.
+          </p>
+
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="rotate-secret">
+                {useForgot ? 'Recovery code' : 'Current passphrase'}
+              </Label>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline transition-colors"
+                onClick={() => {
+                  setUseForgot((v) => !v);
+                  setSecret('');
+                  setError(null);
+                }}
+              >
+                {useForgot
+                  ? 'Use passphrase instead'
+                  : 'Forgot? Use recovery code'}
+              </button>
+            </div>
+            <Input
+              id="rotate-secret"
+              type={useForgot ? 'text' : 'password'}
+              autoComplete={useForgot ? 'off' : 'current-password'}
+              placeholder={useForgot ? 'xxxx-xxxx-xxxx-xxxx-xxxx' : ''}
+              value={secret}
+              onChange={(e) => setSecret(e.target.value)}
+              disabled={pending}
+              required
+            />
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button
+            type="submit"
+            size="sm"
+            className="w-fit"
+            disabled={pending || !secret}
+          >
+            {pending ? 'Rotating…' : 'Rotate recovery code'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RotateRecoveryCard;

--- a/features/settings/RotateRecoveryCard.tsx
+++ b/features/settings/RotateRecoveryCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Copy, Download, Check } from 'lucide-react';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { toast } from 'sonner';
 import { rotateRecoveryAction } from './actions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -25,6 +25,13 @@ const RotateRecoveryCard = () => {
   const [saved, setSaved] = useState(false);
   const [copied, setCopied] = useState(false);
   const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimeout.current) clearTimeout(copyTimeout.current);
+    },
+    []
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/features/settings/SecuritySection.tsx
+++ b/features/settings/SecuritySection.tsx
@@ -1,0 +1,36 @@
+import ChangePassphraseCard from './ChangePassphraseCard';
+import ResetEncryptionCard from './ResetEncryptionCard';
+import RotateRecoveryCard from './RotateRecoveryCard';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+type Props = {
+  enabled: boolean;
+};
+
+const SecuritySection = ({ enabled }: Props) => {
+  if (!enabled) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Security</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            Encryption is not set up for this account.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-lg font-semibold">Security</h2>
+      <ChangePassphraseCard />
+      <RotateRecoveryCard />
+      <ResetEncryptionCard />
+    </div>
+  );
+};
+
+export default SecuritySection;

--- a/features/settings/Settings.tsx
+++ b/features/settings/Settings.tsx
@@ -1,5 +1,6 @@
 import BaseCurrencyForm from './BaseCurrencyForm';
 import DangerZone from './DangerZone';
+import SecuritySection from './SecuritySection';
 import { clearSessionBaseCurrencyAction } from './actions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -10,9 +11,16 @@ type Props = {
   currencies: string[];
   savedDefault: string | null;
   envFallback: string;
+  encryptionEnabled: boolean;
 };
 
-const Settings = ({ base, currencies, savedDefault, envFallback }: Props) => {
+const Settings = ({
+  base,
+  currencies,
+  savedDefault,
+  envFallback,
+  encryptionEnabled,
+}: Props) => {
   const overrideActive =
     (savedDefault !== null && base !== savedDefault) ||
     (savedDefault === null && base !== envFallback);
@@ -47,6 +55,8 @@ const Settings = ({ base, currencies, savedDefault, envFallback }: Props) => {
           )}
         </CardContent>
       </Card>
+
+      <SecuritySection enabled={encryptionEnabled} />
 
       <DangerZone />
     </div>

--- a/features/settings/actions/changePassphrase.test.ts
+++ b/features/settings/actions/changePassphrase.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { changePassphraseAction } from './changePassphrase';
+import { UserCryptoRepository } from '@/lib/crypto';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+const repoHolder: { repo: UserCryptoRepository | null } = { repo: null };
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice' })),
+}));
+vi.mock('@/lib/crypto', async (orig) => ({
+  ...(await orig<typeof import('@/lib/crypto')>()),
+  getUserCryptoRepository: () => repoHolder.repo,
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+const INITIAL = {
+  userId: 'alice',
+  wrapPassphrase: 'd2FwUA==',
+  passSalt: 'c2FsdA==',
+  argonParams: { m: 65536, t: 3, p: 1 },
+  wrapRecovery: 'd2FwUg==',
+};
+
+const NEW_WRAP = {
+  wrapPassphrase: 'bmV3V3JhcA==',
+  passSalt: 'bmV3U2FsdA==',
+  argonParams: { m: 131072, t: 4, p: 2 },
+};
+
+describe('changePassphraseAction', () => {
+  let ctx: TestDbContext;
+  beforeEach(async () => {
+    ctx = await setupTestDb('change-passphrase-');
+    await ctx.insertUser('alice');
+    repoHolder.repo = new UserCryptoRepository(ctx.db);
+  });
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.clearAllMocks();
+  });
+
+  it('updates wrapPassphrase, passSalt, argonParams when row exists', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await changePassphraseAction(NEW_WRAP);
+    expect(res.ok).toBe(true);
+    const row = await repoHolder.repo!.get('alice');
+    expect(row?.wrapPassphrase).toBe(NEW_WRAP.wrapPassphrase);
+    expect(row?.passSalt).toBe(NEW_WRAP.passSalt);
+    expect(row?.argonParams).toEqual(NEW_WRAP.argonParams);
+  });
+
+  it('does not change wrapRecovery when updating passphrase', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    await changePassphraseAction(NEW_WRAP);
+    const row = await repoHolder.repo!.get('alice');
+    expect(row?.wrapRecovery).toBe(INITIAL.wrapRecovery);
+  });
+
+  it('returns ok:false when no userCrypto row exists', async () => {
+    const res = await changePassphraseAction(NEW_WRAP);
+    expect(res.ok).toBe(false);
+    expect((res as { ok: false; message: string }).message).toContain(
+      'not set up'
+    );
+  });
+
+  it('returns ok:false for malformed payload (bad base64)', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await changePassphraseAction({
+      ...NEW_WRAP,
+      wrapPassphrase: 'not base64!',
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('returns ok:false for malformed payload (invalid argonParams)', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await changePassphraseAction({
+      ...NEW_WRAP,
+      argonParams: { m: -1, t: 3, p: 1 },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('returns ok:false for over-long passSalt', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await changePassphraseAction({
+      ...NEW_WRAP,
+      passSalt: 'A'.repeat(65),
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/features/settings/actions/changePassphrase.ts
+++ b/features/settings/actions/changePassphrase.ts
@@ -1,0 +1,27 @@
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { changePassphraseSchema } from '@/lib/crypto/rewrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function changePassphraseAction(input: unknown): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed)
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = changePassphraseSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  const repo = getUserCryptoRepository();
+  if (!(await repo.exists(user.id)))
+    return { ok: false, message: 'Encryption is not set up.' };
+  await repo.updateWrapPassphrase(
+    user.id,
+    parsed.data.wrapPassphrase,
+    parsed.data.passSalt,
+    parsed.data.argonParams
+  );
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/features/settings/actions/confirmEncryptionReset.test.ts
+++ b/features/settings/actions/confirmEncryptionReset.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { confirmEncryptionResetAction } from './confirmEncryptionReset';
+import type { VerifyResult } from '@/lib/crypto/resetChallenge';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice', email: 'alice@example.com' })),
+}));
+
+const { mockVerifyAndReset, mockRateLimit, mockRevalidatePath } = vi.hoisted(
+  () => ({
+    mockVerifyAndReset: vi.fn(
+      async (): Promise<VerifyResult> => ({
+        ok: true,
+      })
+    ),
+    mockRateLimit: vi.fn(() => ({ allowed: true })),
+    mockRevalidatePath: vi.fn(),
+  })
+);
+
+vi.mock('@/lib/crypto/resetChallenge', () => ({
+  encryptionResetService: { verifyAndReset: mockVerifyAndReset },
+  resetCodeSchema: {
+    safeParse: (v: unknown) => {
+      if (typeof v === 'string' && /^\d{6}$/.test(v.trim())) {
+        return { success: true, data: v.trim() };
+      }
+      return { success: false };
+    },
+  },
+}));
+vi.mock('@/lib/rate-limit', async (orig) => ({
+  ...(await orig<typeof import('@/lib/rate-limit')>()),
+  rateLimit: mockRateLimit,
+}));
+vi.mock('next/cache', () => ({ revalidatePath: mockRevalidatePath }));
+
+describe('confirmEncryptionResetAction', () => {
+  let ctx: TestDbContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('conf-enc-reset-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    mockVerifyAndReset.mockClear();
+    mockRateLimit.mockReturnValue({ allowed: true });
+    mockRevalidatePath.mockClear();
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.clearAllMocks();
+  });
+
+  it('returns too-many-attempts when rate limit is exceeded', async () => {
+    mockRateLimit.mockReturnValue({ allowed: false });
+    const res = await confirmEncryptionResetAction('123456');
+    expect(res).toEqual({ ok: false, reason: 'too-many-attempts' });
+    expect(mockVerifyAndReset).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid when code fails schema validation', async () => {
+    const res = await confirmEncryptionResetAction('bad');
+    expect(res).toEqual({ ok: false, reason: 'invalid', remaining: 0 });
+    expect(mockVerifyAndReset).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid when code is not a string', async () => {
+    const res = await confirmEncryptionResetAction(12345);
+    expect(res).toEqual({ ok: false, reason: 'invalid', remaining: 0 });
+    expect(mockVerifyAndReset).not.toHaveBeenCalled();
+  });
+
+  it('calls verifyAndReset and revalidatePath on a valid code', async () => {
+    const res = await confirmEncryptionResetAction('123456');
+    expect(mockVerifyAndReset).toHaveBeenCalledWith('alice', '123456');
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/', 'layout');
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('does not revalidatePath when verifyAndReset returns failure', async () => {
+    mockVerifyAndReset.mockResolvedValueOnce({
+      ok: false,
+      reason: 'invalid',
+      remaining: 3,
+    });
+    const res = await confirmEncryptionResetAction('123456');
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+    expect(res).toEqual({ ok: false, reason: 'invalid', remaining: 3 });
+  });
+
+  it('forwards no-code result from verifyAndReset', async () => {
+    mockVerifyAndReset.mockResolvedValueOnce({ ok: false, reason: 'no-code' });
+    const res = await confirmEncryptionResetAction('123456');
+    expect(res).toEqual({ ok: false, reason: 'no-code' });
+  });
+
+  it('forwards expired result from verifyAndReset', async () => {
+    mockVerifyAndReset.mockResolvedValueOnce({ ok: false, reason: 'expired' });
+    const res = await confirmEncryptionResetAction('123456');
+    expect(res).toEqual({ ok: false, reason: 'expired' });
+  });
+});

--- a/features/settings/actions/confirmEncryptionReset.ts
+++ b/features/settings/actions/confirmEncryptionReset.ts
@@ -1,0 +1,31 @@
+'use server';
+
+import { requireUser } from '@/lib/auth/require-user';
+import {
+  encryptionResetService,
+  resetCodeSchema,
+  type VerifyResult,
+} from '@/lib/crypto/resetChallenge';
+import { rateLimit, DESTRUCTIVE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export const confirmEncryptionResetAction = async (
+  code: unknown
+): Promise<VerifyResult> => {
+  const user = await requireUser();
+  if (!rateLimit(DESTRUCTIVE, user.id).allowed) {
+    return { ok: false, reason: 'too-many-attempts' };
+  }
+  const parsed = resetCodeSchema.safeParse(code);
+  if (!parsed.success) {
+    return { ok: false, reason: 'invalid', remaining: 0 };
+  }
+  const result = await encryptionResetService.verifyAndReset(
+    user.id,
+    parsed.data
+  );
+  if (result.ok) {
+    revalidatePath('/', 'layout');
+  }
+  return result;
+};

--- a/features/settings/actions/index.ts
+++ b/features/settings/actions/index.ts
@@ -9,3 +9,5 @@ export {
 export { clearSessionBaseCurrencyAction } from './clearSessionBaseCurrency';
 export { requestAccountDeletionAction } from './requestAccountDeletion';
 export { deleteAccountAction } from './deleteAccount';
+export { changePassphraseAction } from './changePassphrase';
+export { rotateRecoveryAction } from './rotateRecovery';

--- a/features/settings/actions/index.ts
+++ b/features/settings/actions/index.ts
@@ -11,3 +11,8 @@ export { requestAccountDeletionAction } from './requestAccountDeletion';
 export { deleteAccountAction } from './deleteAccount';
 export { changePassphraseAction } from './changePassphrase';
 export { rotateRecoveryAction } from './rotateRecovery';
+export {
+  requestEncryptionResetAction,
+  type RequestEncryptionResetResult,
+} from './requestEncryptionReset';
+export { confirmEncryptionResetAction } from './confirmEncryptionReset';

--- a/features/settings/actions/requestEncryptionReset.test.ts
+++ b/features/settings/actions/requestEncryptionReset.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { requestEncryptionResetAction } from './requestEncryptionReset';
+import { UserCryptoRepository } from '@/lib/crypto';
+import type { IssueResult } from '@/lib/crypto/resetChallenge';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+// Fake user backed by real test DB
+const repoHolder: { repo: UserCryptoRepository | null } = { repo: null };
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice', email: 'alice@example.com' })),
+}));
+vi.mock('@/lib/crypto', async (orig) => ({
+  ...(await orig<typeof import('@/lib/crypto')>()),
+  getUserCryptoRepository: () => repoHolder.repo,
+}));
+
+// Use vi.hoisted so the mock factory can reference these before variable init
+const { mockIssueCode, mockRateLimit } = vi.hoisted(() => ({
+  mockIssueCode: vi.fn(async (): Promise<IssueResult> => ({ ok: true })),
+  mockRateLimit: vi.fn(() => ({ allowed: true })),
+}));
+
+vi.mock('@/lib/crypto/resetChallenge', () => ({
+  encryptionResetService: { issueCode: mockIssueCode },
+}));
+vi.mock('@/lib/rate-limit', async (orig) => ({
+  ...(await orig<typeof import('@/lib/rate-limit')>()),
+  rateLimit: mockRateLimit,
+}));
+
+const INITIAL_CRYPTO = {
+  userId: 'alice',
+  wrapPassphrase: 'd2FwUA==',
+  passSalt: 'c2FsdA==',
+  argonParams: { m: 65536, t: 3, p: 1 },
+  wrapRecovery: 'd2FwUg==',
+};
+
+describe('requestEncryptionResetAction', () => {
+  let ctx: TestDbContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('req-enc-reset-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repoHolder.repo = new UserCryptoRepository(ctx.db);
+    mockIssueCode.mockClear();
+    mockRateLimit.mockReturnValue({ allowed: true });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.clearAllMocks();
+  });
+
+  it('returns throttled when rate limit is exceeded', async () => {
+    mockRateLimit.mockReturnValue({ allowed: false });
+    await repoHolder.repo!.create(INITIAL_CRYPTO);
+    const res = await requestEncryptionResetAction();
+    expect(res).toEqual({ ok: false, reason: 'throttled' });
+    expect(mockIssueCode).not.toHaveBeenCalled();
+  });
+
+  it('returns not-set-up when no userCrypto row exists', async () => {
+    const res = await requestEncryptionResetAction();
+    expect(res).toEqual({ ok: false, reason: 'not-set-up' });
+    expect(mockIssueCode).not.toHaveBeenCalled();
+  });
+
+  it('calls issueCode and returns its result when crypto row exists', async () => {
+    await repoHolder.repo!.create(INITIAL_CRYPTO);
+    const res = await requestEncryptionResetAction();
+    expect(mockIssueCode).toHaveBeenCalledWith('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('forwards throttled result from issueCode', async () => {
+    await repoHolder.repo!.create(INITIAL_CRYPTO);
+    mockIssueCode.mockResolvedValueOnce({ ok: false, reason: 'throttled' });
+    const res = await requestEncryptionResetAction();
+    expect(res).toEqual({ ok: false, reason: 'throttled' });
+  });
+});

--- a/features/settings/actions/requestEncryptionReset.ts
+++ b/features/settings/actions/requestEncryptionReset.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import {
+  encryptionResetService,
+  type IssueResult,
+} from '@/lib/crypto/resetChallenge';
+import { rateLimit, DESTRUCTIVE } from '@/lib/rate-limit';
+
+export type RequestEncryptionResetResult =
+  | IssueResult
+  | { ok: false; reason: 'not-set-up' };
+
+export const requestEncryptionResetAction =
+  async (): Promise<RequestEncryptionResetResult> => {
+    const user = await requireUser();
+    if (!rateLimit(DESTRUCTIVE, user.id).allowed) {
+      return { ok: false, reason: 'throttled' };
+    }
+    const cryptoExists = await getUserCryptoRepository().exists(user.id);
+    if (!cryptoExists) {
+      return { ok: false, reason: 'not-set-up' };
+    }
+    return encryptionResetService.issueCode(user.id, user.email);
+  };

--- a/features/settings/actions/rotateRecovery.test.ts
+++ b/features/settings/actions/rotateRecovery.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rotateRecoveryAction } from './rotateRecovery';
+import { UserCryptoRepository } from '@/lib/crypto';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+const repoHolder: { repo: UserCryptoRepository | null } = { repo: null };
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: vi.fn(async () => ({ id: 'alice' })),
+}));
+vi.mock('@/lib/crypto', async (orig) => ({
+  ...(await orig<typeof import('@/lib/crypto')>()),
+  getUserCryptoRepository: () => repoHolder.repo,
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+const INITIAL = {
+  userId: 'alice',
+  wrapPassphrase: 'd2FwUA==',
+  passSalt: 'c2FsdA==',
+  argonParams: { m: 65536, t: 3, p: 1 },
+  wrapRecovery: 'd2FwUg==',
+};
+
+const NEW_RECOVERY = {
+  wrapRecovery: 'bmV3UmVjb3Zlcnk=',
+};
+
+describe('rotateRecoveryAction', () => {
+  let ctx: TestDbContext;
+  beforeEach(async () => {
+    ctx = await setupTestDb('rotate-recovery-');
+    await ctx.insertUser('alice');
+    repoHolder.repo = new UserCryptoRepository(ctx.db);
+  });
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.clearAllMocks();
+  });
+
+  it('updates wrapRecovery when row exists', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await rotateRecoveryAction(NEW_RECOVERY);
+    expect(res.ok).toBe(true);
+    const row = await repoHolder.repo!.get('alice');
+    expect(row?.wrapRecovery).toBe(NEW_RECOVERY.wrapRecovery);
+  });
+
+  it('does not change wrapPassphrase or passSalt when rotating recovery', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    await rotateRecoveryAction(NEW_RECOVERY);
+    const row = await repoHolder.repo!.get('alice');
+    expect(row?.wrapPassphrase).toBe(INITIAL.wrapPassphrase);
+    expect(row?.passSalt).toBe(INITIAL.passSalt);
+    expect(row?.argonParams).toEqual(INITIAL.argonParams);
+  });
+
+  it('returns ok:false when no userCrypto row exists', async () => {
+    const res = await rotateRecoveryAction(NEW_RECOVERY);
+    expect(res.ok).toBe(false);
+    expect((res as { ok: false; message: string }).message).toContain(
+      'not set up'
+    );
+  });
+
+  it('returns ok:false for malformed payload (bad base64)', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await rotateRecoveryAction({ wrapRecovery: 'not base64!' });
+    expect(res.ok).toBe(false);
+  });
+
+  it('returns ok:false for over-long wrapRecovery', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await rotateRecoveryAction({
+      wrapRecovery: 'A'.repeat(513),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('returns ok:false for missing wrapRecovery field', async () => {
+    await repoHolder.repo!.create(INITIAL);
+    const res = await rotateRecoveryAction({});
+    expect(res.ok).toBe(false);
+  });
+});

--- a/features/settings/actions/rotateRecovery.ts
+++ b/features/settings/actions/rotateRecovery.ts
@@ -1,0 +1,22 @@
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { getUserCryptoRepository } from '@/lib/crypto';
+import { rotateRecoverySchema } from '@/lib/crypto/rewrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function rotateRecoveryAction(input: unknown): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed)
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = rotateRecoverySchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  const repo = getUserCryptoRepository();
+  if (!(await repo.exists(user.id)))
+    return { ok: false, message: 'Encryption is not set up.' };
+  await repo.updateWrapRecovery(user.id, parsed.data.wrapRecovery);
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/lib/crypto/resetChallenge/index.ts
+++ b/lib/crypto/resetChallenge/index.ts
@@ -1,0 +1,38 @@
+import 'server-only';
+import { EncryptionResetChallengeRepository } from './repository';
+import { EncryptionResetService } from './service';
+import { APP_NAME } from '@/lib/app';
+import { resetUserEncryption } from '@/lib/crypto/resetEncryption';
+import { db } from '@/lib/db';
+import { postalTransport } from '@/lib/email-transport';
+import { env } from '@/lib/env';
+
+const sendCode = async (email: string, code: string): Promise<void> => {
+  const from = env.EMAIL_FROM;
+  const subject = `${APP_NAME}: confirm encryption reset`;
+  const text = [
+    `Your encryption reset code is ${code}.`,
+    `It expires in 10 minutes.`,
+    `Warning: confirming this will permanently delete your encrypted journal and reset encryption to "not set up".`,
+    `If you didn't request this, ignore this email — nothing will happen.`,
+  ].join('\n\n');
+  const html =
+    `<p>Your encryption reset code is <strong style="font-size:1.25rem;letter-spacing:0.15em">${code}</strong>.</p>` +
+    `<p>It expires in 10 minutes.</p>` +
+    `<p><strong>Warning:</strong> confirming this will permanently delete your encrypted journal and reset encryption to &ldquo;not set up&rdquo;.</p>` +
+    `<p>If you didn't request this, ignore this email — nothing will happen.</p>`;
+  await postalTransport({ to: email, from, subject, html, text });
+};
+
+const encryptionResetChallengeRepository =
+  new EncryptionResetChallengeRepository(db);
+
+export const encryptionResetService = new EncryptionResetService(
+  encryptionResetChallengeRepository,
+  { sendCode, reset: (userId) => resetUserEncryption(userId, db) }
+);
+
+export { EncryptionResetChallengeRepository } from './repository';
+export { EncryptionResetService } from './service';
+export type { IssueResult, VerifyResult } from './service';
+export { resetCodeSchema, type ResetCode } from './schema';

--- a/lib/crypto/resetChallenge/repository.test.ts
+++ b/lib/crypto/resetChallenge/repository.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EncryptionResetChallengeRepository } from './repository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('EncryptionResetChallengeRepository', () => {
+  let ctx: TestDbContext;
+  let repo: EncryptionResetChallengeRepository;
+  const future = () => new Date(Date.now() + 600_000);
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('enc-reset-repo-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new EncryptionResetChallengeRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('upsert inserts a row with attempts=0', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    const row = await repo.get('alice');
+    expect(row?.codeHash).toBe('hash1');
+    expect(row?.attempts).toBe(0);
+  });
+
+  it('upsert replaces an existing row and resets attempts', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    await repo.incrementAttempts('alice');
+    await repo.upsert('alice', 'hash2', future());
+    const row = await repo.get('alice');
+    expect(row?.codeHash).toBe('hash2');
+    expect(row?.attempts).toBe(0);
+  });
+
+  it('get returns null when no challenge exists', async () => {
+    expect(await repo.get('alice')).toBeNull();
+  });
+
+  it('incrementAttempts returns the new count', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    expect(await repo.incrementAttempts('alice')).toBe(1);
+    expect(await repo.incrementAttempts('alice')).toBe(2);
+  });
+
+  it('delete removes the row', async () => {
+    await repo.upsert('alice', 'hash1', future());
+    await repo.delete('alice');
+    expect(await repo.get('alice')).toBeNull();
+  });
+});

--- a/lib/crypto/resetChallenge/repository.ts
+++ b/lib/crypto/resetChallenge/repository.ts
@@ -1,0 +1,64 @@
+import { eq, sql } from 'drizzle-orm';
+import {
+  encryptionResetChallenge,
+  type EncryptionResetChallenge,
+} from '@/db/schema/encryptionResetChallenge';
+import type { DbInstance } from '@/lib/db/connection';
+
+export class EncryptionResetChallengeRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  async upsert(
+    userId: string,
+    codeHash: string,
+    expiresAt: Date,
+    createdAt?: Date
+  ): Promise<void> {
+    const insertValues = {
+      userId,
+      codeHash,
+      expiresAt,
+      attempts: 0,
+      ...(createdAt && { createdAt }),
+    };
+
+    const updateSet = {
+      codeHash,
+      expiresAt,
+      attempts: 0,
+      ...(createdAt && { createdAt }),
+    };
+
+    await this.db
+      .insert(encryptionResetChallenge)
+      .values(insertValues)
+      .onConflictDoUpdate({
+        target: encryptionResetChallenge.userId,
+        set: updateSet,
+      });
+  }
+
+  async get(userId: string): Promise<EncryptionResetChallenge | null> {
+    const rows = await this.db
+      .select()
+      .from(encryptionResetChallenge)
+      .where(eq(encryptionResetChallenge.userId, userId))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async incrementAttempts(userId: string): Promise<number> {
+    const rows = await this.db
+      .update(encryptionResetChallenge)
+      .set({ attempts: sql`${encryptionResetChallenge.attempts} + 1` })
+      .where(eq(encryptionResetChallenge.userId, userId))
+      .returning({ attempts: encryptionResetChallenge.attempts });
+    return rows[0]?.attempts ?? 0;
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.db
+      .delete(encryptionResetChallenge)
+      .where(eq(encryptionResetChallenge.userId, userId));
+  }
+}

--- a/lib/crypto/resetChallenge/schema.test.ts
+++ b/lib/crypto/resetChallenge/schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { resetCodeSchema } from './schema';
+
+describe('resetCodeSchema', () => {
+  it('accepts a valid 6-digit code', () => {
+    expect(resetCodeSchema.safeParse('123456').success).toBe(true);
+  });
+
+  it('trims whitespace before validating', () => {
+    expect(resetCodeSchema.safeParse('  123456  ').success).toBe(true);
+  });
+
+  it('rejects fewer than 6 digits', () => {
+    expect(resetCodeSchema.safeParse('12345').success).toBe(false);
+  });
+
+  it('rejects more than 6 digits', () => {
+    expect(resetCodeSchema.safeParse('1234567').success).toBe(false);
+  });
+
+  it('rejects non-numeric characters', () => {
+    expect(resetCodeSchema.safeParse('12345a').success).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(resetCodeSchema.safeParse('').success).toBe(false);
+  });
+});

--- a/lib/crypto/resetChallenge/schema.ts
+++ b/lib/crypto/resetChallenge/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const resetCodeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{6}$/, 'Enter the 6-digit code from your email');
+
+export type ResetCode = z.infer<typeof resetCodeSchema>;

--- a/lib/crypto/resetChallenge/service.test.ts
+++ b/lib/crypto/resetChallenge/service.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EncryptionResetChallengeRepository } from './repository';
+import { EncryptionResetService } from './service';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('EncryptionResetService', () => {
+  let ctx: TestDbContext;
+  let repo: EncryptionResetChallengeRepository;
+  let sent: { email: string; code: string }[];
+  let reset: string[];
+  let nowMs: number;
+
+  const makeService = () =>
+    new EncryptionResetService(repo, {
+      sendCode: async (email, code) => {
+        sent.push({ email, code });
+      },
+      reset: async (userId) => {
+        reset.push(userId);
+      },
+      now: () => nowMs,
+    });
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('enc-reset-svc-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new EncryptionResetChallengeRepository(ctx.db);
+    sent = [];
+    reset = [];
+    nowMs = 1_000_000;
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('issueCode emails a 6-digit code', async () => {
+    const res = await makeService().issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].email).toBe('alice@example.com');
+    expect(sent[0].code).toMatch(/^\d{6}$/);
+  });
+
+  it('issueCode rolls back the challenge when the email send fails', async () => {
+    const svc = new EncryptionResetService(repo, {
+      sendCode: async () => {
+        throw new Error('smtp down');
+      },
+      reset: async () => {},
+      now: () => nowMs,
+    });
+    await expect(svc.issueCode('alice', 'alice@example.com')).rejects.toThrow(
+      'smtp down'
+    );
+    // The throttle must not be armed by a failed send: a retry can issue again.
+    expect(await repo.get('alice')).toBeNull();
+    const retry = new EncryptionResetService(repo, {
+      sendCode: async (email, code) => {
+        sent.push({ email, code });
+      },
+      reset: async () => {},
+      now: () => nowMs,
+    });
+    const res = await retry.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('issueCode throttles within 30 s', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const res = await svc.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: false, reason: 'throttled' });
+    expect(sent).toHaveLength(1);
+  });
+
+  it('issueCode allows a re-send after 30s', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 31_000;
+    const res = await svc.issueCode('alice', 'alice@example.com');
+    expect(res).toEqual({ ok: true });
+    expect(sent).toHaveLength(2);
+  });
+
+  it('verifyAndReset calls reset and deletes the challenge row on the correct code', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const res = await svc.verifyAndReset('alice', sent[0].code);
+    expect(res).toEqual({ ok: true });
+    expect(reset).toEqual(['alice']);
+    // KEY: challenge row must be explicitly deleted (no user cascade on reset)
+    expect(await repo.get('alice')).toBeNull();
+  });
+
+  it('verifyAndReset returns no-code when none issued', async () => {
+    const res = await makeService().verifyAndReset('alice', '000000');
+    expect(res).toEqual({ ok: false, reason: 'no-code' });
+    expect(reset).toHaveLength(0);
+  });
+
+  it('verifyAndReset rejects a wrong code and reports remaining attempts', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const wrong = sent[0].code === '000000' ? '111111' : '000000';
+    const res = await svc.verifyAndReset('alice', wrong);
+    expect(res).toEqual({ ok: false, reason: 'invalid', remaining: 4 });
+    expect(reset).toHaveLength(0);
+  });
+
+  it('verifyAndReset invalidates after 5 failed attempts', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    const wrong = sent[0].code === '000000' ? '111111' : '000000';
+    let res;
+    for (let i = 0; i < 5; i++) res = await svc.verifyAndReset('alice', wrong);
+    expect(res).toEqual({ ok: false, reason: 'too-many-attempts' });
+    // challenge is gone — a follow-up reads as no-code
+    expect(await svc.verifyAndReset('alice', sent[0].code)).toEqual({
+      ok: false,
+      reason: 'no-code',
+    });
+  });
+
+  it('verifyAndReset rejects an expired code', async () => {
+    const svc = makeService();
+    await svc.issueCode('alice', 'alice@example.com');
+    nowMs += 600_001;
+    const res = await svc.verifyAndReset('alice', sent[0].code);
+    expect(res).toEqual({ ok: false, reason: 'expired' });
+    expect(reset).toHaveLength(0);
+  });
+});

--- a/lib/crypto/resetChallenge/service.ts
+++ b/lib/crypto/resetChallenge/service.ts
@@ -1,0 +1,95 @@
+import { createHash, randomInt, timingSafeEqual } from 'crypto';
+import 'server-only';
+import type { EncryptionResetChallengeRepository } from './repository';
+
+export const CODE_TTL_MS = 600_000; // 10 minutes
+export const MAX_ATTEMPTS = 5;
+export const RESEND_THROTTLE_MS = 30_000;
+
+export type IssueResult = { ok: true } | { ok: false; reason: 'throttled' };
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: 'no-code' | 'expired' | 'too-many-attempts' }
+  | { ok: false; reason: 'invalid'; remaining: number };
+
+export type EncryptionResetDeps = {
+  sendCode: (email: string, code: string) => Promise<void>;
+  reset: (userId: string) => Promise<void>;
+  now?: () => number;
+};
+
+const hashCode = (code: string): string =>
+  createHash('sha256').update(code).digest('hex');
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+};
+
+export class EncryptionResetService {
+  private readonly now: () => number;
+
+  constructor(
+    private readonly repo: EncryptionResetChallengeRepository,
+    private readonly deps: EncryptionResetDeps
+  ) {
+    this.now = deps.now ?? Date.now;
+  }
+
+  async issueCode(userId: string, email: string): Promise<IssueResult> {
+    const existing = await this.repo.get(userId);
+    if (
+      existing &&
+      this.now() - existing.createdAt.getTime() < RESEND_THROTTLE_MS
+    ) {
+      return { ok: false, reason: 'throttled' };
+    }
+    const code = String(randomInt(0, 1_000_000)).padStart(6, '0');
+    const nowTime = this.now();
+    const expiresAt = new Date(nowTime + CODE_TTL_MS);
+    const createdAt = new Date(nowTime);
+    await this.repo.upsert(userId, hashCode(code), expiresAt, createdAt);
+    try {
+      await this.deps.sendCode(email, code);
+    } catch (err) {
+      // The upsert above armed the resend throttle. If the email never went
+      // out, roll the challenge back so the user can retry immediately rather
+      // than being locked out for the throttle window with no code in hand.
+      await this.repo.delete(userId);
+      throw err;
+    }
+    return { ok: true };
+  }
+
+  async verifyAndReset(userId: string, code: string): Promise<VerifyResult> {
+    const challenge = await this.repo.get(userId);
+    if (!challenge) return { ok: false, reason: 'no-code' };
+
+    if (challenge.expiresAt.getTime() < this.now()) {
+      await this.repo.delete(userId);
+      return { ok: false, reason: 'expired' };
+    }
+
+    if (!constantTimeEqual(hashCode(code), challenge.codeHash)) {
+      const attempts = await this.repo.incrementAttempts(userId);
+      if (attempts >= MAX_ATTEMPTS) {
+        await this.repo.delete(userId);
+        return { ok: false, reason: 'too-many-attempts' };
+      }
+      return {
+        ok: false,
+        reason: 'invalid',
+        remaining: MAX_ATTEMPTS - attempts,
+      };
+    }
+
+    await this.deps.reset(userId);
+    // ⚠️ A reset does NOT delete the user, so the challenge row will NOT
+    // cascade away. Explicitly delete it so a one-time code can't be replayed.
+    await this.repo.delete(userId);
+    return { ok: true };
+  }
+}

--- a/lib/crypto/resetEncryption.test.ts
+++ b/lib/crypto/resetEncryption.test.ts
@@ -1,0 +1,139 @@
+// lib/crypto/resetEncryption.test.ts
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DEK_BYTES } from './constants';
+import { resetUserEncryption } from './resetEncryption';
+import {
+  setSessionDek,
+  hasSessionDek,
+  __resetSessionKeysForTest,
+} from './sessionKeys';
+import { UserCryptoRepository } from './userCryptoRepository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('resetUserEncryption', () => {
+  let ctx: TestDbContext;
+  let repo: UserCryptoRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('crypto-reset-');
+    await ctx.insertUser('alice', 'Alice', 'alice@example.com');
+    repo = new UserCryptoRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    __resetSessionKeysForTest();
+    await teardownTestDb(ctx);
+  });
+
+  it('deletes the userCrypto row, calls both wipes, drops the DEK, and creates a stub journal', async () => {
+    // Arrange: create a userCrypto row
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'd2FwUGFzcw==',
+      passSalt: 'c2FsdA==',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'd2FwUg==',
+    });
+    expect(await repo.exists('alice')).toBe(true);
+
+    // Arrange: set a session DEK so we can verify it is dropped
+    const fakeDek = Buffer.alloc(DEK_BYTES, 0xab);
+    setSessionDek('alice', fakeDek);
+    expect(hasSessionDek('alice')).toBe(true);
+
+    // Arrange: fake injections to keep test hermetic
+    const clearRemote = vi.fn().mockResolvedValue(undefined);
+    const removeLocalJournal = vi.fn().mockResolvedValue(undefined);
+
+    // Act
+    await resetUserEncryption('alice', ctx.db, {
+      clearRemote,
+      removeLocalJournal,
+    });
+
+    // Assert: userCrypto row is gone (returns to 'unset' status)
+    expect(await repo.exists('alice')).toBe(false);
+
+    // Assert: both storage wipes were called with the correct userId
+    expect(clearRemote).toHaveBeenCalledOnce();
+    expect(clearRemote).toHaveBeenCalledWith('alice');
+    expect(removeLocalJournal).toHaveBeenCalledOnce();
+    expect(removeLocalJournal).toHaveBeenCalledWith('alice');
+
+    // Assert: in-RAM DEK was dropped
+    expect(hasSessionDek('alice')).toBe(false);
+
+    // Assert: empty stub journal was recreated (ensureLayout ran)
+    const journalPath = path.join(
+      ctx.tmpDir,
+      'journals',
+      'alice',
+      'main.ledger'
+    );
+    const stat = await fs.stat(journalPath);
+    expect(stat.isFile()).toBe(true);
+    const content = await fs.readFile(journalPath, 'utf-8');
+    expect(content).toContain('; Ledger journal for user alice');
+  });
+
+  it('wipe order: clearRemote before removeLocalJournal before row delete', async () => {
+    // Arrange
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'd2FwUGFzcw==',
+      passSalt: 'c2FsdA==',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'd2FwUg==',
+    });
+
+    const calls: string[] = [];
+    const clearRemote = vi.fn().mockImplementation(async () => {
+      calls.push('clearRemote');
+    });
+    const removeLocalJournal = vi.fn().mockImplementation(async () => {
+      calls.push('removeLocalJournal');
+    });
+
+    // Act
+    await resetUserEncryption('alice', ctx.db, {
+      clearRemote,
+      removeLocalJournal,
+    });
+
+    // Assert: order matches brief — remote wipe first, then local, then DB
+    expect(calls).toEqual(['clearRemote', 'removeLocalJournal']);
+    // Row must be gone (DB delete happened after both wipes)
+    expect(await repo.exists('alice')).toBe(false);
+  });
+
+  it('user account is NOT deleted — only the userCrypto row is removed', async () => {
+    // This is the key distinction from purgeUserData
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'd2FwUGFzcw==',
+      passSalt: 'c2FsdA==',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'd2FwUg==',
+    });
+
+    await resetUserEncryption('alice', ctx.db, {
+      clearRemote: vi.fn().mockResolvedValue(undefined),
+      removeLocalJournal: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // userCrypto row is gone
+    expect(await repo.exists('alice')).toBe(false);
+
+    // But the user row itself still exists
+    const { user } = await import('@naeemba/next-starter/schema');
+    const { eq } = await import('drizzle-orm');
+    const rows = await ctx.db.select().from(user).where(eq(user.id, 'alice'));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/lib/crypto/resetEncryption.ts
+++ b/lib/crypto/resetEncryption.ts
@@ -1,5 +1,6 @@
 // lib/crypto/resetEncryption.ts
 import { promises as fs } from 'fs';
+import 'server-only';
 import { dropSessionDek } from './sessionKeys';
 import { UserCryptoRepository } from './userCryptoRepository';
 import type { DbInstance } from '@/lib/db/connection';

--- a/lib/crypto/resetEncryption.ts
+++ b/lib/crypto/resetEncryption.ts
@@ -1,0 +1,31 @@
+// lib/crypto/resetEncryption.ts
+import { promises as fs } from 'fs';
+import { dropSessionDek } from './sessionKeys';
+import { UserCryptoRepository } from './userCryptoRepository';
+import type { DbInstance } from '@/lib/db/connection';
+import { JournalRepository } from '@/lib/journal';
+import { getJournalDir } from '@/lib/journal/layout';
+import { clearRemote as clearRemoteDefault } from '@/lib/storage/sync';
+
+type ResetDeps = {
+  clearRemote?: (userId: string) => Promise<void>;
+  removeLocalJournal?: (userId: string) => Promise<void>;
+};
+
+export async function resetUserEncryption(
+  userId: string,
+  db: DbInstance,
+  deps: ResetDeps = {}
+): Promise<void> {
+  const clearRemote = deps.clearRemote ?? clearRemoteDefault;
+  const removeLocalJournal =
+    deps.removeLocalJournal ??
+    ((id: string) =>
+      fs.rm(getJournalDir(id), { recursive: true, force: true }));
+
+  await clearRemote(userId); // wipe encrypted objects in Garage
+  await removeLocalJournal(userId); // wipe local working dir
+  await new UserCryptoRepository(db).delete(userId); // remove crypto metadata → status 'unset'
+  dropSessionDek(userId); // clear any in-RAM DEK
+  await new JournalRepository(db).ensureLayout(userId); // recreate an empty plaintext stub
+}

--- a/lib/crypto/rewrapSchema.ts
+++ b/lib/crypto/rewrapSchema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const b64 = z
+  .string()
+  .regex(/^[A-Za-z0-9+/]+={0,2}$/)
+  .min(1)
+  .max(512);
+export const changePassphraseSchema = z.object({
+  wrapPassphrase: b64,
+  passSalt: z
+    .string()
+    .regex(/^[A-Za-z0-9+/]+={0,2}$/)
+    .min(1)
+    .max(64),
+  argonParams: z.object({
+    m: z.number().int().positive(),
+    t: z.number().int().positive(),
+    p: z.number().int().positive(),
+  }),
+});
+export const rotateRecoverySchema = z.object({ wrapRecovery: b64 });

--- a/lib/crypto/userCryptoRepository.test.ts
+++ b/lib/crypto/userCryptoRepository.test.ts
@@ -68,4 +68,54 @@ describe('UserCryptoRepository', () => {
     await repo.markMigrated('alice');
     expect(await repo.hasMigrated('alice')).toBe(true);
   });
+
+  it('updateWrapPassphrase replaces the passphrase wrap fields', async () => {
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'w1',
+      passSalt: 's1',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'r1',
+    });
+    await repo.updateWrapPassphrase('alice', 'w2', 's2', {
+      m: 19456,
+      t: 2,
+      p: 1,
+    });
+    const row = await repo.get('alice');
+    expect(row?.wrapPassphrase).toBe('w2');
+    expect(row?.passSalt).toBe('s2');
+    expect(row?.argonParams).toEqual({ m: 19456, t: 2, p: 1 });
+    expect(row?.wrapRecovery).toBe('r1'); // recovery wrap untouched
+  });
+
+  it('updateWrapRecovery replaces the recovery wrap and bumps recoveryCreatedAt', async () => {
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'w1',
+      passSalt: 's1',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'r1',
+    });
+    const before = (await repo.get('alice'))!.recoveryCreatedAt;
+    await repo.updateWrapRecovery('alice', 'r2');
+    const row = await repo.get('alice');
+    expect(row?.wrapRecovery).toBe('r2');
+    expect(row?.wrapPassphrase).toBe('w1'); // passphrase wrap untouched
+    expect(row!.recoveryCreatedAt.getTime()).toBeGreaterThanOrEqual(
+      before.getTime()
+    );
+  });
+
+  it('delete removes the row', async () => {
+    await repo.create({
+      userId: 'alice',
+      wrapPassphrase: 'w1',
+      passSalt: 's1',
+      argonParams: { m: 65536, t: 3, p: 1 },
+      wrapRecovery: 'r1',
+    });
+    await repo.delete('alice');
+    expect(await repo.exists('alice')).toBe(false);
+  });
 });

--- a/lib/crypto/userCryptoRepository.ts
+++ b/lib/crypto/userCryptoRepository.ts
@@ -1,5 +1,10 @@
-import { eq } from 'drizzle-orm';
-import { userCrypto, type NewUserCrypto, type UserCrypto } from '@/db/schema';
+import { eq, sql } from 'drizzle-orm';
+import {
+  userCrypto,
+  type ArgonParams,
+  type NewUserCrypto,
+  type UserCrypto,
+} from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
 
 export class UserCryptoRepository {
@@ -34,5 +39,31 @@ export class UserCryptoRepository {
       .update(userCrypto)
       .set({ migratedAt: new Date() })
       .where(eq(userCrypto.userId, userId));
+  }
+
+  async updateWrapPassphrase(
+    userId: string,
+    wrapPassphrase: string,
+    passSalt: string,
+    argonParams: ArgonParams
+  ): Promise<void> {
+    await this.db
+      .update(userCrypto)
+      .set({ wrapPassphrase, passSalt, argonParams })
+      .where(eq(userCrypto.userId, userId));
+  }
+
+  async updateWrapRecovery(
+    userId: string,
+    wrapRecovery: string
+  ): Promise<void> {
+    await this.db
+      .update(userCrypto)
+      .set({ wrapRecovery, recoveryCreatedAt: sql`now()` })
+      .where(eq(userCrypto.userId, userId));
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.db.delete(userCrypto).where(eq(userCrypto.userId, userId));
   }
 }


### PR DESCRIPTION
## Encrypted Journals — P3: Settings → Security

Lets a user manage their encryption from **Settings → Security**, all zero-knowledge:

- **Change passphrase** — with a recovery-code "forgot passphrase" fallback.
- **Rotate recovery code** — new code shown once (copy + download + acknowledge).
- **Reset encryption** — destructive, guarded by an **emailed 6-digit code** (equal strength to account deletion). Wipes the encrypted journal + `userCrypto` row → status `unset` → gate routes to `/crypto/setup`. **Keeps the account.**

**Architecture:** all re-wrapping is client-side. The browser re-obtains the DEK by unwrapping with the *current* secret (exactly as unlock does), then wraps the **same DEK** under a new KEK and uploads only the new opaque wrap. The DEK never changes → journal data is never re-encrypted. The server only ever stores opaque wraps.

Plan: `docs/superpowers/plans/2026-06-25-encrypted-journals-p3.md`. Built via subagent-driven development (TDD per task).

### Commits
- `feat(crypto): userCrypto re-wrap + delete repository methods`
- `feat(crypto): client re-wrap orchestration (change passphrase, rotate recovery)`
- `feat(crypto): change-passphrase + rotate-recovery server actions`
- `feat(crypto): resetUserEncryption wipe service (keeps account)`
- `feat(crypto): emailed-code challenge for reset-encryption` (new `encryptionResetChallenge` table, migration `0004`)
- `feat(crypto): settings security section (change passphrase, rotate recovery, reset)`
- `fix(crypto): mark resetUserEncryption server-only`

### Quality gates
- Each task spec+quality reviewed; whole-branch **opus** review: **READY TO MERGE — 0 Critical / 0 Important**.
- Four binding invariants verified in-code end-to-end: **zero-knowledge**, **DEK-never-changes**, **proof-before-mutation** (wrong secret fails the unwrap with a friendly error, no server mutation), **non-replayable reset** (challenge row explicitly deleted since reset doesn't cascade-delete the user; challenge fully independent from the account-deletion challenge).
- Full suite **551 passing** (110 files), type-check + lint clean.
- Reset challenge: sha256-hashed code, constant-time compare, 10-min TTL, 5-attempt cap, 30s resend throttle, email-rollback on send failure. Migration `0004` creates only `encryptionResetChallenge` (FK cascade to user).

### ⚠️ Live e2e acceptance — REQUIRED before merge (worktree has no Postgres/Garage)
- [ ] **Change passphrase** (current path **and** recovery "forgot" path) → re-unlock with the **new** passphrase → existing journal **still decrypts** / reports render identically (proves DEK identity — only provable against a real DB + Garage).
- [ ] **Rotate recovery** → old code rejected, new code unlocks; new code revealed only after successful persist.
- [ ] **Reset encryption** → email delivers code → confirm → journal wiped, hard-nav to `/crypto/setup`, can re-set-up; Resend works; wrong/expired/too-many-attempts surfaced.
- [ ] **SecuritySection** visual rendering in the settings page (shadcn, matches Danger Zone).

### Deferred non-blocking fast-follows
- `rewrapFlow` tests: snapshot-assert production Argon params `{m:65536,t:3,p:1}` + cover the wrong-recovery-code error path.
- change/rotate action tests: assert `revalidatePath('/', 'layout')` is called.
- `confirmEncryptionResetAction` returns `reason:'too-many-attempts'` on an HTTP rate-limit hit (cosmetic message conflation; no security impact).
- `ChangePassphraseCard`: remove unused `formRef`; rotate button label is static in the recovery-authorizer path.

### Out of scope (next)
- Passkey-PRF unlock fast-follow — add/remove passkey would also live in this Security section once PRF lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
