### PR TITLE
feat(crypto): wizard recovery-gate hardening + inline passkey step

### DIFF
--- a/docs/superpowers/plans/2026-06-26-wizard-recovery-gate-and-passkey-step.md
+++ b/docs/superpowers/plans/2026-06-26-wizard-recovery-gate-and-passkey-step.md
@@ -1,0 +1,768 @@
+# Wizard recovery-gate hardening + inline passkey step — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Force recovery-code saving in the encryption wizard, and add an optional wizard step that registers/enrolls a passkey for unlock inline.
+
+**Architecture:** Two new client helpers in `features/crypto/lib/passkeyFlow.ts` (`registerPasskey`, `enrollPasskeyForUnlock`) carry the logic and get full unit tests. A new `PasskeyStep` component (its own file, au-* styled) consumes them and is wired into `SetupWizard.tsx` as a new step between `recovery` and `encrypting`; the `postDek`+`finalizeEncryption` call moves from the recovery handler to the new passkey handler. The recovery gate is hardened in place. Passkey enrollment is additive — the DEK never changes — and the step is always skippable.
+
+**Tech Stack:** Next.js 16, React client components, TypeScript, Vitest (`environment: 'node'`, `renderToStaticMarkup` for component tests), better-auth passkey client (`authClient.passkey.addPasskey`), WebAuthn PRF + AES-GCM (existing `clientCrypto`/`webauthn` libs).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-26-wizard-recovery-gate-and-passkey-step-design.md`.
+- **DEK never changes:** passkey enrollment is an additional wrap of the same DEK; do not regenerate or re-wrap the DEK, do not re-encrypt the journal.
+- **Passkey step is optional:** the user can always Skip; never block onboarding on it.
+- **Enroll requires only the userCrypto row + auth, not an unlocked session** — `enablePasskeyUnlockAction` checks `getUserCryptoRepository().exists(user.id)` (`features/crypto/actions/enablePasskeyUnlock.ts:22-23`). The row exists from the passphrase step's `runSetup`. So enrollment happens *before* `postDek`/finalize.
+- **PRF at registration is server-configured:** `lib/auth.ts` sets `passkey.registration.extensions.prf = {}` (needs `@naeemba/next-starter` `^0.9.0`, already installed). Any passkey created via `addPasskey` is therefore PRF-capable. Do NOT pass PRF extensions from the client `addPasskey` call.
+- **Styling:** wizard components use the `au-*` editorial classes (`au-card`, `au-btn`, `au-btn--primary`, `au-btn--ghost`, `au-error`) from `features/auth/auth.css` — NOT shadcn. Match the existing steps in `SetupWizard.tsx`.
+- **Copy lives in `features/crypto/cryptoCopy.ts`** — no inline user-facing strings in components.
+- **Gate every task** with: `pnpm type-check`, `pnpm lint`, `pnpm test` (all must pass). The pre-commit husky hook runs type-check + lint-staged; commits fail if type-check fails.
+
+---
+
+### Task 1: Harden the recovery-code gate
+
+Require the user to click **Copy** or **Download** at least once *and* tick the checkbox before "Enable encryption" is enabled. Interactive gating is verified manually (the component imports server actions, so it is not import-testable; this matches the repo's approach — only leaf components like `features/auth/BrandPanel.tsx` get `renderToStaticMarkup` tests).
+
+**Files:**
+- Modify: `features/crypto/cryptoCopy.ts` (add `recovery.saveFirstHint`)
+- Modify: `features/crypto/SetupWizard.tsx` (the `RecoveryStep` function, ~lines 460-590)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing other tasks rely on (self-contained UI change).
+
+- [ ] **Step 1: Add the hint copy string**
+
+In `features/crypto/cryptoCopy.ts`, inside the `recovery: { … }` block, add `saveFirstHint` (place it after `confirmPrompt`):
+
+```ts
+  recovery: {
+    heading: 'Save your recovery code',
+    label: 'Recovery code',
+    warning:
+      'This code is shown once. Write it down or store it in a password manager — you cannot retrieve it later.',
+    instruction:
+      'If you forget your passphrase, this code is the only way to regain access to your journal.',
+    copyLabel: 'Copy code',
+    copiedLabel: 'Copied!',
+    confirmPrompt: 'I have saved my recovery code',
+    saveFirstHint: 'Copy or download your code first.',
+    submitLabel: 'Enable encryption',
+  },
+```
+
+- [ ] **Step 2: Add the `interacted` state and set it on copy/download**
+
+In `features/crypto/SetupWizard.tsx`, in `RecoveryStep`, add the state next to the existing `copied`/`saved` state (~line 462):
+
+```tsx
+  const [copied, setCopied] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [interacted, setInteracted] = useState(false);
+```
+
+Set `interacted` at the start of `handleCopy` and `handleDownload` (a click counts even if the clipboard API fails — the code is visible on screen). In `handleCopy`, add `setInteracted(true);` as the first line of the function body; in `handleDownload`, add `setInteracted(true);` as the first line:
+
+```tsx
+  async function handleCopy() {
+    setInteracted(true);
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      if (copyTimeout.current) clearTimeout(copyTimeout.current);
+      copyTimeout.current = setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // ignore clipboard errors — user can still copy manually
+    }
+  }
+
+  function handleDownload() {
+    setInteracted(true);
+    const blob = new Blob(
+```
+
+- [ ] **Step 3: Disable the checkbox until interacted, the button until interacted+saved, and show the hint**
+
+In the `RecoveryStep` JSX, update the checkbox `<input>` to add `disabled={!interacted}` (~line 568):
+
+```tsx
+        <input
+          type="checkbox"
+          checked={saved}
+          disabled={!interacted}
+          onChange={(e) => setSaved(e.target.checked)}
+          className="mt-0.5 size-4 cursor-pointer accent-[var(--em)] disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={copy.confirmPrompt}
+        />
+```
+
+Add the hint immediately *after* the Copy/Download button group `</div>` (the `<div className="flex gap-2">…</div>` block ends ~line 559) and before the `<p>{copy.instruction}</p>`:
+
+```tsx
+        {!interacted && (
+          <p className="text-xs text-[color:var(--txt-faint)] text-center">
+            {copy.saveFirstHint}
+          </p>
+        )}
+```
+
+Update the "Enable encryption" button's `disabled` (~line 583) from `disabled={!saved}` to:
+
+```tsx
+      <button
+        type="button"
+        className="au-btn au-btn--primary"
+        disabled={!interacted || !saved}
+        onClick={onNext}
+      >
+        {copy.submitLabel}
+      </button>
+```
+
+- [ ] **Step 4: Verify type-check and lint pass**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: both exit 0, no errors.
+
+- [ ] **Step 5: Manual verification (needs a logged-in session at `/crypto/setup`)**
+
+Run the app (`pnpm dev`), sign in as a fresh user, start encryption setup, reach the recovery step. Confirm:
+- The "I have saved my recovery code" checkbox is **disabled** and the hint "Copy or download your code first." is shown on arrival.
+- After clicking **Copy** (or **Download**), the hint disappears and the checkbox becomes tickable.
+- "Enable encryption" stays disabled until the box is both interactable and ticked.
+
+(If no Postgres/Garage dev env is available, defer this to the live-acceptance pass and note it; the automated gate in Step 4 still applies.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/crypto/cryptoCopy.ts features/crypto/SetupWizard.tsx
+git commit -m "feat(crypto): require copy/download before confirming recovery code"
+```
+
+---
+
+### Task 2: `registerPasskey` helper
+
+Register a new PRF-capable passkey via better-auth and resolve its `credentialId`.
+
+**Files:**
+- Modify: `features/crypto/lib/passkeyFlow.ts`
+- Test: `features/crypto/lib/passkeyFlow.test.ts`
+
+**Interfaces:**
+- Consumes: `authClient` from `@/lib/auth-client` (`authClient.passkey.addPasskey({ name }) → Promise<{ data: Passkey | null; error: {...} | null; … }>`, where `Passkey.credentialID: string`).
+- Produces: `registerPasskey(name: string): Promise<{ credentialId: string }>` — used by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `features/crypto/lib/passkeyFlow.test.ts`. At the top, add the auth-client mock alongside the existing `vi.mock` calls, and import the new function + `authClient`:
+
+```ts
+import { authClient } from '@/lib/auth-client';
+import { buildPasskeyWrap, unlockWithPasskey, registerPasskey } from './passkeyFlow';
+// …existing imports…
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: { passkey: { addPasskey: vi.fn() } },
+}));
+```
+
+Add the describe block:
+
+```ts
+describe('registerPasskey', () => {
+  it('returns the new credentialId on success', async () => {
+    (
+      authClient.passkey.addPasskey as MockedFunction<
+        typeof authClient.passkey.addPasskey
+      >
+    ).mockResolvedValue({ data: { credentialID: 'cred-new' }, error: null } as never);
+    const out = await registerPasskey('This device');
+    expect(out.credentialId).toBe('cred-new');
+    expect(authClient.passkey.addPasskey).toHaveBeenCalledWith({
+      name: 'This device',
+    });
+  });
+
+  it('throws with the server message when registration errors', async () => {
+    (
+      authClient.passkey.addPasskey as MockedFunction<
+        typeof authClient.passkey.addPasskey
+      >
+    ).mockResolvedValue({ data: null, error: { message: 'denied' } } as never);
+    await expect(registerPasskey('x')).rejects.toThrow('denied');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test -- features/crypto/lib/passkeyFlow.test.ts`
+Expected: FAIL — `registerPasskey is not a function` (or import error).
+
+- [ ] **Step 3: Implement `registerPasskey`**
+
+In `features/crypto/lib/passkeyFlow.ts`, add the import and the function:
+
+```ts
+import { authClient } from '@/lib/auth-client';
+```
+
+```ts
+/**
+ * Register a new passkey via better-auth and resolve its credentialId. PRF is
+ * requested at registration by the server config (lib/auth.ts:
+ * passkey.registration.extensions.prf = {}), so the created credential supports
+ * PRF — no client-side extension needed here. Throws if the user cancels or the
+ * server rejects.
+ */
+export const registerPasskey = async (
+  name: string
+): Promise<{ credentialId: string }> => {
+  const res = await authClient.passkey.addPasskey({ name });
+  if (!res || res.error || !res.data) {
+    throw new Error(res?.error?.message ?? 'Could not create a passkey.');
+  }
+  return { credentialId: res.data.credentialID };
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test -- features/crypto/lib/passkeyFlow.test.ts`
+Expected: PASS (both new cases + existing `buildPasskeyWrap`/`unlockWithPasskey` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/crypto/lib/passkeyFlow.ts features/crypto/lib/passkeyFlow.test.ts
+git commit -m "feat(crypto): registerPasskey helper for inline passkey creation"
+```
+
+---
+
+### Task 3: `enrollPasskeyForUnlock` helper
+
+Wrap the DEK for a given passkey and persist the wrap — `buildPasskeyWrap` + `enablePasskeyUnlockAction` in one call.
+
+**Files:**
+- Modify: `features/crypto/lib/passkeyFlow.ts`
+- Test: `features/crypto/lib/passkeyFlow.test.ts`
+
+**Interfaces:**
+- Consumes: existing `buildPasskeyWrap(dek, credentialId, label)`; `enablePasskeyUnlockAction(input) → Promise<{ ok: true } | { ok: false; message: string }>` from `@/features/crypto/actions/enablePasskeyUnlock`.
+- Produces: `enrollPasskeyForUnlock(dek: Uint8Array, credentialId: string, label: string): Promise<void>` — used by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `features/crypto/lib/passkeyFlow.test.ts`. Add the action mock and import:
+
+```ts
+import { enablePasskeyUnlockAction } from '@/features/crypto/actions/enablePasskeyUnlock';
+import { buildPasskeyWrap, unlockWithPasskey, registerPasskey, enrollPasskeyForUnlock } from './passkeyFlow';
+
+vi.mock('@/features/crypto/actions/enablePasskeyUnlock');
+```
+
+Add the describe block (`assertPrfForCredential` is already mocked via the existing `vi.mock('./webauthn')`; `wrapDek`/`derivePrfKek` run for real, as in the `buildPasskeyWrap` test):
+
+```ts
+describe('enrollPasskeyForUnlock', () => {
+  it('builds a wrap and enables it', async () => {
+    (
+      assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
+    ).mockResolvedValue({ credentialId: 'cred-A', prfOutput: new Uint8Array(32).fill(7) });
+    (
+      enablePasskeyUnlockAction as MockedFunction<typeof enablePasskeyUnlockAction>
+    ).mockResolvedValue({ ok: true });
+
+    await enrollPasskeyForUnlock(generateDek(), 'cred-A', 'Laptop');
+
+    expect(enablePasskeyUnlockAction).toHaveBeenCalledTimes(1);
+    const arg = (
+      enablePasskeyUnlockAction as MockedFunction<typeof enablePasskeyUnlockAction>
+    ).mock.calls[0][0] as { credentialId: string; label: string };
+    expect(arg.credentialId).toBe('cred-A');
+    expect(arg.label).toBe('Laptop');
+  });
+
+  it('throws with the action message when enabling fails', async () => {
+    (
+      assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
+    ).mockResolvedValue({ credentialId: 'cred-A', prfOutput: new Uint8Array(32).fill(7) });
+    (
+      enablePasskeyUnlockAction as MockedFunction<typeof enablePasskeyUnlockAction>
+    ).mockResolvedValue({ ok: false, message: 'rate limited' });
+
+    await expect(
+      enrollPasskeyForUnlock(generateDek(), 'cred-A', 'L')
+    ).rejects.toThrow('rate limited');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test -- features/crypto/lib/passkeyFlow.test.ts`
+Expected: FAIL — `enrollPasskeyForUnlock is not a function`.
+
+- [ ] **Step 3: Implement `enrollPasskeyForUnlock`**
+
+In `features/crypto/lib/passkeyFlow.ts`, add the import and function:
+
+```ts
+import { enablePasskeyUnlockAction } from '@/features/crypto/actions/enablePasskeyUnlock';
+```
+
+```ts
+/**
+ * Enroll a passkey for unlock: wrap the DEK with the passkey's PRF-derived KEK
+ * and persist the wrap. The caller already holds the DEK (wizard: in-memory;
+ * settings: obtained via an authorizer). Throws if the PRF assertion or the
+ * server action fails.
+ */
+export const enrollPasskeyForUnlock = async (
+  dek: Uint8Array,
+  credentialId: string,
+  label: string
+): Promise<void> => {
+  const input = await buildPasskeyWrap(dek, credentialId, label);
+  const res = await enablePasskeyUnlockAction(input);
+  if (!res.ok) throw new Error(res.message);
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test -- features/crypto/lib/passkeyFlow.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/crypto/lib/passkeyFlow.ts features/crypto/lib/passkeyFlow.test.ts
+git commit -m "feat(crypto): enrollPasskeyForUnlock helper (wrap DEK + persist)"
+```
+
+---
+
+### Task 4: Passkey wizard step + flow rewiring
+
+Add the `passkey` step component and insert it into the wizard between `recovery` and `encrypting`, moving the finalize call to the new step.
+
+**Files:**
+- Modify: `features/crypto/cryptoCopy.ts` (add the `passkey` copy block)
+- Create: `features/crypto/PasskeyStep.tsx`
+- Create: `features/crypto/PasskeyStep.test.tsx`
+- Modify: `features/crypto/SetupWizard.tsx` (Step type/labels/order; `handleRecoveryNext`; new `handlePasskeyNext`; render branch; brand-panel tick)
+
+**Interfaces:**
+- Consumes: `registerPasskey` (Task 2), `enrollPasskeyForUnlock` (Task 3), `CRYPTO_COPY.passkey`.
+- Produces: `PasskeyStep({ dek: Uint8Array; onNext: () => void })` (named export) — consumed by `SetupWizard`.
+
+- [ ] **Step 1: Add the passkey copy block**
+
+In `features/crypto/cryptoCopy.ts`, add a `passkey` block after the `recovery` block:
+
+```ts
+  // ── Passkey step (optional) ─────────────────────────────────────────────────
+  passkey: {
+    heading: 'Add a passkey',
+    body: 'Optionally let this device unlock your journal with a passkey, alongside your passphrase and recovery code. You can add more later in Settings.',
+    twiceNote:
+      "You'll be asked to confirm twice — once to create the passkey, once to link it.",
+    addLabel: 'Add this device',
+    addingLabel: 'Adding…',
+    enableLabel: 'Enable unlock',
+    enablingLabel: 'Enabling…',
+    enrolledLabel: 'Enabled',
+    skipLabel: 'Skip for now',
+    continueLabel: 'Continue',
+    errors: {
+      registerFailed: 'Could not create a passkey. Please try again.',
+      enrollFailed: 'Could not link the passkey. Please try again.',
+    },
+  },
+```
+
+- [ ] **Step 2: Write the failing component test**
+
+Create `features/crypto/PasskeyStep.test.tsx`:
+
+```tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the flow module so the test never pulls in the server action transitively.
+vi.mock('./lib/passkeyFlow', () => ({
+  registerPasskey: vi.fn(),
+  enrollPasskeyForUnlock: vi.fn(),
+}));
+
+import { PasskeyStep } from './PasskeyStep';
+
+describe('PasskeyStep', () => {
+  it('renders the add-device and skip controls', () => {
+    const out = renderToStaticMarkup(
+      <PasskeyStep dek={new Uint8Array(32)} onNext={() => {}} />
+    );
+    expect(out).toContain('Add this device');
+    expect(out).toContain('Skip for now');
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm test -- features/crypto/PasskeyStep.test.tsx`
+Expected: FAIL — cannot find module `./PasskeyStep`.
+
+- [ ] **Step 4: Implement `PasskeyStep`**
+
+Create `features/crypto/PasskeyStep.tsx`:
+
+```tsx
+'use client';
+
+import { CheckCircle2, KeyRound, Loader2, Plus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CRYPTO_COPY } from './cryptoCopy';
+import { enrollPasskeyForUnlock, registerPasskey } from './lib/passkeyFlow';
+
+type Row = { credentialId: string; name: string; enabled: boolean };
+
+const ADD = '__add__';
+
+async function fetchPasskeys(): Promise<
+  { credentialID: string; name?: string }[]
+> {
+  try {
+    const res = await fetch('/api/auth/passkey/list-user-passkeys', {
+      method: 'GET',
+      credentials: 'include',
+    });
+    if (!res.ok) return [];
+    return (await res.json()) as { credentialID: string; name?: string }[];
+  } catch {
+    return [];
+  }
+}
+
+export function PasskeyStep({
+  dek,
+  onNext,
+}: {
+  dek: Uint8Array;
+  onNext: () => void;
+}) {
+  const copy = CRYPTO_COPY.passkey;
+  const [rows, setRows] = useState<Row[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [enrolledCount, setEnrolledCount] = useState(0);
+
+  useEffect(() => {
+    void (async () => {
+      const passkeys = await fetchPasskeys();
+      setRows(
+        passkeys.map((p) => ({
+          credentialId: p.credentialID,
+          name: p.name ?? 'Passkey',
+          enabled: false,
+        }))
+      );
+    })();
+  }, []);
+
+  async function handleAdd() {
+    setError(null);
+    setBusy(ADD);
+    try {
+      const { credentialId } = await registerPasskey('This device');
+      await enrollPasskeyForUnlock(dek, credentialId, 'This device');
+      setRows((r) => [
+        ...r.filter((x) => x.credentialId !== credentialId),
+        { credentialId, name: 'This device', enabled: true },
+      ]);
+      setEnrolledCount((c) => c + 1);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : copy.errors.registerFailed
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleEnable(row: Row) {
+    setError(null);
+    setBusy(row.credentialId);
+    try {
+      await enrollPasskeyForUnlock(dek, row.credentialId, row.name);
+      setRows((r) =>
+        r.map((x) =>
+          x.credentialId === row.credentialId ? { ...x, enabled: true } : x
+        )
+      );
+      setEnrolledCount((c) => c + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : copy.errors.enrollFailed);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const unenrolled = rows.filter((r) => !r.enabled);
+  const enrolled = rows.filter((r) => r.enabled);
+
+  return (
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)] leading-relaxed">
+          {copy.body}
+        </p>
+      </div>
+
+      <div className="au-card p-5 flex flex-col gap-3">
+        <button
+          type="button"
+          className="au-btn au-btn--ghost"
+          onClick={handleAdd}
+          disabled={busy !== null}
+        >
+          {busy === ADD ? (
+            <>
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              {copy.addingLabel}
+            </>
+          ) : (
+            <>
+              <Plus className="size-4" aria-hidden />
+              {copy.addLabel}
+            </>
+          )}
+        </button>
+
+        {unenrolled.map((row) => (
+          <div
+            key={row.credentialId}
+            className="flex items-center justify-between gap-3 rounded-md border border-[var(--line)] p-3"
+          >
+            <span className="flex items-center gap-2 text-sm text-[color:var(--txt-dim)]">
+              <KeyRound className="size-4" aria-hidden />
+              {row.name}
+            </span>
+            <button
+              type="button"
+              className="au-btn au-btn--ghost"
+              style={{ height: '2.25rem', fontSize: '0.8rem' }}
+              onClick={() => handleEnable(row)}
+              disabled={busy !== null}
+            >
+              {busy === row.credentialId ? copy.enablingLabel : copy.enableLabel}
+            </button>
+          </div>
+        ))}
+
+        {enrolled.map((row) => (
+          <div
+            key={row.credentialId}
+            className="flex items-center justify-between gap-3 rounded-md border border-[var(--line)] p-3"
+          >
+            <span className="flex items-center gap-2 text-sm text-[color:var(--txt-dim)]">
+              <KeyRound className="size-4" aria-hidden />
+              {row.name}
+            </span>
+            <span
+              className="flex items-center gap-1.5 text-xs ff-mono"
+              style={{ color: 'var(--em)' }}
+            >
+              <CheckCircle2 className="size-3.5" aria-hidden />
+              {copy.enrolledLabel}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-[color:var(--txt-faint)] leading-relaxed">
+        {copy.twiceNote}
+      </p>
+
+      <button
+        type="button"
+        className="au-btn au-btn--primary"
+        onClick={onNext}
+        disabled={busy !== null}
+      >
+        {enrolledCount > 0 ? copy.continueLabel : copy.skipLabel}
+      </button>
+
+      <p className="au-error" aria-live="polite" aria-atomic="true">
+        {error ?? ''}
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run the component test to verify it passes**
+
+Run: `pnpm test -- features/crypto/PasskeyStep.test.tsx`
+Expected: PASS (`renderToStaticMarkup` does not run the `useEffect`, so no fetch fires; the add + skip controls render).
+
+- [ ] **Step 6: Wire the step into `SetupWizard.tsx` — type, labels, order**
+
+In `features/crypto/SetupWizard.tsx`:
+
+Update the `Step` type (~line 69):
+
+```tsx
+type Step = 'why' | 'passphrase' | 'recovery' | 'passkey' | 'encrypting';
+```
+
+Update `STEP_LABELS` (~line 174) to add `passkey`:
+
+```tsx
+const STEP_LABELS: Record<Step, string> = {
+  why: 'Why',
+  passphrase: 'Passphrase',
+  recovery: 'Recovery code',
+  passkey: 'Passkey',
+  encrypting: 'Encrypting',
+};
+const STEP_ORDER: Step[] = [
+  'why',
+  'passphrase',
+  'recovery',
+  'passkey',
+  'encrypting',
+];
+```
+
+Add the import near the other feature imports (~line 13):
+
+```tsx
+import { PasskeyStep } from '@/features/crypto/PasskeyStep';
+```
+
+- [ ] **Step 7: Move finalize from `handleRecoveryNext` to a new `handlePasskeyNext`**
+
+In `features/crypto/SetupWizard.tsx`, replace the body of `handleRecoveryNext` (~lines 697-722) so it only advances to the passkey step, and add `handlePasskeyNext` with the finalize logic that used to live there:
+
+```tsx
+  // Advance from recovery → passkey. The DEK is already in dekRef and the
+  // userCrypto row already exists, so the optional passkey step can enroll
+  // before the session is unlocked at finalize.
+  function handleRecoveryNext() {
+    if (!dekRef.current) {
+      // Lost the in-memory DEK (e.g. a reload) — the row already exists, so
+      // route through the normal unlock flow instead.
+      window.location.assign('/crypto/unlock');
+      return;
+    }
+    setStep('passkey');
+  }
+
+  // Advance from passkey → encrypting: unlock the session, then finalize.
+  // Both "Skip" and "Continue" call this; enrolling a passkey is additive and
+  // already complete by this point. Idempotent and safe to re-run on "Retry".
+  async function handlePasskeyNext() {
+    const dek = dekRef.current;
+    if (!dek) {
+      window.location.assign('/crypto/unlock');
+      return;
+    }
+    setStep('encrypting');
+    try {
+      await postDek(dek); // unlock this session so migration can run
+      const result = await finalizeEncryption();
+      if (!result.ok) {
+        setFatalRetryStep('passkey');
+        setFatalError(result.error ?? CRYPTO_COPY.errors.setupFailed);
+        return;
+      }
+      // Hard navigate so the session gate sees `ready`.
+      window.location.assign('/dashboard');
+    } catch (err) {
+      setFatalRetryStep('passkey');
+      setFatalError(
+        err instanceof Error ? err.message : CRYPTO_COPY.errors.generic
+      );
+    }
+  }
+```
+
+Note: `handleRecoveryNext` is no longer `async`. Its `onNext` prop on `RecoveryStep` is typed `() => void`, so this is compatible.
+
+- [ ] **Step 8: Render the passkey step in the wizard branch**
+
+In the render branch (~lines 783-791), insert the `passkey` case between `recovery` and `encrypting`:
+
+```tsx
+              ) : step === 'recovery' && recoveryCode ? (
+                <RecoveryStep code={recoveryCode} onNext={handleRecoveryNext} />
+              ) : step === 'passkey' && dekRef.current ? (
+                <PasskeyStep dek={dekRef.current} onNext={handlePasskeyNext} />
+              ) : step === 'encrypting' ? (
+                <EncryptingStep />
+              ) : null}
+```
+
+- [ ] **Step 9: Update the brand-panel feature tick**
+
+In `SetupBrandPanel` (~line 159), change the third feature tick to mention passkeys:
+
+```tsx
+            'Client-side key generation',
+            'Zero-knowledge server',
+            'Passphrase, recovery code & passkey',
+```
+
+- [ ] **Step 10: Verify the full automated gate**
+
+Run: `pnpm type-check && pnpm lint && pnpm test`
+Expected: all pass. (Type-check confirms the `Step` union, the non-async `handleRecoveryNext`, and the `PasskeyStep` props all line up.)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add features/crypto/cryptoCopy.ts features/crypto/PasskeyStep.tsx features/crypto/PasskeyStep.test.tsx features/crypto/SetupWizard.tsx
+git commit -m "feat(crypto): inline passkey step in the encryption setup wizard"
+```
+
+- [ ] **Step 12: Live manual acceptance (needs a real Postgres + Garage dev env)**
+
+These confirm the WebAuthn/PRF path end-to-end and cannot run in CI. Defer to the project's live-acceptance pass if no dev env is available, and record the result:
+
+1. Fresh magic-link user → wizard → after the recovery step, the **Passkey** step appears.
+2. **Add this device** → Touch ID prompt (create), then a second prompt (PRF assert) → row shows **Enabled**; the "twice" note matches the real prompt count.
+3. **Continue** → encrypting → dashboard; journal is ciphertext (`LEJ1`) at rest in Garage.
+4. Lock, then unlock with the new passkey (Touch ID) → journal decrypts.
+5. **Skip for now** path: onboarding still completes with passphrase + recovery only.
+6. Existing-passkey user: the step lists the passkey with **Enable unlock**; enabling works.
+7. A device/browser without PRF: **Add this device** surfaces a clear inline error and **Skip** still completes setup.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Recovery-gate hardening (copy/download + checkbox) → Task 1. ✓
+- New `'passkey'` step + flow rewiring (`handleRecoveryNext`/`handlePasskeyNext`) → Task 4 (Steps 6-8). ✓
+- `registerPasskey` / `enrollPasskeyForUnlock` helpers → Tasks 2, 3. ✓
+- Register-new-inline + enroll-existing in the component → Task 4 `PasskeyStep` (`handleAdd` / `handleEnable`). ✓
+- Reload guard routing to `/crypto/unlock` → Task 4 Step 7 (both handlers). ✓
+- Copy additions (recovery hint + passkey block + brand tick) → Tasks 1, 4. ✓
+- Edge cases (no PRF, dismiss, two prompts, register-ok/enroll-fail, rate limit) → handled by helper throws surfaced inline in `PasskeyStep`; verified in Task 4 Step 12. ✓
+- Tests for the two helpers → Tasks 2, 3; light static test for the component → Task 4 Step 2. ✓
+
+**Placeholder scan:** No TBD/TODO; all code blocks are complete; manual steps have explicit instructions and an env caveat.
+
+**Type consistency:** `registerPasskey → { credentialId }`, `enrollPasskeyForUnlock(dek, credentialId, label) → void`, `PasskeyStep({ dek, onNext })`, `Step` union includes `'passkey'`, `STEP_LABELS`/`STEP_ORDER` both updated, `handleRecoveryNext` made non-async (matches `RecoveryStep` `onNext: () => Promise<void>`? — `RecoveryStep`'s `onNext` is `() => void`; a non-async void function satisfies it). `Passkey.credentialID` (better-auth) maps to our `credentialId`. Consistent.
+```

--- a/docs/superpowers/specs/2026-06-26-wizard-recovery-gate-and-passkey-step-design.md
+++ b/docs/superpowers/specs/2026-06-26-wizard-recovery-gate-and-passkey-step-design.md
@@ -1,0 +1,215 @@
+# Encryption wizard: recovery-gate hardening + inline passkey step
+
+Date: 2026-06-26
+Status: Approved (design)
+Area: `features/crypto` (encryption onboarding wizard)
+
+## Background
+
+The encryption onboarding wizard (`app/crypto/setup` → `features/crypto/SetupWizard.tsx`)
+walks a new user through enabling zero-knowledge encrypted journals. Today it has
+four steps: **why → passphrase → recovery → encrypting**.
+
+Two gaps motivate this work, both rooted in the same risk: a user can lose access
+to their journal forever if they lose *all* unlock methods at once (passphrase +
+recovery code, with no passkey). The encryption is zero-knowledge by design — the
+server holds only opaque wrapped keys, so there is no operator backdoor. The only
+defences are (a) making sure the recovery code is genuinely saved, and (b) making
+a second convenient unlock method (passkey) easy to add during onboarding.
+
+1. **The recovery-code gate is too soft.** `RecoveryStep` shows the one-time code
+   with Copy/Download buttons and a checkbox "I have saved my recovery code" that
+   disables Continue until ticked (`SetupWizard.tsx:567-588`). But the box can be
+   ticked without ever copying or downloading anything.
+2. **Passkey enrollment lives only in Settings, after the fact.** Passkey-PRF
+   unlock shipped (PR #31) but is enrollable only via Settings → Security
+   (`features/settings/PasskeyUnlockCard.tsx`), which enrolls *existing* passkeys
+   and points users to `/settings/passkeys` to add one. A brand-new user who
+   signed up via magic-link has no passkey at all, so they finish onboarding with
+   exactly one fallback (the recovery code) unless they later hunt through
+   Settings. The wizard's deferred "Task 11" passkey step closes this.
+
+## Goals
+
+- Force the user to interact with their recovery code (copy or download) before
+  they can confirm they saved it.
+- Add an optional passkey step to the wizard that works for **every** user,
+  including those with no passkey yet — registering one inline if needed.
+- Keep the change additive: the DEK never changes, the recovery code remains the
+  mandatory fallback, and the passkey step is always skippable.
+
+## Non-goals
+
+- Re-encrypting the journal or rotating the DEK (passkey enrollment is an extra
+  wrap of the same DEK).
+- Adding inline passkey *registration* to the Settings card (it can adopt the new
+  shared helper later; out of scope here).
+- Server-side WebAuthn assertion verification (unchanged: PRF unwraps client-side
+  or it does not).
+
+## Decisions (locked during brainstorming, 2026-06-26)
+
+- **Recovery gate strength:** require the user to click **Copy** or **Download**
+  at least once *and* tick the checkbox. (Chosen over re-typing the code, which
+  risks frustrating users who saved it to a password manager.)
+- **Passkey step behaviour:** register a new passkey inline when the user has
+  none, *and* offer to enroll any existing passkeys. (Chosen over enrolling only
+  existing passkeys, which would be a no-op for most new — magic-link — users.)
+
+## Design
+
+### Part 1 — Recovery-gate hardening
+
+Entirely within `RecoveryStep` in `SetupWizard.tsx`:
+
+- Add an `interacted` state flag, set to `true` inside both `handleCopy` and
+  `handleDownload` (on success; copy still tolerates clipboard failure but a
+  click still counts as interaction — the user can read/transcribe the visible
+  code).
+- The "I have saved my recovery code" checkbox gains `disabled={!interacted}`.
+  The user must copy or download before they can even tick it.
+- "Enable encryption" remains `disabled` until `interacted && saved`.
+- When `!interacted`, show a hint line beneath the Copy/Download buttons:
+  *"Copy or download your code first."* New string `cryptoCopy.recovery.saveFirstHint`.
+
+No new files, no logic outside this component. No change to the recovery code
+generation or the `runSetup` flow.
+
+### Part 2 — Inline passkey step
+
+#### Flow change (`SetupWizard` root)
+
+Insert a new `'passkey'` step between `recovery` and `encrypting`:
+
+```
+Step type:   'why' | 'passphrase' | 'recovery' | 'passkey' | 'encrypting'
+STEP_ORDER:  why → passphrase → recovery → passkey → encrypting
+STEP_LABELS: …, passkey: 'Passkey', …
+```
+
+- `handleRecoveryNext` no longer unlocks/finalizes. It just advances:
+  `setStep('passkey')`. (The DEK is already in `dekRef.current` and the
+  `userCrypto` row already exists from the passphrase step's `runSetup`.)
+- New `handlePasskeyNext` performs what `handleRecoveryNext` used to do —
+  `postDek(dek)` then `finalizeEncryption()` then `window.location.assign('/dashboard')`,
+  with the same fatal-error/retry handling (`fatalRetryStep` becomes `'passkey'`).
+  Both **Skip for now** and **Continue** invoke it; enrolling a passkey is purely
+  additive and complete before this point.
+- The reload guard is preserved: if `dekRef.current` is null when
+  `handlePasskeyNext` runs, route to `/crypto/unlock` (the row exists; unlock
+  reconciles migration). Passkeys can still be added later in Settings.
+
+Ordering rationale: `enablePasskeyUnlockAction` requires only
+`getUserCryptoRepository().exists(user.id)` and an authenticated user — **not** an
+unlocked session (`enablePasskeyUnlock.ts:22-23`). So the passkey step can enroll
+before the session is unlocked at finalize.
+
+#### New component `PasskeyStep` (au-* styled, in `SetupWizard.tsx`)
+
+Props: `{ dek: Uint8Array; onNext: () => void }`.
+
+- On mount: fetch existing login passkeys via
+  `GET /api/auth/passkey/list-user-passkeys` (same call the Settings card uses).
+  Track which `credentialId`s have been enrolled this session in local state
+  (fresh setup starts with none).
+- Render (au-card / au-btn, matching the rest of the wizard — **not** shadcn):
+  - **"Add this device"** button → `registerPasskey(defaultName)` →
+    `enrollPasskeyForUnlock(dek, newCredentialId, name)` → mark enrolled, refresh
+    list. Copy notes "You'll be asked to confirm twice."
+  - For each existing passkey: an **"Enable unlock"** button →
+    `enrollPasskeyForUnlock(dek, credentialId, label)`. Enrolled rows show a ✓ and
+    a disabled state.
+  - **Skip for now** and **Continue** both call `onNext`. "Continue" is the label
+    once at least one passkey is enrolled; "Skip for now" otherwise (cosmetic).
+- Errors surface inline via the wizard's `au-error` pattern; the step is optional
+  so the user can always proceed via Skip.
+
+#### New shared helpers (`features/crypto/lib/passkeyFlow.ts`)
+
+Keep the component thin and the logic unit-testable:
+
+```ts
+// Registers a new PRF-capable passkey via better-auth and resolves its
+// credentialId. PRF is requested at registration by the server config
+// (lib/auth.ts: passkey.registration.extensions.prf = {}), so the created
+// credential supports PRF. If addPasskey does not return the credential id,
+// re-fetch the passkey list and diff against the known set to find the new one.
+export const registerPasskey = async (name: string): Promise<{ credentialId: string }>
+
+// buildPasskeyWrap + enablePasskeyUnlockAction in one step. The caller holds the
+// DEK directly (wizard: dekRef; no authorizer needed since the session already
+// proved identity at login and the DEK is in memory).
+export const enrollPasskeyForUnlock = async (
+  dek: Uint8Array,
+  credentialId: string,
+  label: string,
+): Promise<void>
+```
+
+`enrollPasskeyForUnlock` reuses the existing `buildPasskeyWrap` (which generates a
+PRF salt, asserts the credential, and wraps the DEK) and calls the existing
+`enablePasskeyUnlockAction`. `registerPasskey` is the only genuinely new
+client-side capability (the Settings card never registered passkeys; the starter's
+`PasskeyManagerPage` does it internally via `authClient.passkey.addPasskey`).
+
+### Part 3 — Edge cases, copy, tests
+
+**Edge cases**
+
+- **Device lacks PRF / no platform authenticator / user dismisses prompt:**
+  `registerPasskey` or the PRF assert throws; show inline error, user Skips.
+  `readPrf` already throws "This device does not support passkey unlock."
+- **Two biometric prompts** for a fresh passkey (register, then PRF assert):
+  acknowledged in copy ("You'll be asked to confirm twice.").
+- **Reload mid-step:** `dekRef` lost → `handlePasskeyNext` routes to
+  `/crypto/unlock`; unlock reconciles the (idempotent) migration. No data risk —
+  finalize/migration has not run yet, journal is still plaintext-at-rest, row
+  exists.
+- **Register succeeds but enroll fails:** the new passkey is valid for login and
+  now appears in the list as un-enrolled "Enable unlock"; the user retries or
+  Skips and enrolls later in Settings.
+- **Rate limit:** `enablePasskeyUnlockAction` is behind the per-user WRITE limiter
+  already; enrolling several passkeys in quick succession could hit it — surface
+  the existing `RATE_LIMIT_MESSAGE` inline.
+
+**Copy (`features/crypto/cryptoCopy.ts`)**
+
+- `recovery.saveFirstHint`: "Copy or download your code first."
+- New `passkey` block: `heading`, `body` (mentions optional + twice-prompt),
+  `addLabel` ("Add this device"), `enableLabel` ("Enable unlock"),
+  `enrolledLabel`, `skipLabel` ("Skip for now"), `continueLabel` ("Continue"),
+  and error strings (`unsupported`, `registerFailed`, `enrollFailed`).
+- Brand-panel feature tick: add "Unlock with a passkey" (or fold into the existing
+  "Passphrase + recovery code" tick).
+
+**Tests**
+
+- Unit tests for `registerPasskey` and `enrollPasskeyForUnlock` in
+  `passkeyFlow.test.ts`, mocking `authClient.passkey.addPasskey`,
+  `navigator.credentials`, and the server action — following the existing
+  `passkeyFlow.test.ts` / `webauthn.test.ts` mock patterns.
+- `buildPasskeyWrap` and `enablePasskeyUnlockAction` already have coverage; no new
+  server-action logic.
+- Component-level wizard transition testing stays light (consistent with current
+  repo coverage, which unit-tests the crypto libs rather than the wizard UI).
+
+## Affected files
+
+- `features/crypto/SetupWizard.tsx` — recovery-gate hardening; new `'passkey'`
+  step + `PasskeyStep` component; flow rewiring (`handleRecoveryNext` /
+  `handlePasskeyNext`); StepIndicator order/labels.
+- `features/crypto/lib/passkeyFlow.ts` — `registerPasskey`, `enrollPasskeyForUnlock`.
+- `features/crypto/lib/passkeyFlow.test.ts` — tests for the two new helpers.
+- `features/crypto/cryptoCopy.ts` — recovery hint + `passkey` copy block.
+
+## Acceptance (live, manual — needs a real Postgres + Garage dev env)
+
+1. Fresh user → wizard recovery step: Continue stays disabled until Copy or
+   Download is clicked *and* the checkbox is ticked.
+2. Passkey step: "Add this device" registers a passkey (Touch ID), prompts again
+   for PRF, shows it enrolled; Continue → dashboard; journal encrypted at rest.
+3. Lock → unlock with the new passkey (Touch ID) decrypts the journal.
+4. Skip the passkey step → onboarding still completes with passphrase + recovery.
+5. Existing-passkey user: the step lists it with "Enable unlock"; enabling works.
+6. Device without PRF: clear inline error; Skip still completes setup.
+```

--- a/features/crypto/PasskeyStep.test.tsx
+++ b/features/crypto/PasskeyStep.test.tsx
@@ -8,6 +8,11 @@ vi.mock('./lib/passkeyFlow', () => ({
   enrollPasskeyForUnlock: vi.fn(),
 }));
 
+// Mock getMaterial so the test never hits the network.
+vi.mock('./lib/cryptoMaterial', () => ({
+  getMaterial: vi.fn(),
+}));
+
 describe('PasskeyStep', () => {
   it('renders the add-device and skip controls', () => {
     const out = renderToStaticMarkup(

--- a/features/crypto/PasskeyStep.test.tsx
+++ b/features/crypto/PasskeyStep.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect, vi } from 'vitest';
+import { PasskeyStep } from './PasskeyStep';
+
+// Mock the flow module so the test never pulls in the server action transitively.
+vi.mock('./lib/passkeyFlow', () => ({
+  registerPasskey: vi.fn(),
+  enrollPasskeyForUnlock: vi.fn(),
+}));
+
+describe('PasskeyStep', () => {
+  it('renders the add-device and skip controls', () => {
+    const out = renderToStaticMarkup(
+      <PasskeyStep dek={new Uint8Array(32)} onNext={() => {}} />
+    );
+    expect(out).toContain('Add this device');
+    expect(out).toContain('Skip for now');
+  });
+});

--- a/features/crypto/PasskeyStep.tsx
+++ b/features/crypto/PasskeyStep.tsx
@@ -62,16 +62,31 @@ export function PasskeyStep({
   async function handleAdd() {
     setError(null);
     setBusy(ADD);
+    let credentialId: string;
     try {
-      const { credentialId } = await registerPasskey('This device');
-      await enrollPasskeyForUnlock(dek, credentialId, 'This device');
-      setRows((r) => [
-        ...r.filter((x) => x.credentialId !== credentialId),
-        { credentialId, name: 'This device', enabled: true },
-      ]);
-      setEnrolledCount((c) => c + 1);
+      ({ credentialId } = await registerPasskey('This device'));
     } catch (err) {
       setError(friendlyError(err, copy.errors.registerFailed));
+      setBusy(null);
+      return;
+    }
+    // The passkey now exists server-side. Surface it as an un-enrolled row
+    // immediately so a failed enroll below leaves a retryable "Enable unlock"
+    // entry here instead of an invisible passkey only enrollable via Settings.
+    setRows((r) => [
+      ...r.filter((x) => x.credentialId !== credentialId),
+      { credentialId, name: 'This device', enabled: false },
+    ]);
+    try {
+      await enrollPasskeyForUnlock(dek, credentialId, 'This device');
+      setRows((r) =>
+        r.map((x) =>
+          x.credentialId === credentialId ? { ...x, enabled: true } : x
+        )
+      );
+      setEnrolledCount((c) => c + 1);
+    } catch (err) {
+      setError(friendlyError(err, copy.errors.enrollFailed));
     } finally {
       setBusy(null);
     }

--- a/features/crypto/PasskeyStep.tsx
+++ b/features/crypto/PasskeyStep.tsx
@@ -38,10 +38,11 @@ export function PasskeyStep({
 
   useEffect(() => {
     void (async () => {
-      // fetchUserPasskeys swallows its own errors; only getMaterial can throw.
+      // fetchUserPasskeys swallows its own errors (returns null on failure);
+      // this is an optional step so treat a load failure as "no passkeys".
       // Resolve it separately so a getMaterial failure just means
       // "list passkeys as not-enrolled" without re-fetching the list.
-      const passkeys = await fetchUserPasskeys();
+      const passkeys = (await fetchUserPasskeys()) ?? [];
       const enrolled = await getMaterial()
         .then((m) => new Set(m.passkeys.map((p) => p.credentialId)))
         .catch(() => new Set<string>());

--- a/features/crypto/PasskeyStep.tsx
+++ b/features/crypto/PasskeyStep.tsx
@@ -3,11 +3,21 @@
 import { CheckCircle2, KeyRound, Loader2, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { CRYPTO_COPY } from './cryptoCopy';
+import { getMaterial } from './lib/cryptoMaterial';
 import { enrollPasskeyForUnlock, registerPasskey } from './lib/passkeyFlow';
 
 type Row = { credentialId: string; name: string; enabled: boolean };
 
 const ADD = '__add__';
+
+function friendlyError(err: unknown, fallback: string): string {
+  if (typeof DOMException !== 'undefined' && err instanceof DOMException) {
+    return err.name === 'NotAllowedError'
+      ? CRYPTO_COPY.passkey.errors.cancelled
+      : fallback;
+  }
+  return err instanceof Error && err.message ? err.message : fallback;
+}
 
 async function fetchPasskeys(): Promise<
   { credentialID: string; name?: string }[]
@@ -39,14 +49,33 @@ export function PasskeyStep({
 
   useEffect(() => {
     void (async () => {
-      const passkeys = await fetchPasskeys();
-      setRows(
-        passkeys.map((p) => ({
-          credentialId: p.credentialID,
-          name: p.name ?? 'Passkey',
-          enabled: false,
-        }))
-      );
+      try {
+        const [passkeys, material] = await Promise.all([
+          fetchPasskeys(),
+          getMaterial(),
+        ]);
+        const enrolled = new Set(material.passkeys.map((p) => p.credentialId));
+        setRows(
+          passkeys.map((p) => ({
+            credentialId: p.credentialID,
+            name: p.name ?? 'Passkey',
+            enabled: enrolled.has(p.credentialID),
+          }))
+        );
+        setEnrolledCount(
+          passkeys.filter((p) => enrolled.has(p.credentialID)).length
+        );
+      } catch {
+        // getMaterial failure: fall back to listing passkeys as not-enrolled.
+        const passkeys = await fetchPasskeys();
+        setRows(
+          passkeys.map((p) => ({
+            credentialId: p.credentialID,
+            name: p.name ?? 'Passkey',
+            enabled: false,
+          }))
+        );
+      }
     })();
   }, []);
 
@@ -62,7 +91,7 @@ export function PasskeyStep({
       ]);
       setEnrolledCount((c) => c + 1);
     } catch (err) {
-      setError(err instanceof Error ? err.message : copy.errors.registerFailed);
+      setError(friendlyError(err, copy.errors.registerFailed));
     } finally {
       setBusy(null);
     }
@@ -80,7 +109,7 @@ export function PasskeyStep({
       );
       setEnrolledCount((c) => c + 1);
     } catch (err) {
-      setError(err instanceof Error ? err.message : copy.errors.enrollFailed);
+      setError(friendlyError(err, copy.errors.enrollFailed));
     } finally {
       setBusy(null);
     }

--- a/features/crypto/PasskeyStep.tsx
+++ b/features/crypto/PasskeyStep.tsx
@@ -4,7 +4,11 @@ import { CheckCircle2, KeyRound, Loader2, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { CRYPTO_COPY } from './cryptoCopy';
 import { getMaterial } from './lib/cryptoMaterial';
-import { enrollPasskeyForUnlock, registerPasskey } from './lib/passkeyFlow';
+import {
+  enrollPasskeyForUnlock,
+  fetchUserPasskeys,
+  registerPasskey,
+} from './lib/passkeyFlow';
 
 type Row = { credentialId: string; name: string; enabled: boolean };
 
@@ -17,21 +21,6 @@ function friendlyError(err: unknown, fallback: string): string {
       : fallback;
   }
   return err instanceof Error && err.message ? err.message : fallback;
-}
-
-async function fetchPasskeys(): Promise<
-  { credentialID: string; name?: string }[]
-> {
-  try {
-    const res = await fetch('/api/auth/passkey/list-user-passkeys', {
-      method: 'GET',
-      credentials: 'include',
-    });
-    if (!res.ok) return [];
-    return (await res.json()) as { credentialID: string; name?: string }[];
-  } catch {
-    return [];
-  }
 }
 
 export function PasskeyStep({
@@ -49,34 +38,23 @@ export function PasskeyStep({
 
   useEffect(() => {
     void (async () => {
-      try {
-        const [passkeys, material] = await Promise.all([
-          fetchPasskeys(),
-          getMaterial(),
-        ]);
-        const enrolled = new Set(material.passkeys.map((p) => p.credentialId));
-        setRows(
-          passkeys.map((p) => ({
-            credentialId: p.credentialID,
-            name: p.name ?? 'Passkey',
-            enabled: enrolled.has(p.credentialID),
-          }))
-        );
-        setEnrolledCount(
-          passkeys.filter((p) => enrolled.has(p.credentialID)).length
-        );
-      } catch {
-        // Promise.all rejected (in practice only getMaterial can throw —
-        // fetchPasskeys swallows its own errors): list passkeys as not-enrolled.
-        const passkeys = await fetchPasskeys();
-        setRows(
-          passkeys.map((p) => ({
-            credentialId: p.credentialID,
-            name: p.name ?? 'Passkey',
-            enabled: false,
-          }))
-        );
-      }
+      // fetchUserPasskeys swallows its own errors; only getMaterial can throw.
+      // Resolve it separately so a getMaterial failure just means
+      // "list passkeys as not-enrolled" without re-fetching the list.
+      const passkeys = await fetchUserPasskeys();
+      const enrolled = await getMaterial()
+        .then((m) => new Set(m.passkeys.map((p) => p.credentialId)))
+        .catch(() => new Set<string>());
+      setRows(
+        passkeys.map((p) => ({
+          credentialId: p.credentialID,
+          name: p.name ?? 'Passkey',
+          enabled: enrolled.has(p.credentialID),
+        }))
+      );
+      setEnrolledCount(
+        passkeys.filter((p) => enrolled.has(p.credentialID)).length
+      );
     })();
   }, []);
 

--- a/features/crypto/PasskeyStep.tsx
+++ b/features/crypto/PasskeyStep.tsx
@@ -66,7 +66,8 @@ export function PasskeyStep({
           passkeys.filter((p) => enrolled.has(p.credentialID)).length
         );
       } catch {
-        // getMaterial failure: fall back to listing passkeys as not-enrolled.
+        // Promise.all rejected (in practice only getMaterial can throw —
+        // fetchPasskeys swallows its own errors): list passkeys as not-enrolled.
         const passkeys = await fetchPasskeys();
         setRows(
           passkeys.map((p) => ({

--- a/features/crypto/PasskeyStep.tsx
+++ b/features/crypto/PasskeyStep.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { CheckCircle2, KeyRound, Loader2, Plus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CRYPTO_COPY } from './cryptoCopy';
+import { enrollPasskeyForUnlock, registerPasskey } from './lib/passkeyFlow';
+
+type Row = { credentialId: string; name: string; enabled: boolean };
+
+const ADD = '__add__';
+
+async function fetchPasskeys(): Promise<
+  { credentialID: string; name?: string }[]
+> {
+  try {
+    const res = await fetch('/api/auth/passkey/list-user-passkeys', {
+      method: 'GET',
+      credentials: 'include',
+    });
+    if (!res.ok) return [];
+    return (await res.json()) as { credentialID: string; name?: string }[];
+  } catch {
+    return [];
+  }
+}
+
+export function PasskeyStep({
+  dek,
+  onNext,
+}: {
+  dek: Uint8Array;
+  onNext: () => void;
+}) {
+  const copy = CRYPTO_COPY.passkey;
+  const [rows, setRows] = useState<Row[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [enrolledCount, setEnrolledCount] = useState(0);
+
+  useEffect(() => {
+    void (async () => {
+      const passkeys = await fetchPasskeys();
+      setRows(
+        passkeys.map((p) => ({
+          credentialId: p.credentialID,
+          name: p.name ?? 'Passkey',
+          enabled: false,
+        }))
+      );
+    })();
+  }, []);
+
+  async function handleAdd() {
+    setError(null);
+    setBusy(ADD);
+    try {
+      const { credentialId } = await registerPasskey('This device');
+      await enrollPasskeyForUnlock(dek, credentialId, 'This device');
+      setRows((r) => [
+        ...r.filter((x) => x.credentialId !== credentialId),
+        { credentialId, name: 'This device', enabled: true },
+      ]);
+      setEnrolledCount((c) => c + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : copy.errors.registerFailed);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleEnable(row: Row) {
+    setError(null);
+    setBusy(row.credentialId);
+    try {
+      await enrollPasskeyForUnlock(dek, row.credentialId, row.name);
+      setRows((r) =>
+        r.map((x) =>
+          x.credentialId === row.credentialId ? { ...x, enabled: true } : x
+        )
+      );
+      setEnrolledCount((c) => c + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : copy.errors.enrollFailed);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const unenrolled = rows.filter((r) => !r.enabled);
+  const enrolled = rows.filter((r) => r.enabled);
+
+  return (
+    <div className="flex flex-col gap-7">
+      <div className="space-y-2">
+        <h1 className="au-grad ff-display text-[clamp(2rem,4vw,2.75rem)] leading-[1.05]">
+          {copy.heading}
+        </h1>
+        <p className="text-[0.95rem] text-[color:var(--txt-dim)] leading-relaxed">
+          {copy.body}
+        </p>
+      </div>
+
+      <div className="au-card p-5 flex flex-col gap-3">
+        <button
+          type="button"
+          className="au-btn au-btn--ghost"
+          onClick={handleAdd}
+          disabled={busy !== null}
+        >
+          {busy === ADD ? (
+            <>
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              {copy.addingLabel}
+            </>
+          ) : (
+            <>
+              <Plus className="size-4" aria-hidden />
+              {copy.addLabel}
+            </>
+          )}
+        </button>
+
+        {unenrolled.map((row) => (
+          <div
+            key={row.credentialId}
+            className="flex items-center justify-between gap-3 rounded-md border border-[var(--line)] p-3"
+          >
+            <span className="flex items-center gap-2 text-sm text-[color:var(--txt-dim)]">
+              <KeyRound className="size-4" aria-hidden />
+              {row.name}
+            </span>
+            <button
+              type="button"
+              className="au-btn au-btn--ghost"
+              style={{ height: '2.25rem', fontSize: '0.8rem' }}
+              onClick={() => handleEnable(row)}
+              disabled={busy !== null}
+            >
+              {busy === row.credentialId
+                ? copy.enablingLabel
+                : copy.enableLabel}
+            </button>
+          </div>
+        ))}
+
+        {enrolled.map((row) => (
+          <div
+            key={row.credentialId}
+            className="flex items-center justify-between gap-3 rounded-md border border-[var(--line)] p-3"
+          >
+            <span className="flex items-center gap-2 text-sm text-[color:var(--txt-dim)]">
+              <KeyRound className="size-4" aria-hidden />
+              {row.name}
+            </span>
+            <span
+              className="flex items-center gap-1.5 text-xs ff-mono"
+              style={{ color: 'var(--em)' }}
+            >
+              <CheckCircle2 className="size-3.5" aria-hidden />
+              {copy.enrolledLabel}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-[color:var(--txt-faint)] leading-relaxed">
+        {copy.twiceNote}
+      </p>
+
+      <button
+        type="button"
+        className="au-btn au-btn--primary"
+        onClick={onNext}
+        disabled={busy !== null}
+      >
+        {enrolledCount > 0 ? copy.continueLabel : copy.skipLabel}
+      </button>
+
+      <p className="au-error" aria-live="polite" aria-atomic="true">
+        {error ?? ''}
+      </p>
+    </div>
+  );
+}

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -8,7 +8,7 @@ import {
   Loader2,
   ShieldCheck,
 } from 'lucide-react';
-import { type FormEvent, useState, useRef } from 'react';
+import { type FormEvent, useState, useRef, useEffect } from 'react';
 import '@/features/auth/auth.css';
 import { PasskeyStep } from '@/features/crypto/PasskeyStep';
 import { finalizeEncryption } from '@/features/crypto/actions/finalizeEncryption';
@@ -694,6 +694,15 @@ export function SetupWizard() {
   // (the react-hooks/refs lint rule forbids ref access during render).
   const dekRef = useRef<Uint8Array | null>(null);
   const [dekSnapshot, setDekSnapshot] = useState<Uint8Array | null>(null);
+
+  // If we land on the passkey step without the in-memory DEK (e.g. a reload
+  // reset component state), there is nothing to enroll against — route to the
+  // normal unlock flow, symmetric with handlePasskeyNext's guard.
+  useEffect(() => {
+    if (step === 'passkey' && !dekSnapshot) {
+      window.location.assign('/crypto/unlock');
+    }
+  }, [step, dekSnapshot]);
 
   // Advance from passphrase → recovery: persists the wrapped keys, then
   // surfaces the recovery code. The session unlock (postDek) is deferred to

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { type FormEvent, useState, useRef } from 'react';
 import '@/features/auth/auth.css';
+import { PasskeyStep } from '@/features/crypto/PasskeyStep';
 import { finalizeEncryption } from '@/features/crypto/actions/finalizeEncryption';
 import { setupCrypto } from '@/features/crypto/actions/setupCrypto';
 import { CRYPTO_COPY } from '@/features/crypto/cryptoCopy';
@@ -66,7 +67,7 @@ async function runSetup(
   return { dek, code };
 }
 
-type Step = 'why' | 'passphrase' | 'recovery' | 'encrypting';
+type Step = 'why' | 'passphrase' | 'recovery' | 'passkey' | 'encrypting';
 
 // ── decorative bars (echoes CryptoBrandPanel in UnlockScreen) ──
 const LOCK_TICKS = [14, 22, 18, 28, 20, 32, 16, 26, 24, 30] as const;
@@ -156,7 +157,7 @@ function SetupBrandPanel() {
           [
             'Client-side key generation',
             'Zero-knowledge server',
-            'Passphrase + recovery code',
+            'Passphrase, recovery code & passkey',
           ] as const
         ).map((f) => (
           <li key={f} className="au-tick">
@@ -175,9 +176,16 @@ const STEP_LABELS: Record<Step, string> = {
   why: 'Why',
   passphrase: 'Passphrase',
   recovery: 'Recovery code',
+  passkey: 'Passkey',
   encrypting: 'Encrypting',
 };
-const STEP_ORDER: Step[] = ['why', 'passphrase', 'recovery', 'encrypting'];
+const STEP_ORDER: Step[] = [
+  'why',
+  'passphrase',
+  'recovery',
+  'passkey',
+  'encrypting',
+];
 
 function StepIndicator({ current }: { current: Step }) {
   const currentIdx = STEP_ORDER.indexOf(current);
@@ -680,10 +688,12 @@ export function SetupWizard() {
   const [recoveryCode, setRecoveryCode] = useState<string | null>(null);
   const [fatalError, setFatalError] = useState<string | null>(null);
   const [fatalRetryStep, setFatalRetryStep] = useState<Step>('passphrase');
-  // Held in memory so a transient unlock failure can be retried at finalize
-  // time without re-running setupCrypto (which would now reject with
-  // "already set up" and orphan the displayed recovery code).
+  // dekRef holds the raw DEK so async finalize handlers can read it without
+  // causing re-renders. dekSnapshot mirrors it in state so the render branch
+  // can pass it to PasskeyStep without touching the ref during render
+  // (the react-hooks/refs lint rule forbids ref access during render).
   const dekRef = useRef<Uint8Array | null>(null);
+  const [dekSnapshot, setDekSnapshot] = useState<Uint8Array | null>(null);
 
   // Advance from passphrase → recovery: persists the wrapped keys, then
   // surfaces the recovery code. The session unlock (postDek) is deferred to
@@ -692,6 +702,7 @@ export function SetupWizard() {
     try {
       const { dek, code } = await runSetup(passphrase);
       dekRef.current = dek;
+      setDekSnapshot(dek);
       setRecoveryCode(code);
       setStep('recovery');
     } catch (err) {
@@ -702,13 +713,25 @@ export function SetupWizard() {
     }
   }
 
-  // Advance from recovery → encrypting: unlock the session, then finalize.
-  // Both steps are idempotent and safe to re-run on "Retry".
-  async function handleRecoveryNext() {
+  // Advance from recovery → passkey. The DEK is already in dekRef and the
+  // userCrypto row already exists, so the optional passkey step can enroll
+  // before the session is unlocked at finalize.
+  function handleRecoveryNext() {
+    if (!dekRef.current) {
+      // Lost the in-memory DEK (e.g. a reload) — the row already exists, so
+      // route through the normal unlock flow instead.
+      window.location.assign('/crypto/unlock');
+      return;
+    }
+    setStep('passkey');
+  }
+
+  // Advance from passkey → encrypting: unlock the session, then finalize.
+  // Both "Skip" and "Continue" call this; enrolling a passkey is additive and
+  // already complete by this point. Idempotent and safe to re-run on "Retry".
+  async function handlePasskeyNext() {
     const dek = dekRef.current;
     if (!dek) {
-      // Lost the in-memory DEK (e.g. a reload landed back here) — the row
-      // already exists, so route through the normal unlock flow instead.
       window.location.assign('/crypto/unlock');
       return;
     }
@@ -717,14 +740,14 @@ export function SetupWizard() {
       await postDek(dek); // unlock this session so migration can run
       const result = await finalizeEncryption();
       if (!result.ok) {
-        setFatalRetryStep('recovery');
+        setFatalRetryStep('passkey');
         setFatalError(result.error ?? CRYPTO_COPY.errors.setupFailed);
         return;
       }
       // Hard navigate so the session gate sees `ready`.
       window.location.assign('/dashboard');
     } catch (err) {
-      setFatalRetryStep('recovery');
+      setFatalRetryStep('passkey');
       setFatalError(
         err instanceof Error ? err.message : CRYPTO_COPY.errors.generic
       );
@@ -796,6 +819,8 @@ export function SetupWizard() {
                 <PassphraseStep onNext={handlePassphraseNext} />
               ) : step === 'recovery' && recoveryCode ? (
                 <RecoveryStep code={recoveryCode} onNext={handleRecoveryNext} />
+              ) : step === 'passkey' && dekSnapshot ? (
+                <PasskeyStep dek={dekSnapshot} onNext={handlePasskeyNext} />
               ) : step === 'encrypting' ? (
                 <EncryptingStep />
               ) : null}

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -461,12 +461,14 @@ function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
   const copy = CRYPTO_COPY.recovery;
   const [copied, setCopied] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [interacted, setInteracted] = useState(false);
   const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Format code into groups of 4 separated by dashes
   const groups = code.split('-');
 
   async function handleCopy() {
+    setInteracted(true);
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
@@ -478,6 +480,7 @@ function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
   }
 
   function handleDownload() {
+    setInteracted(true);
     const blob = new Blob(
       [
         `${APP_NAME} Recovery Code\n`,
@@ -559,6 +562,12 @@ function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
         </div>
       </div>
 
+      {!interacted && (
+        <p className="text-xs text-[color:var(--txt-faint)] text-center">
+          {copy.saveFirstHint}
+        </p>
+      )}
+
       <p className="text-sm text-[color:var(--txt-faint)] leading-relaxed">
         {copy.instruction}
       </p>
@@ -568,8 +577,9 @@ function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
         <input
           type="checkbox"
           checked={saved}
+          disabled={!interacted}
           onChange={(e) => setSaved(e.target.checked)}
-          className="mt-0.5 size-4 cursor-pointer accent-[var(--em)]"
+          className="mt-0.5 size-4 cursor-pointer accent-[var(--em)] disabled:cursor-not-allowed disabled:opacity-50"
           aria-label={copy.confirmPrompt}
         />
         <span className="text-sm text-[color:var(--txt-dim)] select-none">
@@ -580,7 +590,7 @@ function RecoveryStep({ code, onNext }: { code: string; onNext: () => void }) {
       <button
         type="button"
         className="au-btn au-btn--primary"
-        disabled={!saved}
+        disabled={!interacted || !saved}
         onClick={onNext}
       >
         {copy.submitLabel}

--- a/features/crypto/cryptoCopy.ts
+++ b/features/crypto/cryptoCopy.ts
@@ -58,6 +58,7 @@ export const CRYPTO_COPY = {
     errors: {
       registerFailed: 'Could not create a passkey. Please try again.',
       enrollFailed: 'Could not link the passkey. Please try again.',
+      cancelled: 'Passkey prompt was dismissed or timed out.',
     },
   },
 

--- a/features/crypto/cryptoCopy.ts
+++ b/features/crypto/cryptoCopy.ts
@@ -38,6 +38,7 @@ export const CRYPTO_COPY = {
     copyLabel: 'Copy code',
     copiedLabel: 'Copied!',
     confirmPrompt: 'I have saved my recovery code',
+    saveFirstHint: 'Copy or download your code first.',
     submitLabel: 'Enable encryption',
   },
 

--- a/features/crypto/cryptoCopy.ts
+++ b/features/crypto/cryptoCopy.ts
@@ -42,6 +42,25 @@ export const CRYPTO_COPY = {
     submitLabel: 'Enable encryption',
   },
 
+  // ── Passkey step (optional) ─────────────────────────────────────────────────
+  passkey: {
+    heading: 'Add a passkey',
+    body: 'Optionally let this device unlock your journal with a passkey, alongside your passphrase and recovery code. You can add more later in Settings.',
+    twiceNote:
+      "You'll be asked to confirm twice — once to create the passkey, once to link it.",
+    addLabel: 'Add this device',
+    addingLabel: 'Adding…',
+    enableLabel: 'Enable unlock',
+    enablingLabel: 'Enabling…',
+    enrolledLabel: 'Enabled',
+    skipLabel: 'Skip for now',
+    continueLabel: 'Continue',
+    errors: {
+      registerFailed: 'Could not create a passkey. Please try again.',
+      enrollFailed: 'Could not link the passkey. Please try again.',
+    },
+  },
+
   // ── Encrypting / progress step ──────────────────────────────────────────────
   encrypting: {
     heading: 'Encrypting your journal…',

--- a/features/crypto/lib/passkeyFlow.test.ts
+++ b/features/crypto/lib/passkeyFlow.test.ts
@@ -5,9 +5,11 @@ import {
   buildPasskeyWrap,
   unlockWithPasskey,
   registerPasskey,
+  enrollPasskeyForUnlock,
 } from './passkeyFlow';
 import { postDek } from './unlockFlow';
 import { assertPrfForCredential, assertPrfAny } from './webauthn';
+import { enablePasskeyUnlockAction } from '@/features/crypto/actions/enablePasskeyUnlock';
 import { authClient } from '@/lib/auth-client';
 
 vi.mock('./webauthn');
@@ -16,6 +18,7 @@ vi.mock('./unlockFlow');
 vi.mock('@/lib/auth-client', () => ({
   authClient: { passkey: { addPasskey: vi.fn() } },
 }));
+vi.mock('@/features/crypto/actions/enablePasskeyUnlock');
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -110,5 +113,50 @@ describe('registerPasskey', () => {
       >
     ).mockResolvedValue({ data: null, error: { message: 'denied' } } as never);
     await expect(registerPasskey('x')).rejects.toThrow('denied');
+  });
+});
+
+describe('enrollPasskeyForUnlock', () => {
+  it('builds a wrap and enables it', async () => {
+    (
+      assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
+    ).mockResolvedValue({
+      credentialId: 'cred-A',
+      prfOutput: new Uint8Array(32).fill(7),
+    });
+    (
+      enablePasskeyUnlockAction as MockedFunction<
+        typeof enablePasskeyUnlockAction
+      >
+    ).mockResolvedValue({ ok: true });
+
+    await enrollPasskeyForUnlock(generateDek(), 'cred-A', 'Laptop');
+
+    expect(enablePasskeyUnlockAction).toHaveBeenCalledTimes(1);
+    const arg = (
+      enablePasskeyUnlockAction as MockedFunction<
+        typeof enablePasskeyUnlockAction
+      >
+    ).mock.calls[0][0] as { credentialId: string; label: string };
+    expect(arg.credentialId).toBe('cred-A');
+    expect(arg.label).toBe('Laptop');
+  });
+
+  it('throws with the action message when enabling fails', async () => {
+    (
+      assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
+    ).mockResolvedValue({
+      credentialId: 'cred-A',
+      prfOutput: new Uint8Array(32).fill(7),
+    });
+    (
+      enablePasskeyUnlockAction as MockedFunction<
+        typeof enablePasskeyUnlockAction
+      >
+    ).mockResolvedValue({ ok: false, message: 'rate limited' });
+
+    await expect(
+      enrollPasskeyForUnlock(generateDek(), 'cred-A', 'L')
+    ).rejects.toThrow('rate limited');
   });
 });

--- a/features/crypto/lib/passkeyFlow.test.ts
+++ b/features/crypto/lib/passkeyFlow.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, describe, expect, it, vi, MockedFunction } from 'vitest';
 import { generateDek, derivePrfKek, wrapDek, toBase64 } from './clientCrypto';
 import { getMaterial } from './cryptoMaterial';
-import { buildPasskeyWrap, unlockWithPasskey } from './passkeyFlow';
+import {
+  buildPasskeyWrap,
+  unlockWithPasskey,
+  registerPasskey,
+} from './passkeyFlow';
 import { postDek } from './unlockFlow';
 import { assertPrfForCredential, assertPrfAny } from './webauthn';
+import { authClient } from '@/lib/auth-client';
 
 vi.mock('./webauthn');
 vi.mock('./cryptoMaterial');
 vi.mock('./unlockFlow');
+vi.mock('@/lib/auth-client', () => ({
+  authClient: { passkey: { addPasskey: vi.fn() } },
+}));
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -75,5 +83,32 @@ describe('unlockWithPasskey', () => {
       passkeys: [],
     });
     await expect(unlockWithPasskey()).rejects.toThrow(/no passkey/i);
+  });
+});
+
+describe('registerPasskey', () => {
+  it('returns the new credentialId on success', async () => {
+    (
+      authClient.passkey.addPasskey as MockedFunction<
+        typeof authClient.passkey.addPasskey
+      >
+    ).mockResolvedValue({
+      data: { credentialID: 'cred-new' },
+      error: null,
+    } as never);
+    const out = await registerPasskey('This device');
+    expect(out.credentialId).toBe('cred-new');
+    expect(authClient.passkey.addPasskey).toHaveBeenCalledWith({
+      name: 'This device',
+    });
+  });
+
+  it('throws with the server message when registration errors', async () => {
+    (
+      authClient.passkey.addPasskey as MockedFunction<
+        typeof authClient.passkey.addPasskey
+      >
+    ).mockResolvedValue({ data: null, error: { message: 'denied' } } as never);
+    await expect(registerPasskey('x')).rejects.toThrow('denied');
   });
 });

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -12,6 +12,27 @@ export type EnablePasskeyInput = {
   label: string;
 };
 
+/** A passkey as returned by better-auth's list-user-passkeys endpoint. */
+export type AuthPasskey = { credentialID: string; name?: string };
+
+/**
+ * List the current user's registered passkeys via better-auth. Returns `[]` on
+ * any network/HTTP error so callers can treat "no passkeys" and "couldn't load"
+ * uniformly; callers that need to distinguish should fetch directly.
+ */
+export const fetchUserPasskeys = async (): Promise<AuthPasskey[]> => {
+  try {
+    const res = await fetch('/api/auth/passkey/list-user-passkeys', {
+      method: 'GET',
+      credentials: 'include',
+    });
+    if (!res.ok) return [];
+    return (await res.json()) as AuthPasskey[];
+  } catch {
+    return [];
+  }
+};
+
 /**
  * Build the wrap for a passkey. The caller must already hold the DEK (obtained
  * via obtainDek with a passphrase/recovery authorizer). Generates a fresh PRF
@@ -43,9 +64,11 @@ export const registerPasskey = async (
   if (!res || res.error || !res.data) {
     throw new Error(res?.error?.message ?? 'Could not create a passkey.');
   }
-  return {
-    credentialId: (res.data as { credentialID: string }).credentialID,
-  };
+  const id = (res.data as { credentialID?: unknown }).credentialID;
+  if (typeof id !== 'string' || !id) {
+    throw new Error('Could not create a passkey.');
+  }
+  return { credentialId: id };
 };
 
 /**

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -16,20 +16,21 @@ export type EnablePasskeyInput = {
 export type AuthPasskey = { credentialID: string; name?: string };
 
 /**
- * List the current user's registered passkeys via better-auth. Returns `[]` on
- * any network/HTTP error so callers can treat "no passkeys" and "couldn't load"
- * uniformly; callers that need to distinguish should fetch directly.
+ * List the current user's registered passkeys via better-auth. Returns `null`
+ * on any network/HTTP error so callers can distinguish "no passkeys" (`[]`) from
+ * "couldn't load" (`null`): the wizard step treats both as empty (optional
+ * step), while the settings card surfaces a load error.
  */
-export const fetchUserPasskeys = async (): Promise<AuthPasskey[]> => {
+export const fetchUserPasskeys = async (): Promise<AuthPasskey[] | null> => {
   try {
     const res = await fetch('/api/auth/passkey/list-user-passkeys', {
       method: 'GET',
       credentials: 'include',
     });
-    if (!res.ok) return [];
+    if (!res.ok) return null;
     return (await res.json()) as AuthPasskey[];
   } catch {
-    return [];
+    return null;
   }
 };
 

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -2,6 +2,7 @@ import { derivePrfKek, toBase64, unwrapDek, wrapDek } from './clientCrypto';
 import { getMaterial } from './cryptoMaterial';
 import { postDek } from './unlockFlow';
 import { assertPrfAny, assertPrfForCredential } from './webauthn';
+import { authClient } from '@/lib/auth-client';
 
 export type EnablePasskeyInput = {
   credentialId: string;
@@ -25,6 +26,25 @@ export const buildPasskeyWrap = async (
   const { prfOutput } = await assertPrfForCredential(credentialId, salt);
   const wrap = await wrapDek(dek, await derivePrfKek(prfOutput));
   return { credentialId, prfSalt: toBase64(salt), wrap, label };
+};
+
+/**
+ * Register a new passkey via better-auth and resolve its credentialId. PRF is
+ * requested at registration by the server config (lib/auth.ts:
+ * passkey.registration.extensions.prf = {}), so the created credential supports
+ * PRF — no client-side extension needed here. Throws if the user cancels or the
+ * server rejects.
+ */
+export const registerPasskey = async (
+  name: string
+): Promise<{ credentialId: string }> => {
+  const res = await authClient.passkey.addPasskey({ name });
+  if (!res || res.error || !res.data) {
+    throw new Error(res?.error?.message ?? 'Could not create a passkey.');
+  }
+  return {
+    credentialId: (res.data as { credentialID: string }).credentialID,
+  };
 };
 
 /** Unlock the session using any enrolled passkey. */

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -2,6 +2,7 @@ import { derivePrfKek, toBase64, unwrapDek, wrapDek } from './clientCrypto';
 import { getMaterial } from './cryptoMaterial';
 import { postDek } from './unlockFlow';
 import { assertPrfAny, assertPrfForCredential } from './webauthn';
+import { enablePasskeyUnlockAction } from '@/features/crypto/actions/enablePasskeyUnlock';
 import { authClient } from '@/lib/auth-client';
 
 export type EnablePasskeyInput = {
@@ -45,6 +46,22 @@ export const registerPasskey = async (
   return {
     credentialId: (res.data as { credentialID: string }).credentialID,
   };
+};
+
+/**
+ * Enroll a passkey for unlock: wrap the DEK with the passkey's PRF-derived KEK
+ * and persist the wrap. The caller already holds the DEK (wizard: in-memory;
+ * settings: obtained via an authorizer). Throws if the PRF assertion or the
+ * server action fails.
+ */
+export const enrollPasskeyForUnlock = async (
+  dek: Uint8Array,
+  credentialId: string,
+  label: string
+): Promise<void> => {
+  const input = await buildPasskeyWrap(dek, credentialId, label);
+  const res = await enablePasskeyUnlockAction(input);
+  if (!res.ok) throw new Error(res.message);
 };
 
 /** Unlock the session using any enrolled passkey. */

--- a/features/settings/PasskeyUnlockCard.tsx
+++ b/features/settings/PasskeyUnlockCard.tsx
@@ -12,20 +12,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getMaterial } from '@/features/crypto/lib/cryptoMaterial';
-import { buildPasskeyWrap } from '@/features/crypto/lib/passkeyFlow';
+import {
+  buildPasskeyWrap,
+  fetchUserPasskeys,
+} from '@/features/crypto/lib/passkeyFlow';
 import { obtainDek, type Authorizer } from '@/features/crypto/lib/rewrapFlow';
 
-type AuthPasskey = { credentialID: string; name?: string };
 type Row = { credentialId: string; name: string; enabled: boolean };
-
-async function fetchPasskeys(): Promise<AuthPasskey[]> {
-  const res = await fetch('/api/auth/passkey/list-user-passkeys', {
-    method: 'GET',
-    credentials: 'include',
-  });
-  if (!res.ok) throw new Error('Could not load passkeys');
-  return (await res.json()) as AuthPasskey[];
-}
 
 const PasskeyUnlockCard = () => {
   const [rows, setRows] = useState<Row[]>([]);
@@ -39,7 +32,7 @@ const PasskeyUnlockCard = () => {
     setLoading(true);
     try {
       const [passkeys, material] = await Promise.all([
-        fetchPasskeys(),
+        fetchUserPasskeys(),
         getMaterial(),
       ]);
       const enabled = new Set(material.passkeys.map((p) => p.credentialId));

--- a/features/settings/PasskeyUnlockCard.tsx
+++ b/features/settings/PasskeyUnlockCard.tsx
@@ -35,6 +35,7 @@ const PasskeyUnlockCard = () => {
         fetchUserPasskeys(),
         getMaterial(),
       ]);
+      if (passkeys === null) throw new Error('Could not load passkeys');
       const enabled = new Set(material.passkeys.map((p) => p.credentialId));
       setRows(
         passkeys.map((p) => ({


### PR DESCRIPTION
## What & why

Two safeguards for the zero-knowledge encrypted-journals onboarding wizard, both aimed at the same risk: a user can lose their journal forever if they lose *all* unlock methods at once. The encryption is zero-knowledge by design — there is no operator backdoor — so the defences are (a) making sure the recovery code is genuinely saved, and (b) making a second unlock method (passkey) easy to add during onboarding.

This finishes the deferred "Task 11" passkey step from PR #31.

## Changes

**1. Recovery-gate hardening** — the recovery step's "I have saved my recovery code" checkbox could be ticked without ever copying or downloading the code. Now the user must click **Copy** or **Download** before the checkbox unlocks, and "Enable encryption" stays disabled until both.

**2. Inline passkey step** — a new optional step (`why → passphrase → recovery → passkey → encrypting`) lets the user enroll a passkey for unlock without leaving onboarding:
- **Registers a new PRF passkey inline** if the user has none (most magic-link users), and offers to enroll existing passkeys.
- Enrollment is **additive** — the DEK never changes, the journal is not re-encrypted; each passkey is a separate wrap of the same DEK. It runs *before* finalize (the `enable` action needs only the `userCrypto` row + auth, not an unlocked session).
- Always **skippable**; the recovery code remains the mandatory fallback.
- Two new helpers carry the logic and are unit-tested: `registerPasskey`, `enrollPasskeyForUnlock`. The `postDek`+`finalizeEncryption` call moved from the recovery handler to the new passkey handler.

## Design / plan

- Spec: `docs/superpowers/specs/2026-06-26-wizard-recovery-gate-and-passkey-step-design.md`
- Plan: `docs/superpowers/plans/2026-06-26-wizard-recovery-gate-and-passkey-step.md`

## Testing

- `pnpm test` — 576/576 green (helper unit tests for both new functions; static-render test for the new component — the wizard component imports server actions so it is intentionally not import-tested, matching repo convention).
- `pnpm type-check` + `pnpm lint` — clean.
- Built via subagent-driven development: per-task review + a final whole-branch opus review (crypto model verified intact; 0 Critical / 0 Important after fixes).

## Notes for reviewer

- ⚠️ **Live WebAuthn/PRF e2e acceptance is still un-run** (needs a real Postgres + Garage dev env) — same gate as the rest of the encrypted-journals epic. To verify live: add-this-device (two biometric prompts: register, then PRF assert) → enrolled → Continue → lock → unlock with the passkey; plus the Skip path and a no-PRF-device error path.
- Spec drift (deferred, non-blocking): the `registerPasskey` re-fetch fallback and a `passkey.errors.unsupported` string from the spec were not implemented — `addPasskey` always returns `credentialID` in the current better-auth client, and the unsupported case folds into the generic `registerFailed`/`cancelled` copy.
- Incidental: the branch's first push surfaced that `main` had stale deps (PR #31 bumped `package.json` to starter 0.9.0 + `hash-wasm` without re-installing); resolved via `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
