### PR TITLE
feat(crypto): encrypted journals — passkey (PRF) unlock

### DIFF
--- a/app/api/crypto/material/route.test.ts
+++ b/app/api/crypto/material/route.test.ts
@@ -36,4 +36,34 @@ describe('GET /api/crypto/material', () => {
     getMock.mockResolvedValue(null);
     expect((await GET()).status).toBe(404);
   });
+  it('projects passkey wraps to strip internal fields', async () => {
+    getMock.mockResolvedValue({
+      passSalt: 's',
+      argonParams: { m: 1, t: 1, p: 1 },
+      wrapPassphrase: 'wp',
+      wrapRecovery: 'wr',
+    });
+    listByUserMock.mockResolvedValue([
+      {
+        id: 'w1',
+        userId: 'alice',
+        credentialId: 'cred-A',
+        prfSalt: 'c2FsdA==',
+        wrap: 'd3JhcA==',
+        label: 'Laptop',
+        createdAt: new Date(),
+      },
+    ]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.passkeys).toEqual([
+      { credentialId: 'cred-A', prfSalt: 'c2FsdA==', wrap: 'd3JhcA==' },
+    ]);
+    expect(Object.keys(body.passkeys[0]).sort()).toEqual([
+      'credentialId',
+      'prfSalt',
+      'wrap',
+    ]);
+  });
 });

--- a/app/api/crypto/material/route.test.ts
+++ b/app/api/crypto/material/route.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GET } from './route';
 
 const getMock = vi.fn();
+const listByUserMock = vi.fn();
 vi.mock('@/lib/auth/require-user', () => ({
   requireUser: vi.fn(async () => ({ id: 'alice' })),
 }));
 vi.mock('@/lib/crypto', () => ({
   getUserCryptoRepository: () => ({ get: getMock }),
+  getPasskeyWrapRepository: () => ({ listByUser: listByUserMock }),
 }));
 
 afterEach(() => vi.clearAllMocks());
@@ -19,6 +21,7 @@ describe('GET /api/crypto/material', () => {
       wrapPassphrase: 'wp',
       wrapRecovery: 'wr',
     });
+    listByUserMock.mockResolvedValue([]);
     const res = await GET();
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -26,6 +29,7 @@ describe('GET /api/crypto/material', () => {
       argonParams: { m: 1, t: 1, p: 1 },
       wrapPassphrase: 'wp',
       wrapRecovery: 'wr',
+      passkeys: [],
     });
   });
   it('404s when not set up', async () => {

--- a/app/api/crypto/material/route.ts
+++ b/app/api/crypto/material/route.ts
@@ -1,5 +1,8 @@
 import { requireUser } from '@/lib/auth/require-user';
-import { getUserCryptoRepository } from '@/lib/crypto';
+import {
+  getPasskeyWrapRepository,
+  getUserCryptoRepository,
+} from '@/lib/crypto';
 import type { CryptoMaterial } from '@/lib/crypto/setupSchema';
 import { NextResponse } from 'next/server';
 
@@ -12,12 +15,18 @@ export async function GET(): Promise<NextResponse> {
       { status: 404 }
     );
   }
-  // All four are opaque without the user's secret.
+  const wraps = await getPasskeyWrapRepository().listByUser(user.id);
+  // All blobs are opaque without the user's secret.
   const material: CryptoMaterial = {
     passSalt: row.passSalt,
     argonParams: row.argonParams,
     wrapPassphrase: row.wrapPassphrase,
     wrapRecovery: row.wrapRecovery,
+    passkeys: wraps.map((w) => ({
+      credentialId: w.credentialId,
+      prfSalt: w.prfSalt,
+      wrap: w.wrap,
+    })),
   };
   return NextResponse.json(material);
 }

--- a/db/migrations/0005_common_black_cat.sql
+++ b/db/migrations/0005_common_black_cat.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "cryptoPasskeyWrap" (
+	"id" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"credentialId" text NOT NULL,
+	"prfSalt" text NOT NULL,
+	"wrap" text NOT NULL,
+	"label" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "cryptoPasskeyWrap_user_cred" UNIQUE("userId","credentialId")
+);
+--> statement-breakpoint
+ALTER TABLE "cryptoPasskeyWrap" ADD CONSTRAINT "cryptoPasskeyWrap_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/db/migrations/meta/0005_snapshot.json
+++ b/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,650 @@
+{
+  "id": "85f421c9-e5bd-40c4-ad1d-b146df4786e2",
+  "prevId": "15ef547e-8656-49e6-8259-b10d89a00005",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accountDeletionChallenge": {
+      "name": "accountDeletionChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accountDeletionChallenge_userId_user_id_fk": {
+          "name": "accountDeletionChallenge_userId_user_id_fk",
+          "tableFrom": "accountDeletionChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commodity_price": {
+      "name": "commodity_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_date": {
+          "name": "fetched_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commodity_price_unique_per_day": {
+          "name": "commodity_price_unique_per_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol",
+            "quote",
+            "fetched_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cryptoPasskeyWrap": {
+      "name": "cryptoPasskeyWrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prfSalt": {
+          "name": "prfSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrap": {
+          "name": "wrap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cryptoPasskeyWrap_userId_user_id_fk": {
+          "name": "cryptoPasskeyWrap_userId_user_id_fk",
+          "tableFrom": "cryptoPasskeyWrap",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cryptoPasskeyWrap_user_cred": {
+          "name": "cryptoPasskeyWrap_user_cred",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryptionResetChallenge": {
+      "name": "encryptionResetChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryptionResetChallenge_userId_user_id_fk": {
+          "name": "encryptionResetChallenge_userId_user_id_fk",
+          "tableFrom": "encryptionResetChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_fetch_run": {
+      "name": "price_fetch_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbols_fetched": {
+          "name": "symbols_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "symbols_failed": {
+          "name": "symbols_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savedView": {
+      "name": "savedView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPath": {
+          "name": "targetPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "savedView_user_name": {
+          "name": "savedView_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savedView_userId_user_id_fk": {
+          "name": "savedView_userId_user_id_fk",
+          "tableFrom": "savedView",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_user_name": {
+          "name": "template_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_userId_user_id_fk": {
+          "name": "template_userId_user_id_fk",
+          "tableFrom": "template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userCrypto": {
+      "name": "userCrypto",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wrapPassphrase": {
+          "name": "wrapPassphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passSalt": {
+          "name": "passSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argonParams": {
+          "name": "argonParams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapRecovery": {
+          "name": "wrapRecovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recoveryCreatedAt": {
+          "name": "recoveryCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kdfVersion": {
+          "name": "kdfVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "migratedAt": {
+          "name": "migratedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userCrypto_userId_user_id_fk": {
+          "name": "userCrypto_userId_user_id_fk",
+          "tableFrom": "userCrypto",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "baseCurrency": {
+          "name": "baseCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journalMain": {
+          "name": "journalMain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main.ledger'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSetting_userId_user_id_fk": {
+          "name": "userSetting_userId_user_id_fk",
+          "tableFrom": "userSetting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782395825605,
       "tag": "0004_tough_guardian",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782401941426,
+      "tag": "0005_common_black_cat",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/cryptoPasskeyWrap.ts
+++ b/db/schema/cryptoPasskeyWrap.ts
@@ -1,0 +1,30 @@
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import { pgTable, text, timestamp, unique } from 'drizzle-orm/pg-core';
+
+// One row per (user, passkey) that can unlock the journal. The DEK is wrapped
+// by a key derived from that passkey's PRF output. credentialId mirrors the
+// better-auth passkey credentialID (base64url); it is NOT a foreign key because
+// better-auth's credentialID column is indexed, not unique. Orphan rows (passkey
+// later deleted) are harmless — they can never assert — and the Settings UI hides
+// them by cross-referencing the live passkey list.
+export const cryptoPasskeyWrap = pgTable(
+  'cryptoPasskeyWrap',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('userId')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    credentialId: text('credentialId').notNull(),
+    prfSalt: text('prfSalt').notNull(), // base64, 32 bytes
+    wrap: text('wrap').notNull(), // opaque base64; DEK wrapped by the PRF-derived KEK
+    label: text('label').notNull(), // mirrors the passkey name, for the UI
+    createdAt: timestamp('createdAt')
+      .notNull()
+      .default(sql`now()`),
+  },
+  (t) => [unique('cryptoPasskeyWrap_user_cred').on(t.userId, t.credentialId)]
+);
+
+export type CryptoPasskeyWrap = typeof cryptoPasskeyWrap.$inferSelect;
+export type NewCryptoPasskeyWrap = typeof cryptoPasskeyWrap.$inferInsert;

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -2,11 +2,16 @@ export {
   accountDeletionChallenge,
   type AccountDeletionChallenge,
 } from './accountDeletionChallenge';
+export { commodityPrice, type CommodityPrice } from './commodityPrice';
+export {
+  cryptoPasskeyWrap,
+  type CryptoPasskeyWrap,
+  type NewCryptoPasskeyWrap,
+} from './cryptoPasskeyWrap';
 export {
   encryptionResetChallenge,
   type EncryptionResetChallenge,
 } from './encryptionResetChallenge';
-export { commodityPrice, type CommodityPrice } from './commodityPrice';
 export { priceFetchRun, type PriceFetchRun } from './priceFetchRun';
 export { savedView, type SavedView } from './savedView';
 export { template, type Template } from './template';

--- a/docs/superpowers/plans/2026-06-25-encrypted-journals-passkey-unlock.md
+++ b/docs/superpowers/plans/2026-06-25-encrypted-journals-passkey-unlock.md
@@ -1,0 +1,1453 @@
+# Encrypted journals — passkey (PRF) unlock — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user's existing login passkey also unlock their encrypted journal, via the WebAuthn PRF extension — additive to the passphrase and recovery-code paths, supporting multiple passkeys.
+
+**Architecture:** A passkey carries an *additional opaque wrap* of the same per-user DEK, derived from the authenticator's PRF output (PRF → HKDF-SHA256 → AES-GCM KEK). Wraps live in a new one-to-many `cryptoPasskeyWrap` table. Unlock needs no server-side assertion verification: the assertion uses a random challenge and the DEK either unwraps client-side or it doesn't. The DEK never changes; passphrase/recovery wraps are untouched.
+
+**Tech Stack:** Next.js 16 (App Router), TypeScript, Drizzle ORM + Postgres, `@better-auth/passkey`, WebCrypto + `hash-wasm` (existing), Vitest. Spec: `docs/superpowers/specs/2026-06-25-encrypted-journals-passkey-unlock-design.md`.
+
+## Global Constraints
+
+- **Zero-knowledge:** the server stores only opaque base64 wraps + salts; it never sees the DEK except in session RAM (posted to `/api/crypto/unlock`). New code must not log or persist plaintext DEK or PRF output.
+- **DEK never changes:** passkey enable/disable only adds/removes a wrap; it never re-encrypts the journal.
+- **Proof-before-mutation:** enabling a passkey requires the user to first prove with passphrase or recovery (re-deriving the DEK via the existing `obtainDek`).
+- **No "last method" guard needed:** passphrase + recovery always exist, so a passkey is never the only way in.
+- **KEK info string:** `"ledger-passkey-v1"` (HKDF `info`), empty HKDF salt — mirrors the recovery path (`"ledger-recovery-v1"`).
+- **PRF salt:** 32 random bytes per credential, stored standard-base64.
+- **Credential IDs** are WebAuthn base64url strings (charset `A-Za-z0-9_-`), as stored by better-auth.
+- Follow the repository + service + one-action-per-file conventions already in the codebase.
+- Run `pnpm test`, `pnpm type-check`, and `pnpm lint` before each commit; all must pass.
+
+---
+
+### Task 1: Enable the PRF extension at passkey registration
+
+**Files:**
+- Modify: `lib/auth.ts:9-13`
+
+**Interfaces:**
+- Produces: passkeys registered from now on are PRF/hmac-secret capable (no runtime export).
+
+- [ ] **Step 1: Add the registration extension**
+
+Edit `lib/auth.ts` so the passkey plugin requests PRF at credential creation:
+
+```ts
+export const auth = await createAuth({
+  passkey: { rpName: APP_NAME, registration: { extensions: { prf: {} } } },
+  transport: postalTransport,
+  ...(googleConfigured && { google: {} }),
+});
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm type-check`
+Expected: PASS. If `createAuth`'s `passkey` option type rejects `registration`, the starter (`@naeemba/next-starter`) does not forward it — note this in the commit body and the live-acceptance checklist; the forwarding fix is a one-line change in the starter (user owns it). Do **not** block the rest of the plan on it — the automated tests below don't depend on real PRF.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/auth.ts
+git commit -m "feat(crypto): request PRF extension at passkey registration"
+```
+
+---
+
+### Task 2: `cryptoPasskeyWrap` schema + migration
+
+**Files:**
+- Create: `db/schema/cryptoPasskeyWrap.ts`
+- Modify: `db/schema/index.ts`
+- Create (generated): `db/migrations/0005_*.sql`
+
+**Interfaces:**
+- Produces: table `cryptoPasskeyWrap`; types `CryptoPasskeyWrap`, `NewCryptoPasskeyWrap`.
+
+- [ ] **Step 1: Write the schema file**
+
+Create `db/schema/cryptoPasskeyWrap.ts`:
+
+```ts
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import { pgTable, text, timestamp, unique } from 'drizzle-orm/pg-core';
+
+// One row per (user, passkey) that can unlock the journal. The DEK is wrapped
+// by a key derived from that passkey's PRF output. credentialId mirrors the
+// better-auth passkey credentialID (base64url); it is NOT a foreign key because
+// better-auth's credentialID column is indexed, not unique. Orphan rows (passkey
+// later deleted) are harmless — they can never assert — and the Settings UI hides
+// them by cross-referencing the live passkey list.
+export const cryptoPasskeyWrap = pgTable(
+  'cryptoPasskeyWrap',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('userId')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    credentialId: text('credentialId').notNull(),
+    prfSalt: text('prfSalt').notNull(), // base64, 32 bytes
+    wrap: text('wrap').notNull(), // opaque base64; DEK wrapped by the PRF-derived KEK
+    label: text('label').notNull(), // mirrors the passkey name, for the UI
+    createdAt: timestamp('createdAt').notNull().default(sql`now()`),
+  },
+  (t) => [unique('cryptoPasskeyWrap_user_cred').on(t.userId, t.credentialId)]
+);
+
+export type CryptoPasskeyWrap = typeof cryptoPasskeyWrap.$inferSelect;
+export type NewCryptoPasskeyWrap = typeof cryptoPasskeyWrap.$inferInsert;
+```
+
+- [ ] **Step 2: Export from the schema barrel**
+
+Add to `db/schema/index.ts` (keep alphabetical-ish ordering near the other crypto export):
+
+```ts
+export {
+  cryptoPasskeyWrap,
+  type CryptoPasskeyWrap,
+  type NewCryptoPasskeyWrap,
+} from './cryptoPasskeyWrap';
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run: `pnpm db:generate`
+Expected: a new file `db/migrations/0005_*.sql` creating the `cryptoPasskeyWrap` table with the unique constraint. Inspect it to confirm the table, FK on `userId`, and the `(userId, credentialId)` unique index.
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/schema/cryptoPasskeyWrap.ts db/schema/index.ts db/migrations/
+git commit -m "feat(crypto): cryptoPasskeyWrap table + migration 0005"
+```
+
+---
+
+### Task 3: `PasskeyWrapRepository`
+
+**Files:**
+- Create: `lib/crypto/passkeyWrapRepository.ts`
+- Create: `lib/crypto/passkeyWrapRepository.test.ts`
+- Modify: `lib/crypto/index.ts`
+
+**Interfaces:**
+- Consumes: `cryptoPasskeyWrap`, `CryptoPasskeyWrap`, `NewCryptoPasskeyWrap` (Task 2); `DbInstance` from `@/lib/db/connection`.
+- Produces:
+  - `class PasskeyWrapRepository { listByUser(userId: string): Promise<CryptoPasskeyWrap[]>; create(input: NewCryptoPasskeyWrap): Promise<void>; deleteByCredential(userId: string, credentialId: string): Promise<void>; }`
+  - `getPasskeyWrapRepository(): PasskeyWrapRepository` from `@/lib/crypto`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/crypto/passkeyWrapRepository.test.ts` (mirrors `userCryptoRepository.test.ts`'s harness):
+
+```ts
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PasskeyWrapRepository } from './passkeyWrapRepository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('PasskeyWrapRepository', () => {
+  let ctx: TestDbContext;
+  let repo: PasskeyWrapRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('passkey-wrap-');
+    await ctx.insertUser('alice');
+    repo = new PasskeyWrapRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  const row = (over: Partial<Parameters<PasskeyWrapRepository['create']>[0]> = {}) => ({
+    id: 'wrap-1',
+    userId: 'alice',
+    credentialId: 'cred-A',
+    prfSalt: 'c2FsdA==',
+    wrap: 'd3JhcA==',
+    label: 'Laptop',
+    ...over,
+  });
+
+  it('create → listByUser round-trips', async () => {
+    expect(await repo.listByUser('alice')).toEqual([]);
+    await repo.create(row());
+    const all = await repo.listByUser('alice');
+    expect(all).toHaveLength(1);
+    expect(all[0].credentialId).toBe('cred-A');
+    expect(all[0].label).toBe('Laptop');
+  });
+
+  it('supports multiple passkeys per user', async () => {
+    await repo.create(row({ id: 'wrap-1', credentialId: 'cred-A' }));
+    await repo.create(row({ id: 'wrap-2', credentialId: 'cred-B', label: 'Phone' }));
+    expect(await repo.listByUser('alice')).toHaveLength(2);
+  });
+
+  it('create is idempotent per (user, credential) — re-enable updates the wrap', async () => {
+    await repo.create(row({ id: 'wrap-1', credentialId: 'cred-A', wrap: 'old==' }));
+    await repo.create(row({ id: 'wrap-2', credentialId: 'cred-A', wrap: 'new==', prfSalt: 's2==' }));
+    const all = await repo.listByUser('alice');
+    expect(all).toHaveLength(1);
+    expect(all[0].wrap).toBe('new==');
+    expect(all[0].prfSalt).toBe('s2==');
+  });
+
+  it('deleteByCredential removes only the matching row', async () => {
+    await repo.create(row({ id: 'wrap-1', credentialId: 'cred-A' }));
+    await repo.create(row({ id: 'wrap-2', credentialId: 'cred-B' }));
+    await repo.deleteByCredential('alice', 'cred-A');
+    const all = await repo.listByUser('alice');
+    expect(all).toHaveLength(1);
+    expect(all[0].credentialId).toBe('cred-B');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test lib/crypto/passkeyWrapRepository.test.ts`
+Expected: FAIL — cannot find module `./passkeyWrapRepository`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `lib/crypto/passkeyWrapRepository.ts`:
+
+```ts
+import { and, eq } from 'drizzle-orm';
+import {
+  cryptoPasskeyWrap,
+  type CryptoPasskeyWrap,
+  type NewCryptoPasskeyWrap,
+} from '@/db/schema';
+import type { DbInstance } from '@/lib/db/connection';
+
+export class PasskeyWrapRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  async listByUser(userId: string): Promise<CryptoPasskeyWrap[]> {
+    return this.db
+      .select()
+      .from(cryptoPasskeyWrap)
+      .where(eq(cryptoPasskeyWrap.userId, userId));
+  }
+
+  /** Insert a wrap, or replace it if this (user, credential) already has one. */
+  async create(input: NewCryptoPasskeyWrap): Promise<void> {
+    await this.db
+      .insert(cryptoPasskeyWrap)
+      .values(input)
+      .onConflictDoUpdate({
+        target: [cryptoPasskeyWrap.userId, cryptoPasskeyWrap.credentialId],
+        set: { prfSalt: input.prfSalt, wrap: input.wrap, label: input.label },
+      });
+  }
+
+  async deleteByCredential(userId: string, credentialId: string): Promise<void> {
+    await this.db
+      .delete(cryptoPasskeyWrap)
+      .where(
+        and(
+          eq(cryptoPasskeyWrap.userId, userId),
+          eq(cryptoPasskeyWrap.credentialId, credentialId)
+        )
+      );
+  }
+}
+```
+
+- [ ] **Step 4: Add the lazy getter to the crypto barrel**
+
+Edit `lib/crypto/index.ts` to add (alongside the existing `getUserCryptoRepository`):
+
+```ts
+import { PasskeyWrapRepository } from './passkeyWrapRepository';
+
+let passkeyWrapRepo: PasskeyWrapRepository | null = null;
+
+export const getPasskeyWrapRepository = (): PasskeyWrapRepository =>
+  (passkeyWrapRepo ??= new PasskeyWrapRepository(db));
+
+export { PasskeyWrapRepository } from './passkeyWrapRepository';
+```
+
+(`db` is already imported in that file.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm test lib/crypto/passkeyWrapRepository.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/crypto/passkeyWrapRepository.ts lib/crypto/passkeyWrapRepository.test.ts lib/crypto/index.ts
+git commit -m "feat(crypto): PasskeyWrapRepository (list/create/delete)"
+```
+
+---
+
+### Task 4: `derivePrfKek` client helper
+
+**Files:**
+- Modify: `features/crypto/lib/clientCrypto.ts`
+- Modify: `features/crypto/lib/clientCrypto.test.ts`
+
+**Interfaces:**
+- Consumes: WebCrypto (`crypto.subtle`).
+- Produces: `derivePrfKek(prfOutput: Uint8Array): Promise<CryptoKey>` — AES-GCM-256 key usable by the existing `wrapDek`/`unwrapDek`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `features/crypto/lib/clientCrypto.test.ts`:
+
+```ts
+import { derivePrfKek, wrapDek, unwrapDek } from './clientCrypto';
+
+describe('derivePrfKek', () => {
+  it('round-trips a DEK wrap and is deterministic for the same PRF output', async () => {
+    const prf = crypto.getRandomValues(new Uint8Array(32));
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const kek = await derivePrfKek(prf);
+    const wrapped = await wrapDek(dek, kek);
+    const kek2 = await derivePrfKek(prf); // same PRF → same key
+    const back = await unwrapDek(wrapped, kek2);
+    expect(Array.from(back)).toEqual(Array.from(dek));
+  });
+
+  it('a different PRF output cannot unwrap', async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const wrapped = await wrapDek(dek, await derivePrfKek(crypto.getRandomValues(new Uint8Array(32))));
+    await expect(
+      unwrapDek(wrapped, await derivePrfKek(crypto.getRandomValues(new Uint8Array(32))))
+    ).rejects.toBeTruthy();
+  });
+});
+```
+
+(If `clientCrypto.test.ts` already imports some of these names, merge imports rather than duplicating.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test features/crypto/lib/clientCrypto.test.ts`
+Expected: FAIL — `derivePrfKek` is not exported.
+
+- [ ] **Step 3: Implement `derivePrfKek`**
+
+Add to `features/crypto/lib/clientCrypto.ts` (next to `recoveryHkdfKey`):
+
+```ts
+const PASSKEY_INFO = new TextEncoder().encode('ledger-passkey-v1');
+
+/** Derive an AES-GCM KEK from a passkey's PRF output (HKDF, empty salt). */
+export const derivePrfKek = async (
+  prfOutput: Uint8Array
+): Promise<CryptoKey> => {
+  const base = await crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(prfOutput) as Uint8Array<ArrayBuffer>,
+    'HKDF',
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0) as Uint8Array<ArrayBuffer>,
+      info: PASSKEY_INFO,
+    },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test features/crypto/lib/clientCrypto.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/crypto/lib/clientCrypto.ts features/crypto/lib/clientCrypto.test.ts
+git commit -m "feat(crypto): derivePrfKek (PRF → HKDF → AES-GCM KEK)"
+```
+
+---
+
+### Task 5: WebAuthn PRF assertion helpers
+
+**Files:**
+- Create: `features/crypto/lib/webauthn.ts`
+- Create: `features/crypto/lib/webauthn.test.ts`
+
+**Interfaces:**
+- Consumes: `fromBase64` from `./clientCrypto`; `navigator.credentials`.
+- Produces:
+  - `base64urlToBytes(s: string): Uint8Array`, `bytesToBase64url(b: Uint8Array): string`
+  - `type PrfAssertion = { credentialId: string; prfOutput: Uint8Array }`
+  - `assertPrfForCredential(credentialId: string, salt: Uint8Array): Promise<PrfAssertion>` (enable flow, single credential)
+  - `assertPrfAny(creds: { credentialId: string; prfSalt: string }[]): Promise<PrfAssertion>` (unlock flow, multiple credentials)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `features/crypto/lib/webauthn.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  base64urlToBytes,
+  bytesToBase64url,
+  assertPrfForCredential,
+  assertPrfAny,
+} from './webauthn';
+
+// Minimal fake of a PublicKeyCredential carrying a PRF result.
+const fakeCred = (id: string, first: ArrayBuffer | undefined) => ({
+  id,
+  getClientExtensionResults: () => (first ? { prf: { results: { first } } } : {}),
+});
+
+const stubGet = (impl: (opts: CredentialRequestOptions) => unknown) => {
+  // @ts-expect-error — jsdom has no navigator.credentials; install a stub.
+  globalThis.navigator = { credentials: { get: vi.fn(impl) } };
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('base64url helpers', () => {
+  it('round-trips bytes', () => {
+    const b = new Uint8Array([0, 1, 2, 250, 255]);
+    expect(Array.from(base64urlToBytes(bytesToBase64url(b)))).toEqual(Array.from(b));
+  });
+});
+
+describe('assertPrfForCredential', () => {
+  it('returns the PRF output for the credential', async () => {
+    const out = new Uint8Array(32).fill(7).buffer;
+    stubGet(() => fakeCred('cred-A', out));
+    const res = await assertPrfForCredential('cred-A', new Uint8Array(32));
+    expect(res.credentialId).toBe('cred-A');
+    expect(res.prfOutput).toHaveLength(32);
+  });
+
+  it('throws a clear error when PRF is unsupported', async () => {
+    stubGet(() => fakeCred('cred-A', undefined));
+    await expect(
+      assertPrfForCredential('cred-A', new Uint8Array(32))
+    ).rejects.toThrow(/does not support/i);
+  });
+
+  it('throws when the prompt is dismissed (null credential)', async () => {
+    stubGet(() => null);
+    await expect(
+      assertPrfForCredential('cred-A', new Uint8Array(32))
+    ).rejects.toThrow(/dismissed/i);
+  });
+});
+
+describe('assertPrfAny', () => {
+  it('identifies which credential answered and returns its PRF output', async () => {
+    const out = new Uint8Array(32).fill(9).buffer;
+    stubGet(() => fakeCred('cred-B', out));
+    const res = await assertPrfAny([
+      { credentialId: 'cred-A', prfSalt: 'c2FsdEE=' },
+      { credentialId: 'cred-B', prfSalt: 'c2FsdEI=' },
+    ]);
+    expect(res.credentialId).toBe('cred-B');
+    expect(res.prfOutput).toHaveLength(32);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test features/crypto/lib/webauthn.test.ts`
+Expected: FAIL — cannot find module `./webauthn`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `features/crypto/lib/webauthn.ts`:
+
+```ts
+import { fromBase64 } from './clientCrypto';
+
+export const base64urlToBytes = (s: string): Uint8Array => {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+};
+
+export const bytesToBase64url = (b: Uint8Array): string =>
+  btoa(String.fromCharCode(...b))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+export type PrfAssertion = { credentialId: string; prfOutput: Uint8Array };
+
+const readPrf = (cred: PublicKeyCredential): Uint8Array => {
+  const first = cred.getClientExtensionResults().prf?.results?.first;
+  if (!first) throw new Error('This device does not support passkey unlock.');
+  return new Uint8Array(first as ArrayBuffer);
+};
+
+/** Single-credential PRF assertion — used when enabling a specific passkey. */
+export const assertPrfForCredential = async (
+  credentialId: string,
+  salt: Uint8Array
+): Promise<PrfAssertion> => {
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [
+        { id: base64urlToBytes(credentialId), type: 'public-key' },
+      ],
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: salt } } },
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('Passkey prompt was dismissed.');
+  return { credentialId, prfOutput: readPrf(cred) };
+};
+
+/** Multi-credential PRF assertion — used at unlock; the user picks any enrolled passkey. */
+export const assertPrfAny = async (
+  creds: { credentialId: string; prfSalt: string }[]
+): Promise<PrfAssertion> => {
+  const evalByCredential: Record<string, { first: BufferSource }> = {};
+  for (const c of creds) {
+    evalByCredential[c.credentialId] = { first: fromBase64(c.prfSalt) };
+  }
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: creds.map((c) => ({
+        id: base64urlToBytes(c.credentialId),
+        type: 'public-key' as const,
+      })),
+      userVerification: 'required',
+      extensions: { prf: { evalByCredential } },
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('Passkey prompt was dismissed.');
+  return { credentialId: cred.id, prfOutput: readPrf(cred) };
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test features/crypto/lib/webauthn.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/crypto/lib/webauthn.ts features/crypto/lib/webauthn.test.ts
+git commit -m "feat(crypto): WebAuthn PRF assertion helpers (enable + unlock)"
+```
+
+---
+
+### Task 6: Extend the material contract + endpoint; add zod schemas
+
+**Files:**
+- Modify: `lib/crypto/setupSchema.ts`
+- Modify: `app/api/crypto/material/route.ts`
+- Modify: `app/api/crypto/material/route.test.ts`
+- Create: `lib/crypto/passkeyWrapSchema.ts`
+
+**Interfaces:**
+- Consumes: `getPasskeyWrapRepository` (Task 3).
+- Produces:
+  - `type PasskeyMaterial = { credentialId: string; prfSalt: string; wrap: string }`
+  - `CryptoMaterial` now includes `passkeys: PasskeyMaterial[]`
+  - `enablePasskeyUnlockSchema`, `disablePasskeyUnlockSchema` (zod)
+
+- [ ] **Step 1: Extend `CryptoMaterial`**
+
+Edit `lib/crypto/setupSchema.ts`, replacing the `CryptoMaterial` type block:
+
+```ts
+export type PasskeyMaterial = {
+  credentialId: string;
+  prfSalt: string;
+  wrap: string;
+};
+
+// Wrapped key-material the server hands back to the client (GET /api/crypto/material).
+// Opaque blobs only; the server never unwraps them. `passkeys` is the list of
+// enrolled passkey wraps (empty when none).
+export type CryptoMaterial = Pick<
+  SetupCryptoInput,
+  'passSalt' | 'argonParams' | 'wrapPassphrase' | 'wrapRecovery'
+> & {
+  passkeys: PasskeyMaterial[];
+};
+```
+
+- [ ] **Step 2: Update the material route test**
+
+Edit `app/api/crypto/material/route.test.ts` to assert `passkeys` is present. Add an expectation to the existing "returns material" test (adapt to the file's existing mocking style):
+
+```ts
+// after the existing assertions on passSalt / wraps:
+expect(body.passkeys).toEqual([]); // none enrolled by default
+```
+
+If the test mocks `getUserCryptoRepository`, also mock `getPasskeyWrapRepository` to return `{ listByUser: async () => [] }`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm test app/api/crypto/material/route.test.ts`
+Expected: FAIL — `passkeys` is undefined / mock missing.
+
+- [ ] **Step 4: Update the material route**
+
+Edit `app/api/crypto/material/route.ts`:
+
+```ts
+import { requireUser } from '@/lib/auth/require-user';
+import {
+  getPasskeyWrapRepository,
+  getUserCryptoRepository,
+} from '@/lib/crypto';
+import type { CryptoMaterial } from '@/lib/crypto/setupSchema';
+import { NextResponse } from 'next/server';
+
+export async function GET(): Promise<NextResponse> {
+  const user = await requireUser();
+  const row = await getUserCryptoRepository().get(user.id);
+  if (!row) {
+    return NextResponse.json(
+      { error: 'Encryption is not set up.' },
+      { status: 404 }
+    );
+  }
+  const wraps = await getPasskeyWrapRepository().listByUser(user.id);
+  // All blobs are opaque without the user's secret.
+  const material: CryptoMaterial = {
+    passSalt: row.passSalt,
+    argonParams: row.argonParams,
+    wrapPassphrase: row.wrapPassphrase,
+    wrapRecovery: row.wrapRecovery,
+    passkeys: wraps.map((w) => ({
+      credentialId: w.credentialId,
+      prfSalt: w.prfSalt,
+      wrap: w.wrap,
+    })),
+  };
+  return NextResponse.json(material);
+}
+```
+
+- [ ] **Step 5: Write the zod schemas**
+
+Create `lib/crypto/passkeyWrapSchema.ts`:
+
+```ts
+import { z } from 'zod';
+
+const b64 = z
+  .string()
+  .regex(/^[A-Za-z0-9+/]+={0,2}$/)
+  .min(1)
+  .max(512);
+
+// WebAuthn credential id: base64url charset.
+const b64url = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]+={0,2}$/)
+  .min(1)
+  .max(512);
+
+export const enablePasskeyUnlockSchema = z.object({
+  credentialId: b64url,
+  prfSalt: b64,
+  wrap: b64,
+  label: z.string().min(1).max(100),
+});
+
+export const disablePasskeyUnlockSchema = z.object({
+  credentialId: b64url,
+});
+```
+
+- [ ] **Step 6: Run tests + type-check**
+
+Run: `pnpm test app/api/crypto/material/route.test.ts && pnpm type-check`
+Expected: PASS. (Type-check confirms `SetupWizard`/unlock code that builds `CryptoMaterial`-shaped objects still compiles; `getMaterial` consumers now see `passkeys`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/crypto/setupSchema.ts app/api/crypto/material/route.ts app/api/crypto/material/route.test.ts lib/crypto/passkeyWrapSchema.ts
+git commit -m "feat(crypto): expose passkey wraps in material + enable/disable schemas"
+```
+
+---
+
+### Task 7: Server actions — enable / disable passkey unlock
+
+**Files:**
+- Create: `features/crypto/actions/enablePasskeyUnlock.ts`
+- Create: `features/crypto/actions/disablePasskeyUnlock.ts`
+- Create: `features/crypto/actions/passkeyUnlock.test.ts`
+
+**Interfaces:**
+- Consumes: `enablePasskeyUnlockSchema`, `disablePasskeyUnlockSchema` (Task 6); `getUserCryptoRepository`, `getPasskeyWrapRepository`; `rateLimit, WRITE, RATE_LIMIT_MESSAGE`; `ulid`.
+- Produces:
+  - `enablePasskeyUnlockAction(input: unknown): Promise<{ ok: true } | { ok: false; message: string }>`
+  - `disablePasskeyUnlockAction(input: unknown): Promise<{ ok: true } | { ok: false; message: string }>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `features/crypto/actions/passkeyUnlock.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const exists = vi.fn();
+const create = vi.fn();
+const deleteByCredential = vi.fn();
+const allowed = vi.fn(() => ({ allowed: true }));
+
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: async () => ({ id: 'alice' }),
+}));
+vi.mock('@/lib/crypto', () => ({
+  getUserCryptoRepository: () => ({ exists }),
+  getPasskeyWrapRepository: () => ({ create, deleteByCredential }),
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: () => allowed(),
+  WRITE: { name: 'write' },
+  RATE_LIMIT_MESSAGE: 'slow down',
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+import { enablePasskeyUnlockAction } from './enablePasskeyUnlock';
+import { disablePasskeyUnlockAction } from './disablePasskeyUnlock';
+
+const validEnable = {
+  credentialId: 'cred-A',
+  prfSalt: 'c2FsdA==',
+  wrap: 'd3JhcA==',
+  label: 'Laptop',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  exists.mockResolvedValue(true);
+  allowed.mockReturnValue({ allowed: true });
+});
+
+describe('enablePasskeyUnlockAction', () => {
+  it('creates a wrap for a valid request', async () => {
+    const res = await enablePasskeyUnlockAction(validEnable);
+    expect(res).toEqual({ ok: true });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'alice', credentialId: 'cred-A', label: 'Laptop' })
+    );
+  });
+
+  it('rejects when encryption is not set up', async () => {
+    exists.mockResolvedValue(false);
+    expect(await enablePasskeyUnlockAction(validEnable)).toMatchObject({ ok: false });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid input', async () => {
+    expect(await enablePasskeyUnlockAction({ credentialId: '' })).toMatchObject({ ok: false });
+  });
+
+  it('rejects when rate-limited', async () => {
+    allowed.mockReturnValue({ allowed: false });
+    expect(await enablePasskeyUnlockAction(validEnable)).toEqual({ ok: false, message: 'slow down' });
+  });
+});
+
+describe('disablePasskeyUnlockAction', () => {
+  it('deletes the wrap', async () => {
+    const res = await disablePasskeyUnlockAction({ credentialId: 'cred-A' });
+    expect(res).toEqual({ ok: true });
+    expect(deleteByCredential).toHaveBeenCalledWith('alice', 'cred-A');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test features/crypto/actions/passkeyUnlock.test.ts`
+Expected: FAIL — action modules do not exist.
+
+- [ ] **Step 3: Write `enablePasskeyUnlock.ts`**
+
+```ts
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import {
+  getPasskeyWrapRepository,
+  getUserCryptoRepository,
+} from '@/lib/crypto';
+import { enablePasskeyUnlockSchema } from '@/lib/crypto/passkeyWrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { ulid } from 'ulid';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function enablePasskeyUnlockAction(
+  input: unknown
+): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed)
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = enablePasskeyUnlockSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  if (!(await getUserCryptoRepository().exists(user.id)))
+    return { ok: false, message: 'Encryption is not set up.' };
+  await getPasskeyWrapRepository().create({
+    id: ulid(),
+    userId: user.id,
+    credentialId: parsed.data.credentialId,
+    prfSalt: parsed.data.prfSalt,
+    wrap: parsed.data.wrap,
+    label: parsed.data.label,
+  });
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: Write `disablePasskeyUnlock.ts`**
+
+```ts
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { getPasskeyWrapRepository } from '@/lib/crypto';
+import { disablePasskeyUnlockSchema } from '@/lib/crypto/passkeyWrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function disablePasskeyUnlockAction(
+  input: unknown
+): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed)
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = disablePasskeyUnlockSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  await getPasskeyWrapRepository().deleteByCredential(
+    user.id,
+    parsed.data.credentialId
+  );
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm test features/crypto/actions/passkeyUnlock.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/crypto/actions/enablePasskeyUnlock.ts features/crypto/actions/disablePasskeyUnlock.ts features/crypto/actions/passkeyUnlock.test.ts
+git commit -m "feat(crypto): enable/disable passkey unlock server actions"
+```
+
+---
+
+### Task 8: Client flows — build-wrap (enable) and unlock-with-passkey
+
+**Files:**
+- Create: `features/crypto/lib/passkeyFlow.ts`
+- Create: `features/crypto/lib/passkeyFlow.test.ts`
+
+**Interfaces:**
+- Consumes: `derivePrfKek`, `wrapDek`, `unwrapDek`, `toBase64` (clientCrypto); `assertPrfForCredential`, `assertPrfAny` (webauthn); `getMaterial` (cryptoMaterial); `postDek` (unlockFlow).
+- Produces:
+  - `type EnablePasskeyInput = { credentialId: string; prfSalt: string; wrap: string; label: string }`
+  - `buildPasskeyWrap(dek: Uint8Array, credentialId: string, label: string): Promise<EnablePasskeyInput>`
+  - `unlockWithPasskey(): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `features/crypto/lib/passkeyFlow.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  generateDek,
+  derivePrfKek,
+  wrapDek,
+  toBase64,
+} from './clientCrypto';
+
+const assertPrfForCredential = vi.fn();
+const assertPrfAny = vi.fn();
+const getMaterial = vi.fn();
+const postDek = vi.fn();
+
+vi.mock('./webauthn', () => ({ assertPrfForCredential, assertPrfAny }));
+vi.mock('./cryptoMaterial', () => ({ getMaterial }));
+vi.mock('./unlockFlow', () => ({ postDek }));
+
+import { buildPasskeyWrap, unlockWithPasskey } from './passkeyFlow';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('buildPasskeyWrap', () => {
+  it('asserts PRF and returns a wrap of the DEK', async () => {
+    const prf = new Uint8Array(32).fill(3);
+    assertPrfForCredential.mockResolvedValue({ credentialId: 'cred-A', prfOutput: prf });
+    const dek = generateDek();
+    const out = await buildPasskeyWrap(dek, 'cred-A', 'Laptop');
+    expect(out.credentialId).toBe('cred-A');
+    expect(out.label).toBe('Laptop');
+    expect(out.prfSalt.length).toBeGreaterThan(0);
+    expect(out.wrap.length).toBeGreaterThan(0);
+  });
+});
+
+describe('unlockWithPasskey', () => {
+  it('unwraps with the responding credential and posts the DEK', async () => {
+    // Arrange: enroll cred-B with a known PRF output.
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    getMaterial.mockResolvedValue({
+      passkeys: [
+        { credentialId: 'cred-A', prfSalt: toBase64(new Uint8Array(32).fill(1)), wrap: 'x' },
+        { credentialId: 'cred-B', prfSalt: toBase64(new Uint8Array(32).fill(2)), wrap },
+      ],
+    });
+    assertPrfAny.mockResolvedValue({ credentialId: 'cred-B', prfOutput: prf });
+
+    await unlockWithPasskey();
+
+    expect(postDek).toHaveBeenCalledTimes(1);
+    const posted = postDek.mock.calls[0][0] as Uint8Array;
+    expect(Array.from(posted)).toEqual(Array.from(dek));
+  });
+
+  it('throws when no passkeys are enrolled', async () => {
+    getMaterial.mockResolvedValue({ passkeys: [] });
+    await expect(unlockWithPasskey()).rejects.toThrow(/no passkey/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test features/crypto/lib/passkeyFlow.test.ts`
+Expected: FAIL — cannot find module `./passkeyFlow`.
+
+- [ ] **Step 3: Implement the flows**
+
+Create `features/crypto/lib/passkeyFlow.ts`:
+
+```ts
+import {
+  derivePrfKek,
+  fromBase64,
+  toBase64,
+  unwrapDek,
+  wrapDek,
+} from './clientCrypto';
+import { getMaterial } from './cryptoMaterial';
+import { postDek } from './unlockFlow';
+import { assertPrfAny, assertPrfForCredential } from './webauthn';
+
+export type EnablePasskeyInput = {
+  credentialId: string;
+  prfSalt: string;
+  wrap: string;
+  label: string;
+};
+
+/**
+ * Build the wrap for a passkey. The caller must already hold the DEK (obtained
+ * via obtainDek with a passphrase/recovery authorizer). Generates a fresh PRF
+ * salt, asserts the passkey to read its PRF output, and wraps the DEK with the
+ * derived KEK. The result is POSTed to enablePasskeyUnlockAction.
+ */
+export const buildPasskeyWrap = async (
+  dek: Uint8Array,
+  credentialId: string,
+  label: string
+): Promise<EnablePasskeyInput> => {
+  const salt = crypto.getRandomValues(new Uint8Array(32));
+  const { prfOutput } = await assertPrfForCredential(credentialId, salt);
+  const wrap = await wrapDek(dek, await derivePrfKek(prfOutput));
+  return { credentialId, prfSalt: toBase64(salt), wrap, label };
+};
+
+/** Unlock the session using any enrolled passkey. */
+export const unlockWithPasskey = async (): Promise<void> => {
+  const m = await getMaterial();
+  if (!m.passkeys.length) throw new Error('No passkey is set up for unlock.');
+  const { credentialId, prfOutput } = await assertPrfAny(
+    m.passkeys.map((p) => ({ credentialId: p.credentialId, prfSalt: p.prfSalt }))
+  );
+  const match = m.passkeys.find((p) => p.credentialId === credentialId);
+  if (!match) throw new Error('Passkey is not enrolled for unlock.');
+  const dek = await unwrapDek(match.wrap, await derivePrfKek(prfOutput)).catch(
+    () => {
+      throw new Error('Passkey unlock failed.');
+    }
+  );
+  await postDek(dek);
+};
+```
+
+(Note: `fromBase64` is imported for parity with other flow files; remove it if lint flags it as unused.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test features/crypto/lib/passkeyFlow.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/crypto/lib/passkeyFlow.ts features/crypto/lib/passkeyFlow.test.ts
+git commit -m "feat(crypto): client passkey enable + unlock flows"
+```
+
+---
+
+### Task 9: Settings → Security — Passkey unlock card
+
+**Files:**
+- Create: `features/settings/PasskeyUnlockCard.tsx`
+- Modify: `features/settings/SecuritySection.tsx`
+- Modify: `features/settings/actions/index.ts` (re-export the two actions, matching the existing barrel pattern)
+
+**Interfaces:**
+- Consumes: `authClient.passkey.listUserPasskeys()`; `getMaterial`; `obtainDek` (rewrapFlow); `buildPasskeyWrap` (passkeyFlow); `enablePasskeyUnlockAction`, `disablePasskeyUnlockAction`.
+- Produces: `<PasskeyUnlockCard />` default export.
+
+- [ ] **Step 1: Re-export the actions from the settings barrel**
+
+Add to `features/settings/actions/index.ts`:
+
+```ts
+export { enablePasskeyUnlockAction } from '@/features/crypto/actions/enablePasskeyUnlock';
+export { disablePasskeyUnlockAction } from '@/features/crypto/actions/disablePasskeyUnlock';
+```
+
+(If the existing barrel re-exports crypto actions differently, follow that file's established style.)
+
+- [ ] **Step 2: Write the card**
+
+Create `features/settings/PasskeyUnlockCard.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  disablePasskeyUnlockAction,
+  enablePasskeyUnlockAction,
+} from './actions';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { authClient } from '@/lib/auth-client';
+import { getMaterial } from '@/features/crypto/lib/cryptoMaterial';
+import { buildPasskeyWrap } from '@/features/crypto/lib/passkeyFlow';
+import { obtainDek, type Authorizer } from '@/features/crypto/lib/rewrapFlow';
+
+type Row = { credentialId: string; name: string; enabled: boolean };
+
+const PasskeyUnlockCard = () => {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [useForgot, setUseForgot] = useState(false);
+  const [secret, setSecret] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const [list, material] = await Promise.all([
+        authClient.passkey.listUserPasskeys(),
+        getMaterial(),
+      ]);
+      const enabled = new Set(material.passkeys.map((p) => p.credentialId));
+      const passkeys = list.data ?? [];
+      setRows(
+        passkeys.map((p) => ({
+          credentialId: p.credentialID,
+          name: p.name ?? 'Passkey',
+          enabled: enabled.has(p.credentialID),
+        }))
+      );
+    } catch {
+      setError('Could not load your passkeys.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function handleEnable(row: Row) {
+    setError(null);
+    if (!secret) {
+      setError('Enter your passphrase or recovery code first.');
+      return;
+    }
+    const authorizer: Authorizer = useForgot
+      ? { kind: 'recovery', code: secret }
+      : { kind: 'passphrase', passphrase: secret };
+    setBusyId(row.credentialId);
+    try {
+      const dek = await obtainDek(authorizer);
+      const input = await buildPasskeyWrap(dek, row.credentialId, row.name);
+      const res = await enablePasskeyUnlockAction(input);
+      if (!res.ok) {
+        setError(res.message);
+        return;
+      }
+      toast.success(`${row.name} can now unlock your journal.`);
+      setSecret('');
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not enable passkey unlock.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDisable(row: Row) {
+    setError(null);
+    setBusyId(row.credentialId);
+    try {
+      const res = await disablePasskeyUnlockAction({ credentialId: row.credentialId });
+      if (!res.ok) {
+        setError(res.message);
+        return;
+      }
+      toast.success(`${row.name} can no longer unlock your journal.`);
+      await refresh();
+    } catch {
+      setError('Could not disable passkey unlock.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Unlock with a passkey</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <p className="text-muted-foreground text-sm">
+          Let a passkey unlock your encrypted journal, alongside your passphrase
+          and recovery code. Enabling a passkey requires your passphrase (or
+          recovery code) to prove it&apos;s you.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="passkey-secret">
+              {useForgot ? 'Recovery code' : 'Current passphrase'}
+            </Label>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 transition-colors hover:underline"
+              onClick={() => {
+                setUseForgot((v) => !v);
+                setSecret('');
+                setError(null);
+              }}
+            >
+              {useForgot ? 'Use passphrase instead' : 'Forgot? Use recovery code'}
+            </button>
+          </div>
+          <Input
+            id="passkey-secret"
+            type={useForgot ? 'text' : 'password'}
+            autoComplete={useForgot ? 'off' : 'current-password'}
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+          />
+        </div>
+
+        {loading ? (
+          <p className="text-muted-foreground text-sm">Loading passkeys…</p>
+        ) : rows.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            You have no passkeys yet. Add one under{' '}
+            <a className="underline" href="/settings/passkeys">
+              Passkeys
+            </a>{' '}
+            first.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {rows.map((row) => (
+              <li
+                key={row.credentialId}
+                className="flex items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <span className="text-sm font-medium">{row.name}</span>
+                {row.enabled ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={busyId === row.credentialId}
+                    onClick={() => handleDisable(row)}
+                  >
+                    {busyId === row.credentialId ? 'Removing…' : 'Disable unlock'}
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    disabled={busyId === row.credentialId || !secret}
+                    onClick={() => handleEnable(row)}
+                  >
+                    {busyId === row.credentialId ? 'Enabling…' : 'Enable unlock'}
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PasskeyUnlockCard;
+```
+
+- [ ] **Step 3: Wire into `SecuritySection`**
+
+Edit `features/settings/SecuritySection.tsx`: import the card and render it after `RotateRecoveryCard`:
+
+```tsx
+import ChangePassphraseCard from './ChangePassphraseCard';
+import PasskeyUnlockCard from './PasskeyUnlockCard';
+import ResetEncryptionCard from './ResetEncryptionCard';
+import RotateRecoveryCard from './RotateRecoveryCard';
+// ...
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-lg font-semibold">Security</h2>
+      <ChangePassphraseCard />
+      <RotateRecoveryCard />
+      <PasskeyUnlockCard />
+      <ResetEncryptionCard />
+    </div>
+  );
+```
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: PASS. (No unit test for the card — it is exercised in live acceptance. If `authClient.passkey.listUserPasskeys` has a different exact name in the installed version, fix it now; the endpoint is `/passkey/list-user-passkeys` returning `Passkey[]` with `credentialID` + `name`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/settings/PasskeyUnlockCard.tsx features/settings/SecuritySection.tsx features/settings/actions/index.ts
+git commit -m "feat(crypto): Settings → Security passkey unlock card"
+```
+
+---
+
+### Task 10: Unlock screen — "Unlock with passkey" button
+
+**Files:**
+- Modify: `features/crypto/UnlockScreen.tsx`
+
+**Interfaces:**
+- Consumes: `unlockWithPasskey` (passkeyFlow); `getMaterial`; `finalizeEncryption`.
+- Produces: a passkey unlock affordance on `/crypto/unlock`, shown only when ≥1 passkey is enrolled.
+
+- [ ] **Step 1: Add passkey state + handler to `UnlockForm`**
+
+In `features/crypto/UnlockScreen.tsx`, extend the `UnlockForm` component. Add imports at the top of the file:
+
+```ts
+import { unlockWithPasskey } from '@/features/crypto/lib/passkeyFlow';
+import { getMaterial } from '@/features/crypto/lib/cryptoMaterial';
+import { useEffect } from 'react';
+```
+
+Inside `UnlockForm`, after the existing `useState` declarations, add:
+
+```ts
+const [hasPasskey, setHasPasskey] = useState(false);
+
+useEffect(() => {
+  void getMaterial()
+    .then((m) => setHasPasskey(m.passkeys.length > 0))
+    .catch(() => setHasPasskey(false));
+}, []);
+
+async function handlePasskey() {
+  setError(null);
+  setPending(true);
+  try {
+    await unlockWithPasskey();
+    await finalizeEncryption().catch(() => {});
+    window.location.assign(resolveCallback());
+  } catch (err) {
+    setError(
+      err instanceof Error ? err.message : CRYPTO_COPY.errors.unlockFailed
+    );
+    setPending(false);
+  }
+}
+```
+
+- [ ] **Step 2: Render the button**
+
+In `UnlockForm`'s returned JSX, immediately after the `</form>` closing tag (before the switch-mode paragraph), add:
+
+```tsx
+{hasPasskey && (
+  <button
+    type="button"
+    className="au-btn au-btn--ghost"
+    onClick={handlePasskey}
+    disabled={pending}
+  >
+    Unlock with passkey
+  </button>
+)}
+```
+
+- [ ] **Step 3: Verify the build compiles**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/crypto/UnlockScreen.tsx
+git commit -m "feat(crypto): passkey unlock button on the unlock screen"
+```
+
+---
+
+### Task 11 (optional, recommended): Setup-wizard passkey step
+
+> Deliverable: after setting the recovery code, the wizard offers "Also unlock with this device's passkey?". Reuses `buildPasskeyWrap` + `enablePasskeyUnlockAction` while the freshly-generated DEK is still in `dekRef`. Skippable — passphrase + recovery already work. Cut this task if it risks destabilizing the wizard's state machine; the feature is complete without it.
+
+**Files:**
+- Modify: `features/crypto/SetupWizard.tsx`
+
+**Interfaces:**
+- Consumes: `dekRef.current` (the in-memory DEK); `authClient.passkey.listUserPasskeys`; `buildPasskeyWrap`; `enablePasskeyUnlockAction`.
+
+- [ ] **Step 1: Add an optional passkey step between `recovery` and `encrypting`**
+
+Extend the `Step` union with `'passkey'` and `STEP_ORDER`/`STEP_LABELS` accordingly. Add a `PasskeyStep` component that:
+- lists the user's passkeys (`authClient.passkey.listUserPasskeys()`),
+- on "Enable", reads `dekRef.current`, calls `buildPasskeyWrap(dek, credentialId, name)` then `enablePasskeyUnlockAction(input)`,
+- offers a "Skip" button.
+
+Both "Enable+continue" and "Skip" advance to `handleRecoveryNext()` (which unlocks the session via `postDek(dekRef.current)` and finalizes). Wire the new step into the render switch and the `RecoveryStep`'s `onNext` to go to `'passkey'` instead of directly calling `handleRecoveryNext`.
+
+Follow the existing `au-*` styling and the in-memory-DEK guard pattern already used in `handleRecoveryNext` (if `dekRef.current` is null, route to `/crypto/unlock`).
+
+- [ ] **Step 2: Verify the build compiles**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add features/crypto/SetupWizard.tsx
+git commit -m "feat(crypto): optional passkey step in the setup wizard"
+```
+
+---
+
+### Task 12: Full suite + live acceptance checklist
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `pnpm test && pnpm type-check && pnpm lint`
+Expected: all PASS (existing suite + the new repository/crypto/action/flow tests).
+
+- [ ] **Step 2: Record the live acceptance checklist in the PR body**
+
+WebAuthn cannot run headless. Add to the PR body (folds into the crypto e2e already owed for P2/P3 on a real Postgres + Garage env):
+
+```
+- [ ] Register a passkey (sign-in passkey); confirm PRF results are returned at assertion (if not, the starter dropped registration.extensions — patch it).
+- [ ] Settings → Security → Enable unlock (prove with passphrase). Lock. Unlock via Touch ID/PIN → journal decrypts.
+- [ ] Enable a second passkey on another device; both unlock independently.
+- [ ] Disable one passkey → it no longer unlocks; the other still does; passphrase + recovery still work.
+- [ ] (If Task 11 shipped) Fresh-user wizard passkey step enables unlock from day one.
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin encrypted-journals-passkey
+gh pr create --title "feat(crypto): encrypted journals — passkey (PRF) unlock" --body "<summary + the acceptance checklist above>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Reuse login passkeys via PRF → Task 1 (registration extension), Tasks 5/8 (assertion + flows). ✓
+- New `cryptoPasskeyWrap` one-to-many table → Task 2. ✓
+- KEK = PRF → HKDF(`ledger-passkey-v1`) → AES-GCM → Task 4. ✓
+- Enable flow (proof-before-mutation) → Tasks 8 (`buildPasskeyWrap`) + 9 (card obtains DEK via `obtainDek`) + 7 (action). ✓
+- Unlock flow (`evalByCredential`, no server verify) → Tasks 5 (`assertPrfAny`) + 8 (`unlockWithPasskey`) + 10 (button). ✓
+- Disable flow, no last-method guard → Task 7 + 9. ✓
+- Material contract extension → Task 6. ✓
+- Setup-wizard touchpoint → Task 11 (optional). ✓
+- Orphan handling (tolerate; no FK on credentialId) → Task 2 schema comment + Task 9 cross-reference hides orphans. ✓
+- Testing (unit/repo/action/flow + live e2e) → Tasks 3,4,5,7,8,12. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. Task 11 is intentionally described at component-shape level (not full code) because it is optional and must adapt to the wizard's evolving state machine — flagged as such, not a hidden gap.
+
+**Type consistency:** `EnablePasskeyInput` (Task 8) matches `enablePasskeyUnlockSchema` fields (Task 6) and the action's `create` call (Task 7). `PasskeyMaterial` (Task 6) matches what `assertPrfAny`/`unlockWithPasskey` consume. `credentialId` is base64url end-to-end (better-auth `credentialID` → schema → material → `cred.id`). Action result shape `{ ok } | { ok:false; message }` matches the card's `res.ok`/`res.message` usage.

--- a/docs/superpowers/specs/2026-06-25-encrypted-journals-passkey-unlock-design.md
+++ b/docs/superpowers/specs/2026-06-25-encrypted-journals-passkey-unlock-design.md
@@ -1,0 +1,222 @@
+# Encrypted journals — passkey (PRF) unlock
+
+**Date:** 2026-06-25
+**Status:** Design approved, pending spec review
+**Phase:** 7 (multi-user hardening) — encrypted-journals fast-follow
+**Supersedes / extends:** `2026-06-25-encrypted-journals-v2-design.md` (P1–P3, all merged: PR #28/#29/#30)
+
+## Summary
+
+Add a **third way to unlock an encrypted journal: the user's passkey**, alongside
+the existing passphrase and one-time recovery code. Unlock is the per-session step
+that hands the server the Data Encryption Key (DEK) in RAM so it can decrypt the
+journal for the duration of the session.
+
+This is **purely additive**. The DEK never changes; passphrase and recovery wraps
+are untouched. A passkey simply carries an *additional wrap* of the same DEK,
+derived from the passkey's **WebAuthn PRF** output. Multiple passkeys are
+supported — each carries its own wrap.
+
+## Background / current state
+
+From P1–P3 (all merged to `main`):
+
+- One random 32-byte **DEK** per user encrypts the journal at the Garage push/pull
+  seam (`LEJ1` ciphertext at rest; plaintext only on the ephemeral local working
+  dir during an unlocked session).
+- The DEK is stored **wrapped** (AES-GCM) in the `userCrypto` table, today as two
+  fixed columns:
+  - `wrapPassphrase` — KEK = Argon2id(passphrase, `passSalt`, `argonParams`)
+  - `wrapRecovery` — KEK = HKDF-SHA256(recovery-code bytes, info=`ledger-recovery-v1`)
+- **Zero-knowledge:** all wraps are opaque base64 blobs created client-side; the
+  server never unwraps them. The server sees the raw DEK only in session RAM,
+  posted to `POST /api/crypto/unlock` after the client unwraps it locally.
+- Unlock (`features/crypto/lib/unlockFlow.ts`): fetch wrap material via
+  `getMaterial()` (`GET /api/crypto/material`), derive the KEK, `unwrapDek`,
+  `postDek`.
+- Rewrap (`features/crypto/lib/rewrapFlow.ts`): `obtainDek(authorizer)` re-derives
+  the DEK from a passphrase **or** recovery authorizer (proof-before-mutation);
+  `changePassphrase` / `rotateRecovery` re-wrap without re-encrypting the journal.
+- Login already uses passkeys via `@better-auth/passkey` (plus magic-link), with a
+  manager UI at `/settings/passkeys` (`PasskeyManagerPage` from `@naeemba/next-starter`).
+  An account can already have multiple passkeys.
+
+**Verified capabilities** (`node_modules/@better-auth/passkey`):
+- The passkey plugin accepts WebAuthn extensions at registration
+  (`opts.registration.extensions`) and authentication (`opts.authentication.extensions`),
+  plus per-call client `extensions`, and returns `clientExtensionResults`. So the
+  **PRF / hmac-secret extension can be enabled at credential creation** and
+  evaluated during an assertion.
+- The application has **no real users yet**, so there are no PRF-less credentials
+  to migrate — enabling PRF on registration from now on is sufficient.
+
+## Decision: reuse login passkeys (not dedicated credentials)
+
+The same passkey the user signs in with also unlocks the journal. Rejected
+alternative: dedicated encryption-only passkeys (cleaner isolation, but a second
+passkey per device and no migration upside given zero existing users).
+
+### Key property: no server-side assertion verification
+
+PRF-based unlock needs **no challenge/verify round-trip**. Security comes entirely
+from "does the PRF-derived key unwrap the DEK" — identical in spirit to the
+passphrase path (derive key, try to unwrap, succeed or fail). The WebAuthn
+assertion can therefore use a random client-generated challenge and is **never
+sent to the server for verification**. The unlock ceremony is stateless: assert →
+read PRF → unwrap locally → `postDek`.
+
+## Data model
+
+New one-to-many table (today's wraps are fixed columns; passkeys need many):
+
+```
+cryptoPasskeyWrap
+  id            text  PK              -- ULID
+  userId        text  → user.id (onDelete: cascade)
+  credentialId  text                  -- the better-auth passkey credential id (base64url)
+  prfSalt       text                  -- random 32 bytes, base64; input to the authenticator PRF
+  wrap          text                  -- DEK wrapped by the PRF-derived KEK (opaque base64)
+  label         text                  -- mirrors the passkey's name, for the UI
+  createdAt     timestamptz  default now()
+  UNIQUE (userId, credentialId)
+```
+
+Migration `0005`.
+
+**Orphan handling** (passkey removed via the passkey manager): prefer a foreign key
+`credentialId → <better-auth passkey credential-id column>` with `onDelete: cascade`
+**if** that column is unique in the better-auth schema. If it is not cleanly
+FK-able, tolerate orphan wraps — an orphan credential can never assert, so its wrap
+is unusable and harmless, and it simply won't appear as an actionable passkey in the
+Settings list (which cross-references the live passkey list). The choice is
+confirmed against the actual passkey schema during implementation.
+
+The server stores only opaque wraps + salts. Zero-knowledge is preserved.
+
+## KEK derivation
+
+Mirrors the recovery path, new domain-separation info string:
+
+```
+PRF output (32 bytes)
+  → HKDF-SHA256(salt = empty, info = "ledger-passkey-v1")
+  → AES-GCM-256 KEK
+  → wrap / unwrap DEK   (existing wrapDek / unwrapDek)
+```
+
+New client helper `derivePrfKek(prfOutput: Uint8Array): Promise<CryptoKey>` next to
+`recoveryHkdfKey` in `features/crypto/lib/clientCrypto.ts`. The PRF input (`first`)
+is the per-credential `prfSalt`.
+
+## Flows
+
+### 1. Enable passkey unlock (Settings → Security; proof-before-mutation)
+
+1. User proves identity with **passphrase or recovery** → `obtainDek(authorizer)`
+   returns the DEK client-side (same as `changePassphrase`).
+2. Generate random `prfSalt` (32 bytes).
+3. `navigator.credentials.get({ publicKey: { challenge: random, allowCredentials:
+   [credentials not yet enabled], userVerification: 'required', extensions: { prf:
+   { eval: { first: prfSalt } } } } })`.
+4. Read `assertion.getClientExtensionResults().prf.results.first` → PRF output. If
+   absent → throw "this device doesn't support passkey unlock."
+5. `derivePrfKek` → `wrapDek(dek, kek)` → wrap.
+6. POST `{ credentialId: assertion.id, prfSalt, wrap, label }` to the
+   `enablePasskeyUnlock` server action → insert `cryptoPasskeyWrap` row.
+
+### 2. Unlock with passkey (`/crypto/unlock`)
+
+1. `getMaterial()` now also returns `passkeys: [{ credentialId, prfSalt, wrap }]`.
+2. `navigator.credentials.get` over **all** the user's enabled credentials, using
+   `extensions: { prf: { evalByCredential: { [credentialId]: { first: prfSalt }, … } } }`
+   (per-credential salts), `userVerification: 'required'`, random challenge.
+3. Identify the responding credential by `assertion.id`; take its `wrap`.
+4. Read PRF output → `derivePrfKek` → `unwrapDek(wrap, kek)` → `postDek(dek)`
+   (existing endpoint, server stores DEK in session RAM).
+
+### 3. Disable passkey unlock (Settings → Security)
+
+- Delete the `cryptoPasskeyWrap` row for that credential. The login passkey is
+  untouched.
+- **No "last unlock method" guard needed** — passphrase + recovery always exist, so
+  a passkey is never the only way in. (Simpler than P3's recovery-rotation guard.)
+
+### 4. Setup-wizard touchpoint (recommended, additive)
+
+During the setup wizard the freshly generated DEK is already in hand client-side —
+the only moment a passkey can be enabled **without** re-entering the passphrase.
+Add an optional final wizard step: *"Also unlock with this device's passkey?"* →
+one PRF assertion → wrap → store. Reuses the enable flow. Makes passkey unlock work
+from day one without a separate Settings visit.
+
+## Auth / PRF configuration
+
+Enable PRF at registration so new passkeys are PRF-capable:
+
+```ts
+// lib/auth.ts
+passkey: { rpName: APP_NAME, registration: { extensions: { prf: {} } } }
+```
+
+Confirm `@naeemba/next-starter`'s `createAuth` forwards the `registration` option to
+the passkey plugin. If it only forwards `rpName`, add the forwarding in the starter
+(user owns it) or wire the plugin option directly — a small change, surfaced when
+hit.
+
+## Components & files
+
+- `db/schema/cryptoPasskeyWrap.ts` + barrel export; migration `0005`.
+- Repository: `PasskeyWrapRepository` (or methods on `UserCryptoRepository`) —
+  `listByUser`, `create`, `deleteByCredential`.
+- `features/crypto/lib/clientCrypto.ts` — add `derivePrfKek`.
+- `features/crypto/lib/passkeyFlow.ts` — `enablePasskeyUnlock` (assert+wrap) and
+  `unlockWithPasskey` (assert+unwrap+postDek) client flows; small WebAuthn helpers
+  for base64url ↔ ArrayBuffer on credential ids.
+- `lib/crypto/setupSchema.ts` — extend `CryptoMaterial` with optional `passkeys`.
+- `app/api/crypto/material/route.ts` — include the passkey wrap list.
+- `features/crypto/actions/enablePasskeyUnlock.ts`,
+  `features/crypto/actions/disablePasskeyUnlock.ts` (one action per file;
+  rate-limited per the existing pattern).
+- `features/settings/PasskeyUnlockCard.tsx` — list passkeys (cross-reference
+  better-auth list + our wraps), Enable / Disable; added to `SecuritySection`.
+- `features/crypto/UnlockScreen.tsx` — "Unlock with passkey" button, shown when
+  `material.passkeys.length > 0`.
+- `features/crypto/SetupWizard.tsx` — optional final passkey step.
+- `lib/auth.ts` — PRF registration extension.
+
+## Error handling
+
+- **PRF unsupported** → clear message on enable; passkey options hidden on the
+  unlock screen when no wraps exist.
+- **User cancels the WebAuthn prompt** → surfaced inline, no state change.
+- **Wrong authorizer on enable** → existing `obtainDek` error messages ("Incorrect
+  passphrase." / "Incorrect recovery code.").
+- **Orphan wrap** → unusable, harmless; cleaned by cascade or ignored (see Data model).
+- Server actions never see plaintext DEK or PRF output — only opaque wraps + salts.
+
+## Testing
+
+- **Unit:** `derivePrfKek` determinism; wrap/unwrap round-trip with a PRF-derived
+  key; `enablePasskeyUnlock` / `unlockWithPasskey` flows with mocked
+  `navigator.credentials` + `getMaterial`.
+- **Repository:** `cryptoPasskeyWrap` CRUD.
+- **Actions:** enable / disable with mocked deps and the established
+  `@/lib/rate-limit` mock.
+- **Migration:** `0005` applies.
+- **Live e2e acceptance** (WebAuthn can't run headless — folds into the crypto e2e
+  already owed for P2/P3):
+  1. Enable passkey unlock (proving with passphrase) in Settings → Security.
+  2. Lock, then unlock via the passkey (Touch ID / device PIN); journal decrypts.
+  3. Register/enable a second passkey on another device; both unlock independently.
+  4. Disable one passkey → it no longer unlocks; the other still does; passphrase +
+     recovery still work.
+  5. Setup-wizard passkey step (fresh user) enables unlock from day one.
+
+## Scope / non-goals
+
+- One cohesive PR, built via SDD (schema/repo → client crypto → material+actions →
+  auth PRF config → UI + wizard → tests), matching P1–P3.
+- **Not** dedicated encryption-only passkeys.
+- **Not** changing the DEK, the at-rest format, or the passphrase/recovery paths.
+- **Not** server-side assertion verification (unnecessary for PRF unlock).
+```

--- a/features/crypto/UnlockScreen.tsx
+++ b/features/crypto/UnlockScreen.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { KeyRound, ShieldCheck } from 'lucide-react';
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import '@/features/auth/auth.css';
 import { finalizeEncryption } from '@/features/crypto/actions/finalizeEncryption';
 import { CRYPTO_COPY } from '@/features/crypto/cryptoCopy';
+import { getMaterial } from '@/features/crypto/lib/cryptoMaterial';
+import { unlockWithPasskey } from '@/features/crypto/lib/passkeyFlow';
 import {
   unlockWithPassphrase,
   unlockWithRecovery,
@@ -147,6 +149,28 @@ function UnlockForm() {
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [hasPasskey, setHasPasskey] = useState(false);
+
+  useEffect(() => {
+    void getMaterial()
+      .then((m) => setHasPasskey(m.passkeys.length > 0))
+      .catch(() => setHasPasskey(false));
+  }, []);
+
+  async function handlePasskey() {
+    setError(null);
+    setPending(true);
+    try {
+      await unlockWithPasskey();
+      await finalizeEncryption().catch(() => {});
+      window.location.assign(resolveCallback());
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : CRYPTO_COPY.errors.unlockFailed
+      );
+      setPending(false);
+    }
+  }
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -233,6 +257,17 @@ function UnlockForm() {
           {error ?? ''}
         </p>
       </form>
+
+      {hasPasskey && (
+        <button
+          type="button"
+          className="au-btn au-btn--ghost"
+          onClick={handlePasskey}
+          disabled={pending}
+        >
+          Unlock with passkey
+        </button>
+      )}
 
       <p className="text-sm text-[color:var(--txt-faint)]">
         <button

--- a/features/crypto/actions/disablePasskeyUnlock.ts
+++ b/features/crypto/actions/disablePasskeyUnlock.ts
@@ -1,0 +1,24 @@
+'use server';
+import { requireUser } from '@/lib/auth/require-user';
+import { getPasskeyWrapRepository } from '@/lib/crypto';
+import { disablePasskeyUnlockSchema } from '@/lib/crypto/passkeyWrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function disablePasskeyUnlockAction(
+  input: unknown
+): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed)
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = disablePasskeyUnlockSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  await getPasskeyWrapRepository().deleteByCredential(
+    user.id,
+    parsed.data.credentialId
+  );
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/features/crypto/actions/enablePasskeyUnlock.ts
+++ b/features/crypto/actions/enablePasskeyUnlock.ts
@@ -1,0 +1,34 @@
+'use server';
+import { ulid } from 'ulid';
+import { requireUser } from '@/lib/auth/require-user';
+import {
+  getPasskeyWrapRepository,
+  getUserCryptoRepository,
+} from '@/lib/crypto';
+import { enablePasskeyUnlockSchema } from '@/lib/crypto/passkeyWrapSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+type Result = { ok: true } | { ok: false; message: string };
+
+export async function enablePasskeyUnlockAction(
+  input: unknown
+): Promise<Result> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed)
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  const parsed = enablePasskeyUnlockSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, message: 'Invalid request.' };
+  if (!(await getUserCryptoRepository().exists(user.id)))
+    return { ok: false, message: 'Encryption is not set up.' };
+  await getPasskeyWrapRepository().create({
+    id: ulid(),
+    userId: user.id,
+    credentialId: parsed.data.credentialId,
+    prfSalt: parsed.data.prfSalt,
+    wrap: parsed.data.wrap,
+    label: parsed.data.label,
+  });
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/features/crypto/actions/passkeyUnlock.test.ts
+++ b/features/crypto/actions/passkeyUnlock.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { disablePasskeyUnlockAction } from './disablePasskeyUnlock';
+import { enablePasskeyUnlockAction } from './enablePasskeyUnlock';
+
+const exists = vi.fn();
+const create = vi.fn();
+const deleteByCredential = vi.fn();
+const allowed = vi.fn(() => ({ allowed: true }));
+
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: async () => ({ id: 'alice' }),
+}));
+vi.mock('@/lib/crypto', () => ({
+  getUserCryptoRepository: () => ({ exists }),
+  getPasskeyWrapRepository: () => ({ create, deleteByCredential }),
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: () => allowed(),
+  WRITE: { name: 'write' },
+  RATE_LIMIT_MESSAGE: 'slow down',
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+const validEnable = {
+  credentialId: 'cred-A',
+  prfSalt: 'c2FsdA==',
+  wrap: 'd3JhcA==',
+  label: 'Laptop',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  exists.mockResolvedValue(true);
+  allowed.mockReturnValue({ allowed: true });
+});
+
+describe('enablePasskeyUnlockAction', () => {
+  it('creates a wrap for a valid request', async () => {
+    const res = await enablePasskeyUnlockAction(validEnable);
+    expect(res).toEqual({ ok: true });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'alice',
+        credentialId: 'cred-A',
+        label: 'Laptop',
+      })
+    );
+  });
+
+  it('rejects when encryption is not set up', async () => {
+    exists.mockResolvedValue(false);
+    expect(await enablePasskeyUnlockAction(validEnable)).toMatchObject({
+      ok: false,
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid input', async () => {
+    expect(await enablePasskeyUnlockAction({ credentialId: '' })).toMatchObject(
+      { ok: false }
+    );
+  });
+
+  it('rejects when rate-limited', async () => {
+    allowed.mockReturnValue({ allowed: false });
+    expect(await enablePasskeyUnlockAction(validEnable)).toEqual({
+      ok: false,
+      message: 'slow down',
+    });
+  });
+});
+
+describe('disablePasskeyUnlockAction', () => {
+  it('deletes the wrap', async () => {
+    const res = await disablePasskeyUnlockAction({ credentialId: 'cred-A' });
+    expect(res).toEqual({ ok: true });
+    expect(deleteByCredential).toHaveBeenCalledWith('alice', 'cred-A');
+  });
+});

--- a/features/crypto/lib/clientCrypto.test.ts
+++ b/features/crypto/lib/clientCrypto.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  derivePrfKek,
   derivePassphraseKek,
   generateDek,
   generateRecoveryCode,
@@ -53,5 +54,31 @@ describe('clientCrypto', () => {
     const { code, bytes } = generateRecoveryCode();
     expect(bytes.length).toBe(32);
     expect(code).toMatch(/^[A-Z2-7]{4}(-[A-Z2-7]{4})+$/);
+  });
+});
+
+describe('derivePrfKek', () => {
+  it('round-trips a DEK wrap and is deterministic for the same PRF output', async () => {
+    const prf = crypto.getRandomValues(new Uint8Array(32));
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const kek = await derivePrfKek(prf);
+    const wrapped = await wrapDek(dek, kek);
+    const kek2 = await derivePrfKek(prf); // same PRF → same key
+    const back = await unwrapDek(wrapped, kek2);
+    expect(Array.from(back)).toEqual(Array.from(dek));
+  });
+
+  it('a different PRF output cannot unwrap', async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const wrapped = await wrapDek(
+      dek,
+      await derivePrfKek(crypto.getRandomValues(new Uint8Array(32)))
+    );
+    await expect(
+      unwrapDek(
+        wrapped,
+        await derivePrfKek(crypto.getRandomValues(new Uint8Array(32)))
+      )
+    ).rejects.toBeTruthy();
   });
 });

--- a/features/crypto/lib/clientCrypto.ts
+++ b/features/crypto/lib/clientCrypto.ts
@@ -2,6 +2,7 @@ import { argon2id } from 'hash-wasm';
 
 const GCM_NONCE = 12;
 const RECOVERY_INFO = new TextEncoder().encode('ledger-recovery-v1');
+const PASSKEY_INFO = new TextEncoder().encode('ledger-passkey-v1');
 
 export const toBase64 = (b: Uint8Array): string =>
   btoa(String.fromCharCode(...b));
@@ -50,6 +51,31 @@ export const recoveryHkdfKey = async (
       hash: 'SHA-256',
       salt: new Uint8Array(0) as Uint8Array<ArrayBuffer>,
       info: RECOVERY_INFO,
+    },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+};
+
+/** Derive an AES-GCM KEK from a passkey's PRF output (HKDF, empty salt). */
+export const derivePrfKek = async (
+  prfOutput: Uint8Array
+): Promise<CryptoKey> => {
+  const base = await crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(prfOutput) as Uint8Array<ArrayBuffer>,
+    'HKDF',
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0) as Uint8Array<ArrayBuffer>,
+      info: PASSKEY_INFO,
     },
     base,
     { name: 'AES-GCM', length: 256 },

--- a/features/crypto/lib/passkeyFlow.test.ts
+++ b/features/crypto/lib/passkeyFlow.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi, MockedFunction } from 'vitest';
+import { generateDek, derivePrfKek, wrapDek, toBase64 } from './clientCrypto';
+import { getMaterial } from './cryptoMaterial';
+import { buildPasskeyWrap, unlockWithPasskey } from './passkeyFlow';
+import { postDek } from './unlockFlow';
+import { assertPrfForCredential, assertPrfAny } from './webauthn';
+
+vi.mock('./webauthn');
+vi.mock('./cryptoMaterial');
+vi.mock('./unlockFlow');
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('buildPasskeyWrap', () => {
+  it('asserts PRF and returns a wrap of the DEK', async () => {
+    const prf = new Uint8Array(32).fill(3);
+    (
+      assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
+    ).mockResolvedValue({
+      credentialId: 'cred-A',
+      prfOutput: prf,
+    });
+    const dek = generateDek();
+    const out = await buildPasskeyWrap(dek, 'cred-A', 'Laptop');
+    expect(out.credentialId).toBe('cred-A');
+    expect(out.label).toBe('Laptop');
+    expect(out.prfSalt.length).toBeGreaterThan(0);
+    expect(out.wrap.length).toBeGreaterThan(0);
+  });
+});
+
+describe('unlockWithPasskey', () => {
+  it('unwraps with the responding credential and posts the DEK', async () => {
+    // Arrange: enroll cred-B with a known PRF output.
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [
+        {
+          credentialId: 'cred-A',
+          prfSalt: toBase64(new Uint8Array(32).fill(1)),
+          wrap: 'x',
+        },
+        {
+          credentialId: 'cred-B',
+          prfSalt: toBase64(new Uint8Array(32).fill(2)),
+          wrap,
+        },
+      ],
+    });
+    (assertPrfAny as MockedFunction<typeof assertPrfAny>).mockResolvedValue({
+      credentialId: 'cred-B',
+      prfOutput: prf,
+    });
+
+    await unlockWithPasskey();
+
+    expect(postDek).toHaveBeenCalledTimes(1);
+    const posted = (postDek as MockedFunction<typeof postDek>).mock
+      .calls[0][0] as Uint8Array;
+    expect(Array.from(posted)).toEqual(Array.from(dek));
+  });
+
+  it('throws when no passkeys are enrolled', async () => {
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [],
+    });
+    await expect(unlockWithPasskey()).rejects.toThrow(/no passkey/i);
+  });
+});

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -1,0 +1,48 @@
+import { derivePrfKek, toBase64, unwrapDek, wrapDek } from './clientCrypto';
+import { getMaterial } from './cryptoMaterial';
+import { postDek } from './unlockFlow';
+import { assertPrfAny, assertPrfForCredential } from './webauthn';
+
+export type EnablePasskeyInput = {
+  credentialId: string;
+  prfSalt: string;
+  wrap: string;
+  label: string;
+};
+
+/**
+ * Build the wrap for a passkey. The caller must already hold the DEK (obtained
+ * via obtainDek with a passphrase/recovery authorizer). Generates a fresh PRF
+ * salt, asserts the passkey to read its PRF output, and wraps the DEK with the
+ * derived KEK. The result is POSTed to enablePasskeyUnlockAction.
+ */
+export const buildPasskeyWrap = async (
+  dek: Uint8Array,
+  credentialId: string,
+  label: string
+): Promise<EnablePasskeyInput> => {
+  const salt = crypto.getRandomValues(new Uint8Array(32));
+  const { prfOutput } = await assertPrfForCredential(credentialId, salt);
+  const wrap = await wrapDek(dek, await derivePrfKek(prfOutput));
+  return { credentialId, prfSalt: toBase64(salt), wrap, label };
+};
+
+/** Unlock the session using any enrolled passkey. */
+export const unlockWithPasskey = async (): Promise<void> => {
+  const m = await getMaterial();
+  if (!m.passkeys.length) throw new Error('No passkey is set up for unlock.');
+  const { credentialId, prfOutput } = await assertPrfAny(
+    m.passkeys.map((p) => ({
+      credentialId: p.credentialId,
+      prfSalt: p.prfSalt,
+    }))
+  );
+  const match = m.passkeys.find((p) => p.credentialId === credentialId);
+  if (!match) throw new Error('Passkey is not enrolled for unlock.');
+  const dek = await unwrapDek(match.wrap, await derivePrfKek(prfOutput)).catch(
+    () => {
+      throw new Error('Passkey unlock failed.');
+    }
+  );
+  await postDek(dek);
+};

--- a/features/crypto/lib/webauthn.test.ts
+++ b/features/crypto/lib/webauthn.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  base64urlToBytes,
+  bytesToBase64url,
+  assertPrfForCredential,
+  assertPrfAny,
+} from './webauthn';
+
+// Minimal fake of a PublicKeyCredential carrying a PRF result.
+const fakeCred = (id: string, first: ArrayBuffer | undefined) => ({
+  id,
+  getClientExtensionResults: () =>
+    first ? { prf: { results: { first } } } : {},
+});
+
+const stubGet = (impl: (opts: CredentialRequestOptions) => unknown) => {
+  // jsdom makes navigator read-only; use vi.stubGlobal (the supported vitest approach).
+  vi.stubGlobal('navigator', { credentials: { get: vi.fn(impl) } });
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('base64url helpers', () => {
+  it('round-trips bytes', () => {
+    const b = new Uint8Array([0, 1, 2, 250, 255]);
+    expect(Array.from(base64urlToBytes(bytesToBase64url(b)))).toEqual(
+      Array.from(b)
+    );
+  });
+});
+
+describe('assertPrfForCredential', () => {
+  it('returns the PRF output for the credential', async () => {
+    const out = new Uint8Array(32).fill(7).buffer;
+    stubGet(() => fakeCred('cred-A', out));
+    const res = await assertPrfForCredential('cred-A', new Uint8Array(32));
+    expect(res.credentialId).toBe('cred-A');
+    expect(res.prfOutput).toHaveLength(32);
+  });
+
+  it('throws a clear error when PRF is unsupported', async () => {
+    stubGet(() => fakeCred('cred-A', undefined));
+    await expect(
+      assertPrfForCredential('cred-A', new Uint8Array(32))
+    ).rejects.toThrow(/does not support/i);
+  });
+
+  it('throws when the prompt is dismissed (null credential)', async () => {
+    stubGet(() => null);
+    await expect(
+      assertPrfForCredential('cred-A', new Uint8Array(32))
+    ).rejects.toThrow(/dismissed/i);
+  });
+});
+
+describe('assertPrfAny', () => {
+  it('identifies which credential answered and returns its PRF output', async () => {
+    const out = new Uint8Array(32).fill(9).buffer;
+    stubGet(() => fakeCred('cred-B', out));
+    const res = await assertPrfAny([
+      { credentialId: 'cred-A', prfSalt: 'c2FsdEE=' },
+      { credentialId: 'cred-B', prfSalt: 'c2FsdEI=' },
+    ]);
+    expect(res.credentialId).toBe('cred-B');
+    expect(res.prfOutput).toHaveLength(32);
+  });
+});

--- a/features/crypto/lib/webauthn.test.ts
+++ b/features/crypto/lib/webauthn.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   base64urlToBytes,
-  bytesToBase64url,
   assertPrfForCredential,
   assertPrfAny,
 } from './webauthn';
@@ -20,12 +19,12 @@ const stubGet = (impl: (opts: CredentialRequestOptions) => unknown) => {
 
 afterEach(() => vi.unstubAllGlobals());
 
-describe('base64url helpers', () => {
-  it('round-trips bytes', () => {
-    const b = new Uint8Array([0, 1, 2, 250, 255]);
-    expect(Array.from(base64urlToBytes(bytesToBase64url(b)))).toEqual(
-      Array.from(b)
-    );
+describe('base64urlToBytes', () => {
+  it('decodes base64url (incl. -_ and missing padding) to bytes', () => {
+    // [0, 1, 2, 250, 255] => standard base64 "AAEC+v8=" => base64url "AAEC-v8"
+    expect(Array.from(base64urlToBytes('AAEC-v8'))).toEqual([
+      0, 1, 2, 250, 255,
+    ]);
   });
 });
 

--- a/features/crypto/lib/webauthn.ts
+++ b/features/crypto/lib/webauthn.ts
@@ -1,0 +1,67 @@
+import { fromBase64 } from './clientCrypto';
+
+export const base64urlToBytes = (s: string): Uint8Array<ArrayBuffer> => {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+  return Uint8Array.from(atob(b64), (c) =>
+    c.charCodeAt(0)
+  ) as Uint8Array<ArrayBuffer>;
+};
+
+export const bytesToBase64url = (b: Uint8Array): string =>
+  btoa(String.fromCharCode(...b))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+export type PrfAssertion = { credentialId: string; prfOutput: Uint8Array };
+
+const readPrf = (cred: PublicKeyCredential): Uint8Array => {
+  const first = cred.getClientExtensionResults().prf?.results?.first;
+  if (!first) throw new Error('This device does not support passkey unlock.');
+  return new Uint8Array(first as ArrayBuffer);
+};
+
+/** Single-credential PRF assertion — used when enabling a specific passkey. */
+export const assertPrfForCredential = async (
+  credentialId: string,
+  salt: Uint8Array
+): Promise<PrfAssertion> => {
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [
+        { id: base64urlToBytes(credentialId), type: 'public-key' },
+      ],
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: salt as unknown as BufferSource } } },
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('Passkey prompt was dismissed.');
+  return { credentialId, prfOutput: readPrf(cred) };
+};
+
+/** Multi-credential PRF assertion — used at unlock; the user picks any enrolled passkey. */
+export const assertPrfAny = async (
+  creds: { credentialId: string; prfSalt: string }[]
+): Promise<PrfAssertion> => {
+  const evalByCredential: Record<string, { first: BufferSource }> = {};
+  for (const c of creds) {
+    evalByCredential[c.credentialId] = {
+      first: fromBase64(c.prfSalt) as unknown as BufferSource,
+    };
+  }
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: creds.map((c) => ({
+        id: base64urlToBytes(c.credentialId),
+        type: 'public-key' as const,
+      })),
+      userVerification: 'required',
+      extensions: { prf: { evalByCredential } },
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('Passkey prompt was dismissed.');
+  return { credentialId: cred.id, prfOutput: readPrf(cred) };
+};

--- a/features/crypto/lib/webauthn.ts
+++ b/features/crypto/lib/webauthn.ts
@@ -8,12 +8,6 @@ export const base64urlToBytes = (s: string): Uint8Array<ArrayBuffer> => {
   ) as Uint8Array<ArrayBuffer>;
 };
 
-export const bytesToBase64url = (b: Uint8Array): string =>
-  btoa(String.fromCharCode(...b))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-
 export type PrfAssertion = { credentialId: string; prfOutput: Uint8Array };
 
 const readPrf = (cred: PublicKeyCredential): Uint8Array => {

--- a/features/settings/PasskeyUnlockCard.tsx
+++ b/features/settings/PasskeyUnlockCard.tsx
@@ -23,7 +23,7 @@ async function fetchPasskeys(): Promise<AuthPasskey[]> {
     method: 'GET',
     credentials: 'include',
   });
-  if (!res.ok) return [];
+  if (!res.ok) throw new Error('Could not load passkeys');
   return (await res.json()) as AuthPasskey[];
 }
 
@@ -36,6 +36,7 @@ const PasskeyUnlockCard = () => {
   const [error, setError] = useState<string | null>(null);
 
   async function refresh() {
+    setLoading(true);
     try {
       const [passkeys, material] = await Promise.all([
         fetchPasskeys(),
@@ -183,7 +184,7 @@ const PasskeyUnlockCard = () => {
                 ) : (
                   <Button
                     size="sm"
-                    disabled={busyId === row.credentialId}
+                    disabled={busyId === row.credentialId || !secret}
                     onClick={() => handleEnable(row)}
                   >
                     {busyId === row.credentialId

--- a/features/settings/PasskeyUnlockCard.tsx
+++ b/features/settings/PasskeyUnlockCard.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  disablePasskeyUnlockAction,
+  enablePasskeyUnlockAction,
+} from './actions';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { getMaterial } from '@/features/crypto/lib/cryptoMaterial';
+import { buildPasskeyWrap } from '@/features/crypto/lib/passkeyFlow';
+import { obtainDek, type Authorizer } from '@/features/crypto/lib/rewrapFlow';
+
+type AuthPasskey = { credentialID: string; name?: string };
+type Row = { credentialId: string; name: string; enabled: boolean };
+
+async function fetchPasskeys(): Promise<AuthPasskey[]> {
+  const res = await fetch('/api/auth/passkey/list-user-passkeys', {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!res.ok) return [];
+  return (await res.json()) as AuthPasskey[];
+}
+
+const PasskeyUnlockCard = () => {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [useForgot, setUseForgot] = useState(false);
+  const [secret, setSecret] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    try {
+      const [passkeys, material] = await Promise.all([
+        fetchPasskeys(),
+        getMaterial(),
+      ]);
+      const enabled = new Set(material.passkeys.map((p) => p.credentialId));
+      setRows(
+        passkeys.map((p) => ({
+          credentialId: p.credentialID,
+          name: p.name ?? 'Passkey',
+          enabled: enabled.has(p.credentialID),
+        }))
+      );
+    } catch {
+      setError('Could not load your passkeys.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+  }, []);
+
+  async function handleEnable(row: Row) {
+    setError(null);
+    if (!secret) {
+      setError('Enter your passphrase or recovery code first.');
+      return;
+    }
+    const authorizer: Authorizer = useForgot
+      ? { kind: 'recovery', code: secret }
+      : { kind: 'passphrase', passphrase: secret };
+    setBusyId(row.credentialId);
+    try {
+      const dek = await obtainDek(authorizer);
+      const input = await buildPasskeyWrap(dek, row.credentialId, row.name);
+      const res = await enablePasskeyUnlockAction(input);
+      if (!res.ok) {
+        setError(res.message);
+        return;
+      }
+      toast.success(`${row.name} can now unlock your journal.`);
+      setSecret('');
+      await refresh();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Could not enable passkey unlock.'
+      );
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDisable(row: Row) {
+    setError(null);
+    setBusyId(row.credentialId);
+    try {
+      const res = await disablePasskeyUnlockAction({
+        credentialId: row.credentialId,
+      });
+      if (!res.ok) {
+        setError(res.message);
+        return;
+      }
+      toast.success(`${row.name} can no longer unlock your journal.`);
+      await refresh();
+    } catch {
+      setError('Could not disable passkey unlock.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Unlock with a passkey</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <p className="text-muted-foreground text-sm">
+          Let a passkey unlock your encrypted journal, alongside your passphrase
+          and recovery code. Enabling a passkey requires your passphrase (or
+          recovery code) to prove it&apos;s you.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="passkey-secret">
+              {useForgot ? 'Recovery code' : 'Current passphrase'}
+            </Label>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 transition-colors hover:underline"
+              onClick={() => {
+                setUseForgot((v) => !v);
+                setSecret('');
+                setError(null);
+              }}
+            >
+              {useForgot
+                ? 'Use passphrase instead'
+                : 'Forgot? Use recovery code'}
+            </button>
+          </div>
+          <Input
+            id="passkey-secret"
+            type={useForgot ? 'text' : 'password'}
+            autoComplete={useForgot ? 'off' : 'current-password'}
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+          />
+        </div>
+
+        {loading ? (
+          <p className="text-muted-foreground text-sm">Loading passkeys…</p>
+        ) : rows.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            You have no passkeys yet. Add one under{' '}
+            <a className="underline" href="/settings/passkeys">
+              Passkeys
+            </a>{' '}
+            first.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {rows.map((row) => (
+              <li
+                key={row.credentialId}
+                className="flex items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <span className="text-sm font-medium">{row.name}</span>
+                {row.enabled ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={busyId === row.credentialId}
+                    onClick={() => handleDisable(row)}
+                  >
+                    {busyId === row.credentialId
+                      ? 'Removing…'
+                      : 'Disable unlock'}
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    disabled={busyId === row.credentialId}
+                    onClick={() => handleEnable(row)}
+                  >
+                    {busyId === row.credentialId
+                      ? 'Enabling…'
+                      : 'Enable unlock'}
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PasskeyUnlockCard;

--- a/features/settings/SecuritySection.tsx
+++ b/features/settings/SecuritySection.tsx
@@ -1,4 +1,5 @@
 import ChangePassphraseCard from './ChangePassphraseCard';
+import PasskeyUnlockCard from './PasskeyUnlockCard';
 import ResetEncryptionCard from './ResetEncryptionCard';
 import RotateRecoveryCard from './RotateRecoveryCard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -28,6 +29,7 @@ const SecuritySection = ({ enabled }: Props) => {
       <h2 className="text-lg font-semibold">Security</h2>
       <ChangePassphraseCard />
       <RotateRecoveryCard />
+      <PasskeyUnlockCard />
       <ResetEncryptionCard />
     </div>
   );

--- a/features/settings/actions/index.ts
+++ b/features/settings/actions/index.ts
@@ -16,3 +16,5 @@ export {
   type RequestEncryptionResetResult,
 } from './requestEncryptionReset';
 export { confirmEncryptionResetAction } from './confirmEncryptionReset';
+export { enablePasskeyUnlockAction } from '@/features/crypto/actions/enablePasskeyUnlock';
+export { disablePasskeyUnlockAction } from '@/features/crypto/actions/disablePasskeyUnlock';

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -7,7 +7,9 @@ const googleConfigured =
   !!process.env.GOOGLE_CLIENT_ID && !!process.env.GOOGLE_CLIENT_SECRET;
 
 export const auth = await createAuth({
-  passkey: { rpName: APP_NAME },
+  // PRF extension at registration so passkeys can derive a stable secret for
+  // client-side encryption-key wrapping (passkey unlock of encrypted journals).
+  passkey: { rpName: APP_NAME, registration: { extensions: { prf: {} } } },
   transport: postalTransport,
   ...(googleConfigured && { google: {} }),
 });

--- a/lib/crypto/index.ts
+++ b/lib/crypto/index.ts
@@ -1,10 +1,16 @@
+import { PasskeyWrapRepository } from './passkeyWrapRepository';
 import { UserCryptoRepository } from './userCryptoRepository';
 import { db } from '@/lib/db';
 
 let repo: UserCryptoRepository | null = null;
+let passkeyWrapRepo: PasskeyWrapRepository | null = null;
 
 /** Lazy singleton bound to the production db (connects on first query). */
 export const getUserCryptoRepository = (): UserCryptoRepository =>
   (repo ??= new UserCryptoRepository(db));
 
+export const getPasskeyWrapRepository = (): PasskeyWrapRepository =>
+  (passkeyWrapRepo ??= new PasskeyWrapRepository(db));
+
 export { UserCryptoRepository } from './userCryptoRepository';
+export { PasskeyWrapRepository } from './passkeyWrapRepository';

--- a/lib/crypto/passkeyWrapRepository.test.ts
+++ b/lib/crypto/passkeyWrapRepository.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PasskeyWrapRepository } from './passkeyWrapRepository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('PasskeyWrapRepository', () => {
+  let ctx: TestDbContext;
+  let repo: PasskeyWrapRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('passkey-wrap-');
+    await ctx.insertUser('alice');
+    repo = new PasskeyWrapRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  const row = (
+    over: Partial<Parameters<PasskeyWrapRepository['create']>[0]> = {}
+  ) => ({
+    id: 'wrap-1',
+    userId: 'alice',
+    credentialId: 'cred-A',
+    prfSalt: 'c2FsdA==',
+    wrap: 'd3JhcA==',
+    label: 'Laptop',
+    ...over,
+  });
+
+  it('create → listByUser round-trips', async () => {
+    expect(await repo.listByUser('alice')).toEqual([]);
+    await repo.create(row());
+    const all = await repo.listByUser('alice');
+    expect(all).toHaveLength(1);
+    expect(all[0].credentialId).toBe('cred-A');
+    expect(all[0].label).toBe('Laptop');
+  });
+
+  it('supports multiple passkeys per user', async () => {
+    await repo.create(row({ id: 'wrap-1', credentialId: 'cred-A' }));
+    await repo.create(
+      row({ id: 'wrap-2', credentialId: 'cred-B', label: 'Phone' })
+    );
+    expect(await repo.listByUser('alice')).toHaveLength(2);
+  });
+
+  it('create is idempotent per (user, credential) — re-enable updates the wrap', async () => {
+    await repo.create(
+      row({ id: 'wrap-1', credentialId: 'cred-A', wrap: 'old==' })
+    );
+    await repo.create(
+      row({
+        id: 'wrap-2',
+        credentialId: 'cred-A',
+        wrap: 'new==',
+        prfSalt: 's2==',
+      })
+    );
+    const all = await repo.listByUser('alice');
+    expect(all).toHaveLength(1);
+    expect(all[0].wrap).toBe('new==');
+    expect(all[0].prfSalt).toBe('s2==');
+  });
+
+  it('deleteByCredential removes only the matching row', async () => {
+    await repo.create(row({ id: 'wrap-1', credentialId: 'cred-A' }));
+    await repo.create(row({ id: 'wrap-2', credentialId: 'cred-B' }));
+    await repo.deleteByCredential('alice', 'cred-A');
+    const all = await repo.listByUser('alice');
+    expect(all).toHaveLength(1);
+    expect(all[0].credentialId).toBe('cred-B');
+  });
+});

--- a/lib/crypto/passkeyWrapRepository.ts
+++ b/lib/crypto/passkeyWrapRepository.ts
@@ -1,0 +1,43 @@
+import { and, eq } from 'drizzle-orm';
+import {
+  cryptoPasskeyWrap,
+  type CryptoPasskeyWrap,
+  type NewCryptoPasskeyWrap,
+} from '@/db/schema';
+import type { DbInstance } from '@/lib/db/connection';
+
+export class PasskeyWrapRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  async listByUser(userId: string): Promise<CryptoPasskeyWrap[]> {
+    return this.db
+      .select()
+      .from(cryptoPasskeyWrap)
+      .where(eq(cryptoPasskeyWrap.userId, userId));
+  }
+
+  /** Insert a wrap, or replace it if this (user, credential) already has one. */
+  async create(input: NewCryptoPasskeyWrap): Promise<void> {
+    await this.db
+      .insert(cryptoPasskeyWrap)
+      .values(input)
+      .onConflictDoUpdate({
+        target: [cryptoPasskeyWrap.userId, cryptoPasskeyWrap.credentialId],
+        set: { prfSalt: input.prfSalt, wrap: input.wrap, label: input.label },
+      });
+  }
+
+  async deleteByCredential(
+    userId: string,
+    credentialId: string
+  ): Promise<void> {
+    await this.db
+      .delete(cryptoPasskeyWrap)
+      .where(
+        and(
+          eq(cryptoPasskeyWrap.userId, userId),
+          eq(cryptoPasskeyWrap.credentialId, credentialId)
+        )
+      );
+  }
+}

--- a/lib/crypto/passkeyWrapSchema.ts
+++ b/lib/crypto/passkeyWrapSchema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+const b64 = z
+  .string()
+  .regex(/^[A-Za-z0-9+/]+={0,2}$/)
+  .min(1)
+  .max(512);
+
+// WebAuthn credential id: base64url charset.
+const b64url = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]+={0,2}$/)
+  .min(1)
+  .max(512);
+
+export const enablePasskeyUnlockSchema = z.object({
+  credentialId: b64url,
+  prfSalt: b64,
+  wrap: b64,
+  label: z.string().min(1).max(100),
+});
+
+export const disablePasskeyUnlockSchema = z.object({
+  credentialId: b64url,
+});

--- a/lib/crypto/passkeyWrapSchema.ts
+++ b/lib/crypto/passkeyWrapSchema.ts
@@ -6,7 +6,11 @@ const b64 = z
   .min(1)
   .max(512);
 
-// WebAuthn credential id: base64url charset.
+// WebAuthn credential id: base64url charset. This hard-asserts better-auth
+// hands back a base64url `credentialID`; a standard-base64 id (with `+`/`/`)
+// would fail closed here with a generic "Invalid request." See live-acceptance
+// item 5 (confirm the list-user-passkeys response shape) before assuming
+// otherwise — the client-side base64urlToBytes only translates `-_`.
 const b64url = z
   .string()
   .regex(/^[A-Za-z0-9_-]+={0,2}$/)

--- a/lib/crypto/setupSchema.ts
+++ b/lib/crypto/setupSchema.ts
@@ -22,10 +22,18 @@ export const setupCryptoSchema = z.object({
 });
 export type SetupCryptoInput = z.infer<typeof setupCryptoSchema>;
 
+export type PasskeyMaterial = {
+  credentialId: string;
+  prfSalt: string;
+  wrap: string;
+};
+
 // Wrapped key-material the server hands back to the client (GET /api/crypto/material).
-// Same opaque blobs as setup, minus the server-owned userId. Derived from the
-// schema so the route and its client consumer can't drift out of sync.
+// Opaque blobs only; the server never unwraps them. `passkeys` is the list of
+// enrolled passkey wraps (empty when none).
 export type CryptoMaterial = Pick<
   SetupCryptoInput,
   'passSalt' | 'argonParams' | 'wrapPassphrase' | 'wrapRecovery'
->;
+> & {
+  passkeys: PasskeyMaterial[];
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@base-ui/react": "^1.4.1",
     "@better-auth/passkey": "^1.6.10",
     "@heroicons/react": "^2.2.0",
-    "@naeemba/next-starter": "^0.8.0",
+    "@naeemba/next-starter": "^0.9.0",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.9",
     "adm-zip": "^0.5.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.6)
       '@naeemba/next-starter':
-        specifier: ^0.8.0
-        version: 0.8.0(kdfycvscpr5k77eefnlzn7k3am)
+        specifier: ^0.9.0
+        version: 0.9.0(kdfycvscpr5k77eefnlzn7k3am)
       '@react-email/components':
         specifier: ^1.0.12
         version: 1.0.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1420,8 +1420,8 @@ packages:
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
-  '@naeemba/next-starter@0.8.0':
-    resolution: {integrity: sha512-nDEywzJavoiHoiPVC6tpuknn317wzdc54rYCe15ovYohcRxsrL8H3jKZAJMleg7VMLBUgfTWmczAodoqBZzonw==}
+  '@naeemba/next-starter@0.9.0':
+    resolution: {integrity: sha512-C0xnIAJN2dG24v7kjDgVqx+x1VcBZ2n8sffSSsm/ZI0E+A65h6pa8bPyi3Y6c+q1I/AjeOQPsQ4HSoyr0J4oSg==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
@@ -7054,7 +7054,7 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@naeemba/next-starter@0.8.0(kdfycvscpr5k77eefnlzn7k3am)':
+  '@naeemba/next-starter@0.9.0(kdfycvscpr5k77eefnlzn7k3am)':
     dependencies:
       better-auth: 1.6.20(better-sqlite3@12.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(kysely@0.28.17)(postgres@3.4.9))(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
       drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.3)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(kysely@0.28.17)(postgres@3.4.9)


### PR DESCRIPTION
## Encrypted journals — passkey (PRF) unlock

Adds a third way to unlock the zero-knowledge encrypted journal: the user's **passkey**, alongside the existing passphrase and one-time recovery code. Purely additive — the DEK never changes; passphrase/recovery wraps are untouched. Multiple passkeys are supported (each carries its own wrap).

Spec: `docs/superpowers/specs/2026-06-25-encrypted-journals-passkey-unlock-design.md`
Plan: `docs/superpowers/plans/2026-06-25-encrypted-journals-passkey-unlock.md`

### How it works
A passkey carries an additional opaque wrap of the per-user DEK, derived from the authenticator's **WebAuthn PRF** output: `PRF → HKDF-SHA256(info "ledger-passkey-v1") → AES-GCM-256 KEK`. PRF-based unlock needs **no server-side assertion verification** — the assertion uses a random challenge and the DEK either unwraps client-side or it doesn't (same model as the passphrase path). Reuses the existing login passkeys via the PRF extension.

### What's included
- `cryptoPasskeyWrap` one-to-many table + migration `0005`; `PasskeyWrapRepository`.
- `derivePrfKek` + WebAuthn PRF assertion helpers (`assertPrfForCredential`, `assertPrfAny`).
- `CryptoMaterial` extended with `passkeys[]`; `/api/crypto/material` projects only `{credentialId, prfSalt, wrap}`.
- `enablePasskeyUnlock` / `disablePasskeyUnlock` server actions.
- Client flows `buildPasskeyWrap` (proof-before-mutation) + `unlockWithPasskey`.
- Settings → Security **Passkey unlock** card; **Unlock with passkey** button on `/crypto/unlock`.
- Enables the PRF extension at passkey registration (requires `@naeemba/next-starter` ≥ 0.9.0, bumped here).

### Invariants (verified end-to-end in final review)
- **Zero-knowledge** — server stores/returns only opaque wraps+salts; no DEK/PRF logged; material projection strips `id`/`userId`/`label`/`createdAt` (test-asserted).
- **DEK never changes** — enable/disable only add/remove a wrap; unlock recovers the same DEK (round-trip test).
- **Proof-before-mutation** — enabling requires the passphrase/recovery secret client-side (`obtainDek`); the typed secret never reaches a server action.
- **No last-method guard needed** — passphrase + recovery always remain.

### Tests
571 passing (114 files), type-check + lint clean. Final whole-branch review (opus): **0 Critical / 0 Important.**

### ⚠️ Live acceptance (merge gate — needs Postgres + Garage + a PRF-capable authenticator)
Folds into the encrypted-journals e2e already owed for P2/P3.
- [ ] A newly-registered passkey returns a PRF result on assertion (confirms starter 0.9.0 forwards `registration.extensions`).
- [ ] Settings → Security → Enable unlock (prove with passphrase). Lock. Unlock via Touch ID/PIN → journal decrypts.
- [ ] Second passkey on another device; both unlock independently.
- [ ] Disable one passkey → it no longer unlocks; the other still does; passphrase + recovery still work.
- [ ] Confirm the `/api/auth/passkey/list-user-passkeys` response shape matches the Settings card's parsing.

### Deferred follow-ups (non-blocking)
- Optional setup-wizard passkey step (enable from day one) — intentionally deferred; modifies the wizard state machine, best tested live.
- Cosmetic: migration trailing newline; unlock error preserving root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
