### PR TITLE
feat(prices): manual price records (/prices)

### DIFF
--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -1,0 +1,24 @@
+import { PricesView } from '@/features/prices';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+
+export const dynamic = 'force-dynamic';
+
+const PricesPage = async () => {
+  const user = await requireUser();
+  const [prices, commodities, baseCurrency] = await Promise.all([
+    priceService.listManualPrices(user.id),
+    priceService.listCommoditiesForUser(user.id),
+    priceService.getBaseCurrency(user.id),
+  ]);
+
+  return (
+    <PricesView
+      prices={prices}
+      commodities={commodities}
+      baseCurrency={baseCurrency}
+    />
+  );
+};
+
+export default PricesPage;

--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -8,8 +8,8 @@ const PricesPage = async () => {
   const user = await requireUser();
   const [prices, commodities, baseCurrency] = await Promise.all([
     priceService.listManualPrices(user.id),
-    priceService.listCommoditiesForUser(user.id),
-    priceService.getBaseCurrency(user.id),
+    priceService.listNormalizedSymbolsForUser(user.id),
+    priceService.resolveBaseCurrency(user.id),
   ]);
 
   return (

--- a/components/nav/config.ts
+++ b/components/nav/config.ts
@@ -13,6 +13,7 @@ import {
   PiggyBank,
   PlusCircle,
   Settings,
+  TrendingUp,
   Users,
   type LucideIcon,
 } from 'lucide-react';
@@ -177,6 +178,15 @@ export const getNavSections = (): NavSection[] => {
           description: 'Replace your journal from a file or .zip archive.',
           icon: FileUp,
           keywords: ['upload', 'replace', 'zip'],
+        },
+        {
+          id: 'prices',
+          title: 'Prices',
+          href: '/prices',
+          match: 'exact',
+          description: 'Record exchange rates for commodities like KIRT.',
+          icon: TrendingUp,
+          keywords: ['exchange', 'rate', 'commodity', 'currency', 'price'],
         },
       ],
     },

--- a/db/migrations/0009_odd_sunfire.sql
+++ b/db/migrations/0009_odd_sunfire.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "manual_price" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"symbol" text NOT NULL,
+	"quote" text NOT NULL,
+	"price" real NOT NULL,
+	"priced_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "manual_price_unique_per_instant" UNIQUE("user_id","symbol","quote","priced_at")
+);
+--> statement-breakpoint
+ALTER TABLE "manual_price" ADD CONSTRAINT "manual_price_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/db/migrations/meta/0009_snapshot.json
+++ b/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,847 @@
+{
+  "id": "523f7087-2b77-4029-ba64-241da651f3cb",
+  "prevId": "b075401a-e10e-4963-b0c0-3b13642c8962",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accountDeletionChallenge": {
+      "name": "accountDeletionChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accountDeletionChallenge_userId_user_id_fk": {
+          "name": "accountDeletionChallenge_userId_user_id_fk",
+          "tableFrom": "accountDeletionChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auditLog": {
+      "name": "auditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUid": {
+          "name": "targetUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytesBefore": {
+          "name": "bytesBefore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytesAfter": {
+          "name": "bytesAfter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auditLog_user_id": {
+          "name": "auditLog_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auditLog_userId_user_id_fk": {
+          "name": "auditLog_userId_user_id_fk",
+          "tableFrom": "auditLog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commodity_price": {
+      "name": "commodity_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_date": {
+          "name": "fetched_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commodity_price_unique_per_day": {
+          "name": "commodity_price_unique_per_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol",
+            "quote",
+            "fetched_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cryptoPasskeyWrap": {
+      "name": "cryptoPasskeyWrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prfSalt": {
+          "name": "prfSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrap": {
+          "name": "wrap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cryptoPasskeyWrap_userId_user_id_fk": {
+          "name": "cryptoPasskeyWrap_userId_user_id_fk",
+          "tableFrom": "cryptoPasskeyWrap",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cryptoPasskeyWrap_user_cred": {
+          "name": "cryptoPasskeyWrap_user_cred",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryptionResetChallenge": {
+      "name": "encryptionResetChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryptionResetChallenge_userId_user_id_fk": {
+          "name": "encryptionResetChallenge_userId_user_id_fk",
+          "tableFrom": "encryptionResetChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_price": {
+      "name": "manual_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priced_at": {
+          "name": "priced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "manual_price_user_id_user_id_fk": {
+          "name": "manual_price_user_id_user_id_fk",
+          "tableFrom": "manual_price",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "manual_price_unique_per_instant": {
+          "name": "manual_price_unique_per_instant",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "symbol",
+            "quote",
+            "priced_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_fetch_run": {
+      "name": "price_fetch_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbols_fetched": {
+          "name": "symbols_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "symbols_failed": {
+          "name": "symbols_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savedView": {
+      "name": "savedView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPath": {
+          "name": "targetPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "savedView_user_name": {
+          "name": "savedView_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savedView_userId_user_id_fk": {
+          "name": "savedView_userId_user_id_fk",
+          "tableFrom": "savedView",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_user_name": {
+          "name": "template_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_userId_user_id_fk": {
+          "name": "template_userId_user_id_fk",
+          "tableFrom": "template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userCrypto": {
+      "name": "userCrypto",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wrapPassphrase": {
+          "name": "wrapPassphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passSalt": {
+          "name": "passSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argonParams": {
+          "name": "argonParams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapRecovery": {
+          "name": "wrapRecovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recoveryCreatedAt": {
+          "name": "recoveryCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kdfVersion": {
+          "name": "kdfVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "migratedAt": {
+          "name": "migratedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userCrypto_userId_user_id_fk": {
+          "name": "userCrypto_userId_user_id_fk",
+          "tableFrom": "userCrypto",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "baseCurrency": {
+          "name": "baseCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journalMain": {
+          "name": "journalMain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main.ledger'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSetting_userId_user_id_fk": {
+          "name": "userSetting_userId_user_id_fk",
+          "tableFrom": "userSetting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782504971594,
       "tag": "0008_lowly_zarek",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1782513743588,
+      "tag": "0009_odd_sunfire",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -13,6 +13,7 @@ export {
   encryptionResetChallenge,
   type EncryptionResetChallenge,
 } from './encryptionResetChallenge';
+export { manualPrice, type ManualPrice } from './manualPrice';
 export { priceFetchRun, type PriceFetchRun } from './priceFetchRun';
 export { savedView, type SavedView } from './savedView';
 export { template, type Template } from './template';

--- a/db/schema/manualPrice.ts
+++ b/db/schema/manualPrice.ts
@@ -1,0 +1,37 @@
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import {
+  pgTable,
+  real,
+  serial,
+  text,
+  timestamp,
+  unique,
+} from 'drizzle-orm/pg-core';
+
+export const manualPrice = pgTable(
+  'manual_price',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    symbol: text('symbol').notNull(),
+    quote: text('quote').notNull(),
+    price: real('price').notNull(),
+    pricedAt: timestamp('priced_at').notNull(),
+    createdAt: timestamp('created_at')
+      .notNull()
+      .default(sql`now()`),
+  },
+  (t) => [
+    unique('manual_price_unique_per_instant').on(
+      t.userId,
+      t.symbol,
+      t.quote,
+      t.pricedAt
+    ),
+  ]
+);
+
+export type ManualPrice = typeof manualPrice.$inferSelect;

--- a/docs/superpowers/plans/2026-06-27-manual-price-records.md
+++ b/docs/superpowers/plans/2026-06-27-manual-price-records.md
@@ -1,0 +1,1224 @@
+# Manual Price Records Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user record manual, dated exchange rates for one or more commodities (e.g. KIRT = 0.0000033 USD) on a top-level `/prices` page, merged into the regenerated `price-db.ledger` so ledger conversions and historical valuation work.
+
+**Architecture:** A new per-user `manual_price` table holds dated rates. A `ManualPriceRepository` does CRUD; `PriceService` gains add/list/delete methods and merges manual rows into `regenerateUserPriceDb`. Two one-action-per-file server actions back a batch form + history list on `/prices`. Manual rows render through the existing `formatLedgerDateTime` so the merged price-db is uniform.
+
+**Tech Stack:** Next.js (App Router, RSC + server actions), Drizzle ORM + Postgres, Zod, Vitest, React `useActionState`, existing `Combobox` UI component.
+
+## Global Constraints
+
+- Symbols and quote currencies are normalized via `normalizeCommoditySymbol` (`lib/prices/symbols.ts`): trims, strips quotes, `$`→`USD`, alphanumeric-only, uppercased; returns `null` for invalid input.
+- All price timestamps are **UTC**. `formatLedgerDateTime` (`utils/formatDate.ts`) emits `YYYY/MM/DD HH:MM:SS` in UTC.
+- Blank time → `pricedAt` is end-of-day `23:59:59Z`; provided time `HH:MM` → `HH:MM:00Z`.
+- `price` must be a finite number `> 0`. Column type is `real` (matches `commodity_price`).
+- Conflict resolution is "later timestamp wins" (ledger-native). On identical timestamps, manual rows are written **after** fetched rows in the file so ledger uses the manual one.
+- One action per file under `features/prices/actions/`. Each mutating action: `requireUser()` → `rateLimit(WRITE, user.id)` → validate → service call → `auditService.record(...)` → `revalidatePath('/prices')`.
+- Follow the Repository + Service split: repositories do DB I/O only; business logic (normalization, timestamp building, regeneration) lives in `PriceService`.
+- Tests use Vitest with the real test Postgres via `setupTestDb`/`teardownTestDb` from `@/lib/test-utils/db`.
+- Never commit with a `Co-Authored-By: Claude` trailer or any Claude/Anthropic attribution line.
+
+---
+
+### Task 1: `manual_price` table + migration
+
+**Files:**
+- Create: `db/schema/manualPrice.ts`
+- Modify: `db/schema/index.ts`
+- Create (generated): `db/migrations/00NN_*.sql`
+
+**Interfaces:**
+- Produces: `manualPrice` Drizzle table; `type ManualPrice = typeof manualPrice.$inferSelect` with fields `{ id: number; userId: string; symbol: string; quote: string; price: number; pricedAt: Date; createdAt: Date }`.
+
+- [ ] **Step 1: Write the schema file**
+
+Create `db/schema/manualPrice.ts`:
+
+```ts
+import { sql } from 'drizzle-orm';
+import { user } from '@naeemba/next-starter/schema';
+import {
+  pgTable,
+  real,
+  serial,
+  text,
+  timestamp,
+  unique,
+} from 'drizzle-orm/pg-core';
+
+export const manualPrice = pgTable(
+  'manual_price',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    symbol: text('symbol').notNull(),
+    quote: text('quote').notNull(),
+    price: real('price').notNull(),
+    pricedAt: timestamp('priced_at').notNull(),
+    createdAt: timestamp('created_at')
+      .notNull()
+      .default(sql`now()`),
+  },
+  (t) => [
+    unique('manual_price_unique_per_instant').on(
+      t.userId,
+      t.symbol,
+      t.quote,
+      t.pricedAt
+    ),
+  ]
+);
+
+export type ManualPrice = typeof manualPrice.$inferSelect;
+```
+
+- [ ] **Step 2: Export it from the schema barrel**
+
+In `db/schema/index.ts`, add this line in alphabetical position (after the `auditLog` export):
+
+```ts
+export { manualPrice, type ManualPrice } from './manualPrice';
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run: `pnpm db:generate`
+Expected: a new file `db/migrations/00NN_*.sql` containing `CREATE TABLE "manual_price"` with the unique constraint, plus an updated `db/migrations/meta/` journal.
+
+- [ ] **Step 4: Apply and verify the migration**
+
+Run: `pnpm db:migrate`
+Expected: applies cleanly. Then run `pnpm type-check`
+Expected: PASS (no type errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/schema/manualPrice.ts db/schema/index.ts db/migrations
+git commit -m "feat(prices): add manual_price table"
+```
+
+---
+
+### Task 2: `ManualPriceRepository`
+
+**Files:**
+- Create: `lib/prices/manualRepository.ts`
+- Test: `lib/prices/manualRepository.test.ts`
+
+**Interfaces:**
+- Consumes: `manualPrice`, `ManualPrice` (Task 1); `DbInstance` from `@/lib/db/connection`.
+- Produces:
+  - `type ManualPriceInput = { userId: string; symbol: string; quote: string; price: number; pricedAt: Date }`
+  - `class ManualPriceRepository`:
+    - `upsertMany(rows: ManualPriceInput[]): Promise<void>`
+    - `listForUser(userId: string): Promise<ManualPrice[]>` — newest `pricedAt` first
+    - `deleteForUser(userId: string, id: number): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/prices/manualRepository.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ManualPriceRepository } from './manualRepository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('ManualPriceRepository', () => {
+  let ctx: TestDbContext;
+  let repo: ManualPriceRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('manual-price-');
+    await ctx.insertUser('alice', 'alice', 'alice@example.com');
+    repo = new ManualPriceRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('inserts and lists rows newest-first', async () => {
+    await repo.upsertMany([
+      {
+        userId: 'alice',
+        symbol: 'KIRT',
+        quote: 'USD',
+        price: 0.0000033,
+        pricedAt: new Date('2026-01-01T23:59:59Z'),
+      },
+      {
+        userId: 'alice',
+        symbol: 'KIRT',
+        quote: 'USD',
+        price: 0.0000040,
+        pricedAt: new Date('2026-06-27T23:59:59Z'),
+      },
+    ]);
+    const rows = await repo.listForUser('alice');
+    expect(rows.map((r) => r.pricedAt.toISOString())).toEqual([
+      '2026-06-27T23:59:59.000Z',
+      '2026-01-01T23:59:59.000Z',
+    ]);
+  });
+
+  it('upserts on (userId, symbol, quote, pricedAt) conflict', async () => {
+    const at = new Date('2026-06-27T23:59:59Z');
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 1, pricedAt: at },
+    ]);
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 2, pricedAt: at },
+    ]);
+    const rows = await repo.listForUser('alice');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].price).toBe(2);
+  });
+
+  it('collapses duplicate conflict keys within one batch (last-wins)', async () => {
+    const at = new Date('2026-06-27T23:59:59Z');
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 1, pricedAt: at },
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 5, pricedAt: at },
+    ]);
+    const rows = await repo.listForUser('alice');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].price).toBe(5);
+  });
+
+  it('deleteForUser removes only the owner row', async () => {
+    await ctx.insertUser('bob', 'bob', 'bob@example.com');
+    const at = new Date('2026-06-27T23:59:59Z');
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 1, pricedAt: at },
+      { userId: 'bob', symbol: 'KIRT', quote: 'USD', price: 2, pricedAt: at },
+    ]);
+    const aliceRow = (await repo.listForUser('alice'))[0];
+    await repo.deleteForUser('bob', aliceRow.id); // wrong owner → no-op
+    expect(await repo.listForUser('alice')).toHaveLength(1);
+    await repo.deleteForUser('alice', aliceRow.id);
+    expect(await repo.listForUser('alice')).toHaveLength(0);
+    expect(await repo.listForUser('bob')).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test lib/prices/manualRepository.test.ts`
+Expected: FAIL — `Cannot find module './manualRepository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `lib/prices/manualRepository.ts`:
+
+```ts
+import { and, desc, eq, sql } from 'drizzle-orm';
+import { manualPrice, type ManualPrice } from '@/db/schema';
+import type { DbInstance } from '@/lib/db/connection';
+
+export type ManualPriceInput = {
+  userId: string;
+  symbol: string;
+  quote: string;
+  price: number;
+  pricedAt: Date;
+};
+
+export class ManualPriceRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  /** Upsert rows by (userId, symbol, quote, pricedAt) in a single statement. */
+  async upsertMany(rows: ManualPriceInput[]): Promise<void> {
+    if (rows.length === 0) return;
+    // Collapse duplicate conflict keys before the batched upsert: a single
+    // ON CONFLICT DO UPDATE that targets the same row twice throws Postgres
+    // 21000. Last-wins matches the upsert's intent.
+    const deduped = [
+      ...new Map(
+        rows.map((r) => [
+          `${r.userId}|${r.symbol}|${r.quote}|${r.pricedAt.toISOString()}`,
+          r,
+        ])
+      ).values(),
+    ];
+    await this.db
+      .insert(manualPrice)
+      .values(deduped)
+      .onConflictDoUpdate({
+        target: [
+          manualPrice.userId,
+          manualPrice.symbol,
+          manualPrice.quote,
+          manualPrice.pricedAt,
+        ],
+        set: { price: sql`excluded.price` },
+      });
+  }
+
+  async listForUser(userId: string): Promise<ManualPrice[]> {
+    return this.db
+      .select()
+      .from(manualPrice)
+      .where(eq(manualPrice.userId, userId))
+      .orderBy(desc(manualPrice.pricedAt), desc(manualPrice.id));
+  }
+
+  async deleteForUser(userId: string, id: number): Promise<void> {
+    await this.db
+      .delete(manualPrice)
+      .where(and(eq(manualPrice.userId, userId), eq(manualPrice.id, id)));
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test lib/prices/manualRepository.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/prices/manualRepository.ts lib/prices/manualRepository.test.ts
+git commit -m "feat(prices): ManualPriceRepository CRUD"
+```
+
+---
+
+### Task 3: Validation schema + timestamp builder
+
+**Files:**
+- Create: `lib/prices/manualSchema.ts`
+- Test: `lib/prices/manualSchema.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `manualPriceDraftSchema` (Zod) validating `{ date: string; time?: string; quote: string; rows: { symbol: string; price: number }[] }`.
+  - `type ManualPriceDraft = z.infer<typeof manualPriceDraftSchema>`.
+  - `buildPricedAt(date: string, time?: string): Date | null` — UTC instant; blank time → `23:59:59Z`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/prices/manualSchema.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { manualPriceDraftSchema, buildPricedAt } from './manualSchema';
+
+describe('manualPriceDraftSchema', () => {
+  const valid = {
+    date: '2026-06-27',
+    quote: 'USD',
+    rows: [{ symbol: 'KIRT', price: 0.0000033 }],
+  };
+
+  it('accepts a well-formed draft', () => {
+    expect(manualPriceDraftSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects a malformed date', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, date: '27/06/2026' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a non-positive price', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({
+        ...valid,
+        rows: [{ symbol: 'KIRT', price: 0 }],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects an empty rows array', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, rows: [] }).success
+    ).toBe(false);
+  });
+
+  it('rejects a bad time format', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, time: '9am' }).success
+    ).toBe(false);
+  });
+
+  it('allows an empty-string time (means "no time")', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, time: '' }).success
+    ).toBe(true);
+  });
+});
+
+describe('buildPricedAt', () => {
+  it('defaults blank time to end-of-day UTC', () => {
+    expect(buildPricedAt('2026-06-27')?.toISOString()).toBe(
+      '2026-06-27T23:59:59.000Z'
+    );
+    expect(buildPricedAt('2026-06-27', '')?.toISOString()).toBe(
+      '2026-06-27T23:59:59.000Z'
+    );
+  });
+
+  it('uses an explicit time as UTC', () => {
+    expect(buildPricedAt('2026-06-27', '14:30')?.toISOString()).toBe(
+      '2026-06-27T14:30:00.000Z'
+    );
+  });
+
+  it('returns null for an unparseable date', () => {
+    expect(buildPricedAt('2026-13-40')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test lib/prices/manualSchema.test.ts`
+Expected: FAIL — `Cannot find module './manualSchema'`.
+
+- [ ] **Step 3: Write the schema + builder**
+
+Create `lib/prices/manualSchema.ts`:
+
+```ts
+import { z } from 'zod';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_RE = /^\d{2}:\d{2}$/;
+
+export const manualPriceDraftSchema = z.object({
+  date: z.string().regex(DATE_RE, 'Date must be YYYY-MM-DD'),
+  time: z
+    .union([z.string().regex(TIME_RE, 'Time must be HH:MM'), z.literal('')])
+    .optional(),
+  quote: z.string().min(1, 'Quote currency is required'),
+  rows: z
+    .array(
+      z.object({
+        symbol: z.string().min(1),
+        price: z.number().finite().positive(),
+      })
+    )
+    .min(1, 'Add at least one price'),
+});
+
+export type ManualPriceDraft = z.infer<typeof manualPriceDraftSchema>;
+
+/**
+ * Build the UTC instant a manual rate applies to. Blank time → end-of-day
+ * (23:59:59Z) so a date-only rate is authoritative for the whole calendar day
+ * and beats any intraday fetched rate. Returns null if the result is invalid.
+ */
+export const buildPricedAt = (date: string, time?: string): Date | null => {
+  const t = time && time.length > 0 ? `${time}:00` : '23:59:59';
+  const d = new Date(`${date}T${t}Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test lib/prices/manualSchema.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/prices/manualSchema.ts lib/prices/manualSchema.test.ts
+git commit -m "feat(prices): manual price draft schema + pricedAt builder"
+```
+
+---
+
+### Task 4: `PriceService` manual-price methods + regeneration merge + DI
+
+**Files:**
+- Modify: `lib/prices/service.ts`
+- Modify: `lib/prices/index.ts`
+- Test: `lib/prices/service.test.ts` (add a new `describe` block)
+
+**Interfaces:**
+- Consumes: `ManualPriceRepository`, `ManualPriceInput` (Task 2); `ManualPriceDraft`, `buildPricedAt` (Task 3); `normalizeCommoditySymbol`; existing `renderPriceDb` + `CommodityPriceRow`.
+- Produces, on `PriceService`:
+  - `addManualPrices(userId: string, draft: ManualPriceDraft): Promise<{ ok: true } | { ok: false; formError: string }>`
+  - `listManualPrices(userId: string): Promise<ManualPrice[]>`
+  - `deleteManualPrice(userId: string, id: number): Promise<void>`
+  - `getBaseCurrency(userId: string): Promise<string>` (public)
+  - `listCommoditiesForUser(userId: string): Promise<string[]>` (public)
+- `Deps` gains `manualRepo: ManualPriceRepository`. `priceService` singleton wires it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/prices/service.test.ts` (add the import at the top alongside the existing ones, then the new describe block at the end of the file):
+
+```ts
+// add near the other imports
+import { ManualPriceRepository } from './manualRepository';
+```
+
+```ts
+describe('PriceService manual prices', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  const make = () =>
+    new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+    });
+
+  beforeEach(async () => {
+    __resetPriceLockForTests();
+    ctx = await setupTestDb('prices-manual-svc-');
+    service = make();
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.restoreAllMocks();
+  });
+
+  const readPriceDb = async (userId: string) =>
+    fs.readFile(
+      path.join(getJournalDir(userId), 'price-db.ledger'),
+      'utf-8'
+    );
+
+  it('emits a never-transacted manual symbol into price-db', async () => {
+    await seedUser(ctx, 'alice', '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n', 'USD');
+    const result = await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'KIRT', price: 0.0000033 }],
+    });
+    expect(result).toEqual({ ok: true });
+    const file = await readPriceDb('alice');
+    expect(file).toContain('KIRT');
+    expect(file).toContain('0.0000033');
+    expect(file).toContain('2026/06/27 23:59:59');
+  });
+
+  it('normalizes $ to USD and rejects pricing a symbol in itself', async () => {
+    await seedUser(ctx, 'alice', '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n', 'USD');
+    const ok = await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: '$',
+      rows: [{ symbol: 'kirt', price: 2 }],
+    });
+    expect(ok).toEqual({ ok: true });
+    expect(await readPriceDb('alice')).toContain('KIRT 2 USD');
+
+    const bad = await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'USD', price: 2 }],
+    });
+    expect(bad.ok).toBe(false);
+  });
+
+  it('manual rate beats a same-day fetched rate via end-of-day ordering', async () => {
+    await seedUser(ctx, 'alice', '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n', 'USD');
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'BTC',
+        quote: 'USD',
+        price: 60000,
+        fetchedAt: new Date('2026-06-27T12:00:00Z'),
+        fetchedDate: '2026-06-27',
+      },
+    ]);
+    await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'BTC', price: 65000 }],
+    });
+    const file = await readPriceDb('alice');
+    // both lines present; the 23:59:59 manual line sorts after the 12:00:00 one
+    const idxFetched = file.indexOf('60000');
+    const idxManual = file.indexOf('65000');
+    expect(idxFetched).toBeGreaterThanOrEqual(0);
+    expect(idxManual).toBeGreaterThan(idxFetched);
+  });
+
+  it('deleteManualPrice removes the row and regenerates without it', async () => {
+    await seedUser(ctx, 'alice', '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n', 'USD');
+    await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'KIRT', price: 3 }],
+    });
+    const row = (await service.listManualPrices('alice'))[0];
+    await service.deleteManualPrice('alice', row.id);
+    expect(await service.listManualPrices('alice')).toHaveLength(0);
+    expect(await readPriceDb('alice')).not.toContain('KIRT');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test lib/prices/service.test.ts`
+Expected: FAIL — `manualRepo` missing from `Deps` / `addManualPrices is not a function`.
+
+- [ ] **Step 3: Add the import and `Deps` field in `service.ts`**
+
+In `lib/prices/service.ts`, add to the imports:
+
+```ts
+import { buildPricedAt, type ManualPriceDraft } from './manualSchema';
+import type { ManualPriceRepository } from './manualRepository';
+import type { CommodityPriceRow } from './formatter';
+import type { ManualPrice } from '@/db/schema';
+```
+
+Add the field to the `Deps` type:
+
+```ts
+type Deps = {
+  db: DbInstance;
+  commodityRepo: CommodityPriceRepository;
+  runRepo: PriceFetchRunRepository;
+  journalRepo: JournalRepository;
+  manualRepo: ManualPriceRepository;
+};
+```
+
+- [ ] **Step 4: Merge manual rows into `regenerateUserPriceDb`**
+
+Replace the body of `regenerateUserPriceDb` (currently lines ~59-76) with:
+
+```ts
+  async regenerateUserPriceDb(userId: string): Promise<void> {
+    const layout = await this.deps.journalRepo.ensureLayout(userId);
+    const base = await this.resolveBaseCurrency(userId);
+    const all = await this.deps.commodityRepo.listForQuote(base);
+    const userSymbols = new Set(
+      await this.listNormalizedSymbolsForUser(userId)
+    );
+    const fetched = all.filter((r) => userSymbols.has(r.symbol));
+    const manual = await this.deps.manualRepo.listForUser(userId);
+    const manualRows: CommodityPriceRow[] = manual.map((m) => ({
+      symbol: m.symbol,
+      quote: m.quote,
+      price: m.price,
+      fetchedAt: m.pricedAt,
+      fetchedDate: utcDate(m.pricedAt),
+    }));
+    // Concatenate fetched-first, then stable-sort by instant: equal timestamps
+    // keep fetched before manual, so manual ends up later in the file and wins.
+    const merged = [...fetched, ...manualRows].sort(
+      (a, b) => a.fetchedAt.getTime() - b.fetchedAt.getTime()
+    );
+    const body = renderPriceDb(merged);
+    const target = path.join(layout.dir, PRICE_DB_NAME);
+    await this.deps.journalRepo.writeFileAtomic(target, body);
+    try {
+      revalidateTag(getJournalCacheTag(userId), 'max');
+    } catch {
+      // revalidateTag throws outside a Next.js request context (cron, tests).
+      // Acceptable — the cache invalidates on the next request.
+    }
+  }
+```
+
+- [ ] **Step 5: Make the two helper methods public**
+
+In `service.ts`, change `private async resolveBaseCurrency` to `async resolveBaseCurrency` and `private async listNormalizedSymbolsForUser` to `async listNormalizedSymbolsForUser` (drop only the `private` keyword on each).
+
+- [ ] **Step 6: Add the manual-price methods**
+
+Add these methods to the `PriceService` class (e.g. after `regenerateUserPriceDb`):
+
+```ts
+  async addManualPrices(
+    userId: string,
+    draft: ManualPriceDraft
+  ): Promise<{ ok: true } | { ok: false; formError: string }> {
+    const quote = normalizeCommoditySymbol(draft.quote);
+    if (!quote) return { ok: false, formError: 'Invalid quote currency' };
+    const pricedAt = buildPricedAt(draft.date, draft.time);
+    if (!pricedAt) return { ok: false, formError: 'Invalid date or time' };
+
+    const byKey = new Map<
+      string,
+      { userId: string; symbol: string; quote: string; price: number; pricedAt: Date }
+    >();
+    for (const row of draft.rows) {
+      const symbol = normalizeCommoditySymbol(row.symbol);
+      if (!symbol) {
+        return { ok: false, formError: `Invalid commodity: ${row.symbol}` };
+      }
+      if (symbol === quote) {
+        return { ok: false, formError: `Cannot price ${symbol} in itself` };
+      }
+      byKey.set(symbol, { userId, symbol, quote, price: row.price, pricedAt });
+    }
+
+    await this.deps.manualRepo.upsertMany([...byKey.values()]);
+    await this.regenerateUserPriceDb(userId);
+    return { ok: true };
+  }
+
+  async listManualPrices(userId: string): Promise<ManualPrice[]> {
+    return this.deps.manualRepo.listForUser(userId);
+  }
+
+  async deleteManualPrice(userId: string, id: number): Promise<void> {
+    await this.deps.manualRepo.deleteForUser(userId, id);
+    await this.regenerateUserPriceDb(userId);
+  }
+
+  async getBaseCurrency(userId: string): Promise<string> {
+    return this.resolveBaseCurrency(userId);
+  }
+
+  async listCommoditiesForUser(userId: string): Promise<string[]> {
+    return this.listNormalizedSymbolsForUser(userId);
+  }
+```
+
+- [ ] **Step 7: Wire the dependency in the singleton**
+
+In `lib/prices/index.ts`, add the import and repository, and pass it into the service:
+
+```ts
+import { ManualPriceRepository } from './manualRepository';
+```
+
+```ts
+export const manualPriceRepository = new ManualPriceRepository(db);
+export const priceService = new PriceService({
+  db,
+  commodityRepo: commodityPriceRepository,
+  runRepo: priceFetchRunRepository,
+  journalRepo: journalRepository,
+  manualRepo: manualPriceRepository,
+});
+```
+
+Also add a re-export near the others:
+
+```ts
+export { ManualPriceRepository } from './manualRepository';
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `pnpm test lib/prices/service.test.ts`
+Expected: PASS — existing `refreshAll` tests plus the 4 new manual-price tests.
+
+- [ ] **Step 9: Run the full prices suite + type-check**
+
+Run: `pnpm test lib/prices && pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/prices/service.ts lib/prices/index.ts lib/prices/service.test.ts
+git commit -m "feat(prices): add manual price service methods + merge into price-db"
+```
+
+---
+
+### Task 5: Server actions + audit actions
+
+**Files:**
+- Modify: `lib/audit/schema.ts`
+- Create: `features/prices/actions/types.ts`
+- Create: `features/prices/actions/addManualPrices.ts`
+- Create: `features/prices/actions/deleteManualPrice.ts`
+- Create: `features/prices/actions/index.ts`
+
+**Interfaces:**
+- Consumes: `priceService` (Task 4); `manualPriceDraftSchema` (Task 3); `requireUser`, `rateLimit`/`WRITE`/`RATE_LIMIT_MESSAGE`, `auditService`/`auditRequestMeta`, `revalidatePath`.
+- Produces:
+  - `type PriceActionState = { ok: boolean; formError?: string }`
+  - `addManualPricesAction(prev: PriceActionState | null, formData: FormData): Promise<PriceActionState>`
+  - `deleteManualPriceAction(formData: FormData): Promise<void>`
+
+- [ ] **Step 1: Add the audit actions**
+
+In `lib/audit/schema.ts`, add two entries to the `AUDIT_ACTIONS` array (after `'journal.import'`):
+
+```ts
+  'price.add',
+  'price.delete',
+```
+
+(Without this, `auditEventSchema` would silently drop the events — actions are validated against this enum.)
+
+- [ ] **Step 2: Write the action-state type**
+
+Create `features/prices/actions/types.ts`:
+
+```ts
+export type PriceActionState = {
+  ok: boolean;
+  formError?: string;
+};
+```
+
+- [ ] **Step 3: Write the add action**
+
+Create `features/prices/actions/addManualPrices.ts`:
+
+```ts
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import type { PriceActionState } from './types';
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { manualPriceDraftSchema } from '@/lib/prices/manualSchema';
+import { priceService } from '@/lib/prices';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+
+export async function addManualPricesAction(
+  _prev: PriceActionState | null,
+  formData: FormData
+): Promise<PriceActionState> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, formError: RATE_LIMIT_MESSAGE };
+  }
+
+  const draftJson = formData.get('draft');
+  if (typeof draftJson !== 'string') {
+    return { ok: false, formError: 'Missing price payload' };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(draftJson);
+  } catch {
+    return { ok: false, formError: 'Price payload is not valid JSON' };
+  }
+
+  const parsed = manualPriceDraftSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    return { ok: false, formError: 'Please fix the highlighted fields' };
+  }
+
+  const result = await priceService.addManualPrices(user.id, parsed.data);
+  await auditService.record(user.id, {
+    action: 'price.add',
+    result: result.ok ? 'success' : 'failure',
+    detail: result.ok ? { count: parsed.data.rows.length } : undefined,
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) return { ok: false, formError: result.formError };
+
+  revalidatePath('/prices');
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: Write the delete action**
+
+Create `features/prices/actions/deleteManualPrice.ts`:
+
+```ts
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+import { rateLimit, WRITE } from '@/lib/rate-limit';
+
+export async function deleteManualPriceAction(
+  formData: FormData
+): Promise<void> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) return;
+
+  const raw = formData.get('id');
+  const id = typeof raw === 'string' ? Number(raw) : NaN;
+  if (!Number.isInteger(id) || id <= 0) return;
+
+  await priceService.deleteManualPrice(user.id, id);
+  await auditService.record(user.id, {
+    action: 'price.delete',
+    result: 'success',
+    ...(await auditRequestMeta()),
+  });
+  revalidatePath('/prices');
+}
+```
+
+- [ ] **Step 5: Write the barrel**
+
+Create `features/prices/actions/index.ts`:
+
+```ts
+export { addManualPricesAction } from './addManualPrices';
+export { deleteManualPriceAction } from './deleteManualPrice';
+export type { PriceActionState } from './types';
+```
+
+- [ ] **Step 6: Verify type-check + lint**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: PASS (no type errors, no lint errors). The action logic is covered by the service tests in Task 4; these are thin wrappers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/audit/schema.ts features/prices/actions
+git commit -m "feat(prices): add/delete manual price server actions"
+```
+
+---
+
+### Task 6: `/prices` page + `PricesView`
+
+**Files:**
+- Create: `app/prices/page.tsx`
+- Create: `features/prices/PricesView.tsx`
+- Create: `features/prices/index.ts`
+
+**Interfaces:**
+- Consumes: `priceService` (`listManualPrices`, `listCommoditiesForUser`, `getBaseCurrency`); `requireUser`; `ManualPrice`; the action barrel (Task 5); `Combobox`; `formatLedgerDateTime`.
+- Produces: a server page that loads data and renders `<PricesView prices commodities baseCurrency />`.
+
+- [ ] **Step 1: Write the page shell**
+
+Create `app/prices/page.tsx`:
+
+```tsx
+import { PricesView } from '@/features/prices';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+
+export const dynamic = 'force-dynamic';
+
+const PricesPage = async () => {
+  const user = await requireUser();
+  const [prices, commodities, baseCurrency] = await Promise.all([
+    priceService.listManualPrices(user.id),
+    priceService.listCommoditiesForUser(user.id),
+    priceService.getBaseCurrency(user.id),
+  ]);
+
+  return (
+    <PricesView
+      prices={prices}
+      commodities={commodities}
+      baseCurrency={baseCurrency}
+    />
+  );
+};
+
+export default PricesPage;
+```
+
+- [ ] **Step 2: Write the client view**
+
+Create `features/prices/PricesView.tsx`:
+
+```tsx
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useActionState, useState } from 'react';
+import Combobox from '@/components/Combobox/Combobox';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ManualPrice } from '@/db/schema';
+import {
+  addManualPricesAction,
+  deleteManualPriceAction,
+  type PriceActionState,
+} from '@/features/prices/actions';
+import { formatLedgerDateTime } from '@/utils/formatDate';
+
+type Row = { symbol: string; price: string };
+
+type Props = {
+  prices: ManualPrice[];
+  commodities: string[];
+  baseCurrency: string;
+};
+
+const todayUtc = () => new Date().toISOString().slice(0, 10);
+
+export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
+  const [state, formAction, isPending] = useActionState<
+    PriceActionState,
+    FormData
+  >(addManualPricesAction, { ok: false });
+
+  const [date, setDate] = useState(todayUtc());
+  const [time, setTime] = useState('');
+  const [quote, setQuote] = useState(baseCurrency);
+  const [rows, setRows] = useState<Row[]>([{ symbol: '', price: '' }]);
+
+  const updateRow = (i: number, patch: Partial<Row>) =>
+    setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+  const addRow = () => setRows((rs) => [...rs, { symbol: '', price: '' }]);
+  const removeRow = (i: number) =>
+    setRows((rs) => (rs.length > 1 ? rs.filter((_, j) => j !== i) : rs));
+
+  const draft = JSON.stringify({
+    date,
+    time: time || undefined,
+    quote,
+    rows: rows
+      .filter((r) => r.symbol.trim() && r.price.trim())
+      .map((r) => ({ symbol: r.symbol.trim(), price: Number(r.price) })),
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-8 p-4">
+      <header>
+        <h1 className="text-2xl font-semibold">Prices</h1>
+        <p className="text-muted-foreground text-sm">
+          Record exchange rates for commodities (e.g. KIRT) your price provider
+          doesn&apos;t cover. Each rate is dated, so historical reports use the
+          rate in effect at the time.
+        </p>
+      </header>
+
+      <form action={formAction} className="space-y-4 rounded-lg border p-4">
+        <input type="hidden" name="draft" value={draft} />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="space-y-1">
+            <Label htmlFor="price-date">Date</Label>
+            <Input
+              id="price-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="price-time">Time (optional)</Label>
+            <Input
+              id="price-time"
+              type="time"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Quote currency</Label>
+            <Combobox
+              value={quote}
+              onChange={setQuote}
+              options={commodities}
+              placeholder="USD"
+              allowFreeText
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {rows.map((row, i) => (
+            <div key={i} className="flex items-end gap-2">
+              <div className="flex-1 space-y-1">
+                {i === 0 && <Label>Commodity</Label>}
+                <Combobox
+                  value={row.symbol}
+                  onChange={(v) => updateRow(i, { symbol: v })}
+                  options={commodities}
+                  placeholder="KIRT"
+                  allowFreeText
+                />
+              </div>
+              <div className="flex-1 space-y-1">
+                {i === 0 && <Label htmlFor={`price-${i}`}>Rate</Label>}
+                <Input
+                  id={`price-${i}`}
+                  type="number"
+                  step="any"
+                  min="0"
+                  inputMode="decimal"
+                  value={row.price}
+                  onChange={(e) => updateRow(i, { price: e.target.value })}
+                  placeholder="0.0000033"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove row"
+                onClick={() => removeRow(i)}
+                disabled={rows.length === 1}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Button type="button" variant="outline" size="sm" onClick={addRow}>
+            Add another commodity
+          </Button>
+        </div>
+
+        {state.formError && (
+          <p className="text-destructive text-sm">{state.formError}</p>
+        )}
+        {state.ok && (
+          <p className="text-sm text-green-600">Prices saved.</p>
+        )}
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? 'Saving…' : 'Save prices'}
+        </Button>
+      </form>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">History</h2>
+        {prices.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No manual prices yet.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-muted-foreground text-left">
+                <th className="py-1">When</th>
+                <th>Commodity</th>
+                <th className="text-right">Rate</th>
+                <th>Quote</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {prices.map((p) => (
+                <tr key={p.id} className="border-t">
+                  <td className="py-1">
+                    {formatLedgerDateTime(new Date(p.pricedAt))}
+                  </td>
+                  <td>{p.symbol}</td>
+                  <td className="text-right tabular-nums">{p.price}</td>
+                  <td>{p.quote}</td>
+                  <td className="text-right">
+                    <form action={deleteManualPriceAction}>
+                      <input type="hidden" name="id" value={p.id} />
+                      <Button
+                        type="submit"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${p.symbol} rate`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </form>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Write the feature barrel**
+
+Create `features/prices/index.ts`:
+
+```ts
+export { PricesView } from './PricesView';
+```
+
+- [ ] **Step 4: Verify imports exist**
+
+Confirm `@/components/ui/input`, `@/components/ui/label`, and `@/components/ui/button` exist (they are referenced by existing forms). Then run `pnpm type-check`.
+Expected: PASS. (If `Combobox` is a default export — it is — the `import Combobox from '@/components/Combobox/Combobox'` form is correct.)
+
+- [ ] **Step 5: Run lint + build the route**
+
+Run: `pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/prices features/prices/PricesView.tsx features/prices/index.ts
+git commit -m "feat(prices): /prices page with batch add form + history"
+```
+
+---
+
+### Task 7: Navigation entry
+
+**Files:**
+- Modify: `components/nav/config.ts`
+
+**Interfaces:**
+- Consumes: the `/prices` route (Task 6); `getNavSections()` structure.
+
+- [ ] **Step 1: Import the icon**
+
+In `components/nav/config.ts`, add `TrendingUp` to the `lucide-react` import (alphabetical, after `Settings`/before `Users` — keep the existing ordering style):
+
+```ts
+  TrendingUp,
+```
+
+- [ ] **Step 2: Add the nav item**
+
+In the `journal` section's `items` array (after the `import` item, before the section closes), add:
+
+```ts
+        {
+          id: 'prices',
+          title: 'Prices',
+          href: '/prices',
+          match: 'exact',
+          description: 'Record exchange rates for commodities like KIRT.',
+          icon: TrendingUp,
+          keywords: ['exchange', 'rate', 'commodity', 'currency', 'price'],
+        },
+```
+
+- [ ] **Step 3: Verify type-check**
+
+Run: `pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/nav/config.ts
+git commit -m "feat(prices): add Prices nav item"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full prices test suite:** `pnpm test lib/prices`
+- [ ] **Type-check the whole project:** `pnpm type-check`
+- [ ] **Lint:** `pnpm lint`
+- [ ] **Manual smoke test** (`pnpm dev`): navigate to `/prices`, add a KIRT→USD rate with a blank time, confirm it appears in History, confirm `data/journals/<userId>/price-db.ledger` contains `P <today> 23:59:59 KIRT <rate> USD`, then delete it and confirm it's gone from both the list and the file.
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** per-user table (T1), repository CRUD (T2), Zod validation + end-of-day default (T3), service add/list/delete + merge-into-price-db + always-emit-manual + manual-wins ordering (T4), one-action-per-file with auth/rate-limit/audit (T5), top-level `/prices` page with batch form + autocomplete-allow-new + history+delete (T6), nav entry (T7). All spec sections map to a task.
+- **Audit gap closed:** `price.add`/`price.delete` added to `AUDIT_ACTIONS` (T5 Step 1) — without it the audit writes would be silently dropped.
+- **Type consistency:** `addManualPrices` returns `{ ok: true } | { ok: false; formError }` everywhere; `PriceActionState` is `{ ok; formError? }`; `deleteManualPriceAction` is `(FormData) => Promise<void>` (plain form action, no `useActionState`); `manualRepo` added to `Deps` and the singleton together.
+- **Out of scope (YAGNI), per spec:** no inline edit, no CSV import, no per-row quote, no new `components/ui` primitives, no new audit *activity-type grouping* (events still recorded and visible under "all").

--- a/docs/superpowers/specs/2026-06-27-manual-price-records-design.md
+++ b/docs/superpowers/specs/2026-06-27-manual-price-records-design.md
@@ -1,0 +1,240 @@
+# Manual price records (`/prices`)
+
+**Status:** Approved design — ready for implementation planning
+**Date:** 2026-06-27
+
+## Problem
+
+The app already fetches commodity rates from external providers (CoinGecko/Yahoo)
+into a global `commodity_price` table, then regenerates an auto-generated
+`price-db.ledger` per user that ledger reads via `--price-db` for `-X`
+conversions. There is **no way to enter a rate by hand**.
+
+That gap matters for commodities no provider knows about. The driving example is
+**KIRT** ("Kilo IRT" = 1000 IRT), a custom unit the user values themselves. There
+is no feed for it, so the only way to make `-X USD` conversions and net-worth
+figures work for KIRT holdings is to enter the rate manually.
+
+Because ledger resolves a commodity's value from **dated `P` directives** — for
+any report date it uses the most recent price on-or-before that date — a history
+of dated manual rates gives true **valuation-over-time**: current net worth uses
+the latest rate, while a historical/as-of-date report uses the rate that was in
+effect then.
+
+## Goals
+
+- Let a user record manual exchange rates for one or more commodities in a single
+  batch, sharing a date (and optional time) and a quote currency.
+- Support brand-new commodity symbols (e.g. KIRT) that may not appear in any
+  transaction yet.
+- Persist rates per-user, build a dated history (never overwrite older dates),
+  and merge them into the regenerated `price-db.ledger` so they immediately power
+  ledger conversions and survive every provider refresh.
+- Surface the history with the ability to delete individual entries.
+
+## Non-goals (YAGNI)
+
+- No inline editing — to change an entry, delete and re-add (re-entering the same
+  instant upserts anyway).
+- No CSV/bulk file import.
+- No per-row quote currency — one shared quote currency per batch.
+- No new shared UI primitives — reuse the existing `Combobox`, `input`, `button`.
+
+## Key concepts confirmed with the user
+
+1. **Valuation-over-time is the point.** Each rate is a separate dated row; we
+   never overwrite an older date. Ledger picks the right rate per report date.
+2. **Ledger `P` directives carry an optional time** (`P DATE [TIME] SYMBOL PRICE
+   QUOTE`). The existing fetched-price formatter already emits full timestamps via
+   `formatLedgerDateTime` → `YYYY/MM/DD HH:MM:SS` (UTC). Manual rates do the same.
+3. **"Later timestamp wins"** for current calculations — which is just how ledger
+   resolves prices, applied automatically. No special-case override rule.
+
+## Data model
+
+New **per-user** table `manual_price` (file: `db/schema/manualPrice.ts`,
+re-exported from `db/schema/index.ts`).
+
+The existing `commodity_price` table is **global** — `BTC = 62500 USD` is the same
+fact for every user, so it has no `userId`. Manual rates are the opposite: a
+user's own valuation of their own unit. They get a separate table rather than
+adding a nullable `userId` + source flag to the shared one, which keeps the
+global table's semantics and unique constraint intact.
+
+```
+manual_price
+  id        serial    primary key
+  userId    text      not null          -- user.id
+  symbol    text      not null          -- normalized, uppercase (e.g. KIRT)
+  quote     text      not null          -- normalized, uppercase (e.g. USD)
+  price     real      not null          -- > 0
+  pricedAt  timestamp not null          -- UTC instant the rate applies to
+  createdAt timestamp not null
+  unique(userId, symbol, quote, pricedAt)
+```
+
+- `real` for `price` matches `commodity_price`.
+- Uniqueness on the full `pricedAt` (not the day) allows **multiple same-day rates
+  at different times** (intraday history); re-entering the **exact same instant**
+  upserts (fixes a typo) without touching other rows.
+- No separate `pricedDate` column — the calendar day is derivable from `pricedAt`.
+
+### Migration
+
+Add the table to `db/schema/manualPrice.ts`, then:
+
+```
+pnpm db:generate   # emits db/migrations/00NN_*.sql
+pnpm db:migrate    # applies it
+```
+
+Commit the generated SQL.
+
+## Time handling
+
+The form collects a calendar **Date** (required) and an optional **Time**, both
+treated as **UTC** (consistent with the codebase's UTC-everywhere price
+convention; `formatLedgerDateTime` formats in UTC).
+
+- **Time provided** → `pricedAt` = that exact `YYYY-MM-DDTHH:MM:00Z`.
+- **Time omitted** → `pricedAt` = **end-of-day** `YYYY-MM-DDT23:59:59Z`. A
+  date-only manual rate is therefore the authoritative price for that whole
+  calendar day and beats any intraday fetched rate on the same day — achieving
+  "manual wins for that day" purely through ordering, with no special-case logic.
+
+## Merge into `price-db.ledger`
+
+`PriceService.regenerateUserPriceDb(userId)` today emits **only fetched** prices
+for the base quote, filtered to commodities the user has transacted. Extend it to
+also emit **all of the user's manual prices, always** — including symbols never
+transacted (the KIRT case) and quotes other than the base currency.
+
+- Build the file from two row sources: existing filtered fetched rows + **all**
+  `manual_price` rows for the user.
+- Render both through `formatLedgerDateTime` so output is uniform:
+  `P 2026/06/27 23:59:59 KIRT 0.0000033 USD`.
+- Ordering: ledger resolves by date/time natively, so no cross-source dedupe is
+  needed. In the unlikely event a manual and a fetched row share the **identical**
+  timestamp for the same symbol+quote, manual lines are written **after** fetched
+  lines so ledger uses the manual one.
+- This runs on every manual mutation and on every provider refresh
+  (`runOnce` already calls `regenerateUserPriceDb` per user), so manual rates
+  survive refreshes automatically.
+
+`renderPriceDb` (in `lib/prices/formatter.ts`) is generalized to accept a list of
+already-timestamped rows (symbol, quote, price, instant) rather than only
+`CommodityPriceRow`, so manual and fetched rows share one render path.
+
+## Backend (Repository + Service + one-action-per-file)
+
+### `ManualPriceRepository` — `lib/prices/manualRepository.ts`
+
+- `upsertMany(rows)` — batched upsert on conflict
+  `(userId, symbol, quote, pricedAt)` set `price`, mirroring
+  `CommodityPriceRepository.insert`'s dedupe-then-batched-upsert approach (collapse
+  duplicate conflict keys before the statement to avoid Postgres 21000).
+- `listForUser(userId)` — all rows, newest `pricedAt` first.
+- `deleteForUser(userId, id)` — delete one row scoped to the owner.
+
+### `PriceService` additions — `lib/prices/service.ts`
+
+- `addManualPrices(userId, { date, time?, quote, rows })` — normalize symbols +
+  quote via `normalizeCommoditySymbol`, build `pricedAt`, `upsertMany`, then
+  `regenerateUserPriceDb`.
+- `listManualPrices(userId)` — delegates to the repository.
+- `deleteManualPrice(userId, id)` — delete then `regenerateUserPriceDb`.
+- Make `listNormalizedSymbolsForUser` **public** (or expose via a thin wrapper) so
+  the page can feed the commodity autocomplete.
+
+Wire `ManualPriceRepository` into the `priceService` singleton in
+`lib/prices/index.ts` (constructed with `db`), and pass it into `PriceService`'s
+deps.
+
+### Server actions — `features/prices/actions/` (one file each)
+
+Both follow the `createTransaction.ts` shape: `requireUser` →
+`rateLimit(WRITE, user.id)` (return `RATE_LIMIT_MESSAGE` if blocked) → parse +
+Zod-validate → service call → `auditService.record(...)` with
+`auditRequestMeta()` → return an action-state object. The page calls
+`revalidatePath('/prices')` / relies on `regenerateUserPriceDb`'s cache tag
+invalidation.
+
+- `addManualPrices.ts` — audit action `price.add`.
+- `deleteManualPrice.ts` — audit action `price.delete`.
+
+### Validation (Zod) — `lib/prices/manualSchema.ts`
+
+- `date`: required, real `YYYY-MM-DD`.
+- `time`: optional `HH:MM` (24h).
+- `quote`: normalizes to a non-empty symbol.
+- `rows`: ≥ 1; each `{ symbol, price }` where `symbol` normalizes non-empty and
+  `price` is finite `> 0`.
+- Reject any row where `symbol === quote` (can't price a thing in itself).
+- Collapse duplicate symbols within one batch (last-wins).
+
+## Frontend
+
+### Route — `app/prices/page.tsx` (thin server shell)
+
+`requireUser` → load `listManualPrices(user.id)`, the commodity list
+(`listNormalizedSymbolsForUser`), and the resolved base currency → render the
+client view. Mirrors `app/settings/activity/page.tsx`.
+
+### `features/prices/PricesView.tsx` (client component)
+
+**Batch add form** (`useActionState` + `addManualPrices` action):
+- Shared **Date** input (`type="date"`, default today).
+- Shared **Time** input (`type="time"`, optional) — applies to all rows.
+- Shared **Quote currency** — `Combobox` over the commodity list,
+  `allowFreeText`, default = base currency.
+- A dynamic list of **rows**, each: **Commodity** `Combobox`
+  (`allowFreeText` so KIRT works) + **Rate** number input. Add-row / remove-row
+  buttons. At least one row.
+- The form serializes `{ date, time, quote, rows }` to a JSON `draft` field
+  (matching the transactions form's `draft` convention).
+
+**History table:**
+- The user's manual rates, newest first: date (+ time when not the end-of-day
+  default), symbol, rate, quote, and a **delete** button per row
+  (`deleteManualPrice` action).
+
+### Navigation — `components/nav/config.ts`
+
+Add a "Prices" nav item (`href: '/prices'`, lucide `TrendingUp`, `match: 'exact'`)
+in a suitable section, rendered by `components/Sidebar/AppSidebar.tsx`.
+
+## Testing
+
+- **Repository:** `upsertMany` inserts and upserts on the
+  `(userId, symbol, quote, pricedAt)` key; `listForUser` ordering and per-user
+  scoping; `deleteForUser` only deletes the owner's row.
+- **Schema:** rejects bad dates/times, non-positive prices, `symbol === quote`;
+  normalizes `$`→`USD` and uppercases; collapses duplicate symbols.
+- **Service:**
+  - `addManualPrices` normalizes, upserts, and regenerates.
+  - Omitted time → `23:59:59Z`; provided time → exact instant.
+  - **Regeneration emits a never-transacted manual symbol** (KIRT) into
+    `price-db.ledger`.
+  - **Same-day manual rate beats a fetched rate** via end-of-day ordering;
+    explicit earlier time orders correctly.
+  - `deleteManualPrice` removes the row and regenerates.
+- **Action:** requires a user, is rate-limited, rejects malformed payloads, and
+  writes an audit record.
+- **Component/integration:** batch form submits multiple rows; history renders and
+  delete works.
+
+## File summary
+
+| Concern | Path |
+|---|---|
+| Table | `db/schema/manualPrice.ts` (+ `db/schema/index.ts`) |
+| Migration | `db/migrations/00NN_*.sql` |
+| Repository | `lib/prices/manualRepository.ts` |
+| Service methods | `lib/prices/service.ts` |
+| Render generalization | `lib/prices/formatter.ts` |
+| DI wiring | `lib/prices/index.ts` |
+| Validation | `lib/prices/manualSchema.ts` |
+| Actions | `features/prices/actions/addManualPrices.ts`, `deleteManualPrice.ts` |
+| Page shell | `app/prices/page.tsx` |
+| View | `features/prices/PricesView.tsx` (+ `features/prices/index.ts`) |
+| Nav | `components/nav/config.ts` |

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -19,5 +19,6 @@ export default defineConfig({
     'price_fetch_run',
     'savedView',
     'encryptionResetChallenge',
+    'manual_price',
   ],
 });

--- a/features/prices/PricesView.tsx
+++ b/features/prices/PricesView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Trash2 } from 'lucide-react';
-import { useActionState, useState } from 'react';
+import { useActionState, useState, useTransition } from 'react';
 import Combobox from '@/components/Combobox/Combobox';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -12,7 +12,7 @@ import {
   deleteManualPriceAction,
   type PriceActionState,
 } from '@/features/prices/actions';
-import { formatLedgerDateTime } from '@/utils/formatDate';
+import { formatLedgerInstant } from '@/utils/formatDate';
 
 type Row = { symbol: string; price: string };
 
@@ -34,6 +34,20 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
   const [time, setTime] = useState('');
   const [quote, setQuote] = useState(baseCurrency);
   const [rows, setRows] = useState<Row[]>([{ symbol: '', price: '' }]);
+
+  const [isDeleting, startDelete] = useTransition();
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleDelete = (id: number) => {
+    setDeleteError(null);
+    setDeletingId(id);
+    startDelete(async () => {
+      const result = await deleteManualPriceAction(id);
+      setDeletingId(null);
+      if (!result.ok) setDeleteError(result.message);
+    });
+  };
 
   const updateRow = (i: number, patch: Partial<Row>) =>
     setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...patch } : r)));
@@ -151,6 +165,9 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
 
       <section className="space-y-2">
         <h2 className="text-lg font-medium">History</h2>
+        {deleteError && (
+          <p className="text-destructive text-sm">{deleteError}</p>
+        )}
         {prices.length === 0 ? (
           <p className="text-muted-foreground text-sm">No manual prices yet.</p>
         ) : (
@@ -168,23 +185,22 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
               {prices.map((p) => (
                 <tr key={p.id} className="border-t">
                   <td className="py-1">
-                    {formatLedgerDateTime(new Date(p.pricedAt))}
+                    {formatLedgerInstant(new Date(p.pricedAt))}
                   </td>
                   <td>{p.symbol}</td>
                   <td className="text-right tabular-nums">{p.price}</td>
                   <td>{p.quote}</td>
                   <td className="text-right">
-                    <form action={deleteManualPriceAction}>
-                      <input type="hidden" name="id" value={p.id} />
-                      <Button
-                        type="submit"
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Delete ${p.symbol} rate`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </form>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Delete ${p.symbol} rate`}
+                      disabled={isDeleting && deletingId === p.id}
+                      onClick={() => handleDelete(p.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   </td>
                 </tr>
               ))}

--- a/features/prices/PricesView.tsx
+++ b/features/prices/PricesView.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useActionState, useState } from 'react';
+import Combobox from '@/components/Combobox/Combobox';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ManualPrice } from '@/db/schema';
+import {
+  addManualPricesAction,
+  deleteManualPriceAction,
+  type PriceActionState,
+} from '@/features/prices/actions';
+import { formatLedgerDateTime } from '@/utils/formatDate';
+
+type Row = { symbol: string; price: string };
+
+type Props = {
+  prices: ManualPrice[];
+  commodities: string[];
+  baseCurrency: string;
+};
+
+const todayUtc = () => new Date().toISOString().slice(0, 10);
+
+export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
+  const [state, formAction, isPending] = useActionState<
+    PriceActionState,
+    FormData
+  >(addManualPricesAction, { ok: false });
+
+  const [date, setDate] = useState(todayUtc());
+  const [time, setTime] = useState('');
+  const [quote, setQuote] = useState(baseCurrency);
+  const [rows, setRows] = useState<Row[]>([{ symbol: '', price: '' }]);
+
+  const updateRow = (i: number, patch: Partial<Row>) =>
+    setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+  const addRow = () => setRows((rs) => [...rs, { symbol: '', price: '' }]);
+  const removeRow = (i: number) =>
+    setRows((rs) => (rs.length > 1 ? rs.filter((_, j) => j !== i) : rs));
+
+  const draft = JSON.stringify({
+    date,
+    time: time || undefined,
+    quote,
+    rows: rows
+      .filter((r) => r.symbol.trim() && r.price.trim())
+      .map((r) => ({ symbol: r.symbol.trim(), price: Number(r.price) })),
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-8 p-4">
+      <header>
+        <h1 className="text-2xl font-semibold">Prices</h1>
+        <p className="text-muted-foreground text-sm">
+          Record exchange rates for commodities (e.g. KIRT) your price provider
+          doesn&apos;t cover. Each rate is dated, so historical reports use the
+          rate in effect at the time.
+        </p>
+      </header>
+
+      <form action={formAction} className="space-y-4 rounded-lg border p-4">
+        <input type="hidden" name="draft" value={draft} />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="space-y-1">
+            <Label htmlFor="price-date">Date</Label>
+            <Input
+              id="price-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="price-time">Time (optional)</Label>
+            <Input
+              id="price-time"
+              type="time"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Quote currency</Label>
+            <Combobox
+              value={quote}
+              onChange={setQuote}
+              options={commodities}
+              placeholder="USD"
+              allowFreeText
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {rows.map((row, i) => (
+            <div key={i} className="flex items-end gap-2">
+              <div className="flex-1 space-y-1">
+                {i === 0 && <Label>Commodity</Label>}
+                <Combobox
+                  value={row.symbol}
+                  onChange={(v) => updateRow(i, { symbol: v })}
+                  options={commodities}
+                  placeholder="KIRT"
+                  allowFreeText
+                />
+              </div>
+              <div className="flex-1 space-y-1">
+                {i === 0 && <Label htmlFor={`price-${i}`}>Rate</Label>}
+                <Input
+                  id={`price-${i}`}
+                  type="number"
+                  step="any"
+                  min="0"
+                  inputMode="decimal"
+                  value={row.price}
+                  onChange={(e) => updateRow(i, { price: e.target.value })}
+                  placeholder="0.0000033"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove row"
+                onClick={() => removeRow(i)}
+                disabled={rows.length === 1}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Button type="button" variant="outline" size="sm" onClick={addRow}>
+            Add another commodity
+          </Button>
+        </div>
+
+        {state.formError && (
+          <p className="text-destructive text-sm">{state.formError}</p>
+        )}
+        {state.ok && <p className="text-sm text-green-600">Prices saved.</p>}
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? 'Saving…' : 'Save prices'}
+        </Button>
+      </form>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">History</h2>
+        {prices.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No manual prices yet.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-muted-foreground text-left">
+                <th className="py-1">When</th>
+                <th>Commodity</th>
+                <th className="text-right">Rate</th>
+                <th>Quote</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {prices.map((p) => (
+                <tr key={p.id} className="border-t">
+                  <td className="py-1">
+                    {formatLedgerDateTime(new Date(p.pricedAt))}
+                  </td>
+                  <td>{p.symbol}</td>
+                  <td className="text-right tabular-nums">{p.price}</td>
+                  <td>{p.quote}</td>
+                  <td className="text-right">
+                    <form action={deleteManualPriceAction}>
+                      <input type="hidden" name="id" value={p.id} />
+                      <Button
+                        type="submit"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${p.symbol} rate`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </form>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/features/prices/actions/addManualPrices.ts
+++ b/features/prices/actions/addManualPrices.ts
@@ -1,0 +1,48 @@
+'use server';
+
+import type { PriceActionState } from './types';
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+import { manualPriceDraftSchema } from '@/lib/prices/manualSchema';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export async function addManualPricesAction(
+  _prev: PriceActionState | null,
+  formData: FormData
+): Promise<PriceActionState> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, formError: RATE_LIMIT_MESSAGE };
+  }
+
+  const draftJson = formData.get('draft');
+  if (typeof draftJson !== 'string') {
+    return { ok: false, formError: 'Missing price payload' };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(draftJson);
+  } catch {
+    return { ok: false, formError: 'Price payload is not valid JSON' };
+  }
+
+  const parsed = manualPriceDraftSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    return { ok: false, formError: 'Please fix the highlighted fields' };
+  }
+
+  const result = await priceService.addManualPrices(user.id, parsed.data);
+  await auditService.record(user.id, {
+    action: 'price.add',
+    result: result.ok ? 'success' : 'failure',
+    detail: result.ok ? { count: parsed.data.rows.length } : undefined,
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) return { ok: false, formError: result.formError };
+
+  revalidatePath('/prices');
+  return { ok: true };
+}

--- a/features/prices/actions/deleteManualPrice.ts
+++ b/features/prices/actions/deleteManualPrice.ts
@@ -3,24 +3,50 @@
 import { auditService, auditRequestMeta } from '@/lib/audit';
 import { requireUser } from '@/lib/auth/require-user';
 import { priceService } from '@/lib/prices';
-import { rateLimit, WRITE } from '@/lib/rate-limit';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import { revalidatePath } from 'next/cache';
 
+export type DeleteManualPriceResult =
+  | { ok: true }
+  | { ok: false; message: string };
+
 export async function deleteManualPriceAction(
-  formData: FormData
-): Promise<void> {
+  id: number
+): Promise<DeleteManualPriceResult> {
   const user = await requireUser();
-  if (!rateLimit(WRITE, user.id).allowed) return;
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
 
-  const raw = formData.get('id');
-  const id = typeof raw === 'string' ? Number(raw) : NaN;
-  if (!Number.isInteger(id) || id <= 0) return;
+  if (!Number.isInteger(id) || id <= 0) {
+    return { ok: false, message: 'Invalid price id' };
+  }
 
-  await priceService.deleteManualPrice(user.id, id);
+  let removed: boolean;
+  try {
+    removed = await priceService.deleteManualPrice(user.id, id);
+  } catch (e) {
+    await auditService.record(user.id, {
+      action: 'price.delete',
+      result: 'failure',
+      ...(await auditRequestMeta()),
+    });
+    return {
+      ok: false,
+      message: e instanceof Error ? e.message : 'Could not delete price',
+    };
+  }
+
   await auditService.record(user.id, {
     action: 'price.delete',
-    result: 'success',
+    result: removed ? 'success' : 'failure',
     ...(await auditRequestMeta()),
   });
+
+  if (!removed) {
+    return { ok: false, message: 'Price not found' };
+  }
+
   revalidatePath('/prices');
+  return { ok: true };
 }

--- a/features/prices/actions/deleteManualPrice.ts
+++ b/features/prices/actions/deleteManualPrice.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+import { rateLimit, WRITE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export async function deleteManualPriceAction(
+  formData: FormData
+): Promise<void> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) return;
+
+  const raw = formData.get('id');
+  const id = typeof raw === 'string' ? Number(raw) : NaN;
+  if (!Number.isInteger(id) || id <= 0) return;
+
+  await priceService.deleteManualPrice(user.id, id);
+  await auditService.record(user.id, {
+    action: 'price.delete',
+    result: 'success',
+    ...(await auditRequestMeta()),
+  });
+  revalidatePath('/prices');
+}

--- a/features/prices/actions/index.ts
+++ b/features/prices/actions/index.ts
@@ -1,3 +1,6 @@
 export { addManualPricesAction } from './addManualPrices';
-export { deleteManualPriceAction } from './deleteManualPrice';
+export {
+  deleteManualPriceAction,
+  type DeleteManualPriceResult,
+} from './deleteManualPrice';
 export type { PriceActionState } from './types';

--- a/features/prices/actions/index.ts
+++ b/features/prices/actions/index.ts
@@ -1,0 +1,3 @@
+export { addManualPricesAction } from './addManualPrices';
+export { deleteManualPriceAction } from './deleteManualPrice';
+export type { PriceActionState } from './types';

--- a/features/prices/actions/types.ts
+++ b/features/prices/actions/types.ts
@@ -1,0 +1,4 @@
+export type PriceActionState = {
+  ok: boolean;
+  formError?: string;
+};

--- a/features/prices/index.ts
+++ b/features/prices/index.ts
@@ -1,0 +1,1 @@
+export { PricesView } from './PricesView';

--- a/lib/audit/describe.ts
+++ b/lib/audit/describe.ts
@@ -8,6 +8,8 @@ const COPY: Record<string, [string, string]> = {
   'tx.edit': ['Edited a transaction', 'Failed to edit a transaction'],
   'tx.delete': ['Deleted a transaction', 'Failed to delete a transaction'],
   'journal.import': ['Imported journal', 'Import failed'],
+  'price.add': ['Recorded a price', 'Failed to record a price'],
+  'price.delete': ['Deleted a price', 'Failed to delete a price'],
   'crypto.enable': ['Enabled encryption', 'Failed to enable encryption'],
   'crypto.unlock': ['Unlocked journal', 'Failed to unlock journal'],
   'crypto.lock': ['Locked journal', 'Failed to lock journal'],

--- a/lib/audit/schema.ts
+++ b/lib/audit/schema.ts
@@ -5,6 +5,8 @@ export const AUDIT_ACTIONS = [
   'tx.edit',
   'tx.delete',
   'journal.import',
+  'price.add',
+  'price.delete',
   'crypto.enable',
   'crypto.unlock',
   'crypto.lock',

--- a/lib/prices/index.ts
+++ b/lib/prices/index.ts
@@ -1,3 +1,4 @@
+import { ManualPriceRepository } from './manualRepository';
 import {
   CommodityPriceRepository,
   PriceFetchRunRepository,
@@ -8,11 +9,13 @@ import { journalRepository } from '@/lib/journal';
 
 export const commodityPriceRepository = new CommodityPriceRepository(db);
 export const priceFetchRunRepository = new PriceFetchRunRepository(db);
+export const manualPriceRepository = new ManualPriceRepository(db);
 export const priceService = new PriceService({
   db,
   commodityRepo: commodityPriceRepository,
   runRepo: priceFetchRunRepository,
   journalRepo: journalRepository,
+  manualRepo: manualPriceRepository,
 });
 
 export { PriceService } from './service';
@@ -21,6 +24,7 @@ export {
   CommodityPriceRepository,
   PriceFetchRunRepository,
 } from './repository';
+export { ManualPriceRepository } from './manualRepository';
 export { fetchPrices } from './provider';
 export type { QuotePair, PriceQuote, ProviderResult } from './provider';
 export { renderPriceDb, hasGeneratedBanner, BANNER_MARKER } from './formatter';

--- a/lib/prices/manualRepository.test.ts
+++ b/lib/prices/manualRepository.test.ts
@@ -76,9 +76,9 @@ describe('ManualPriceRepository', () => {
       { userId: 'bob', symbol: 'KIRT', quote: 'USD', price: 2, pricedAt: at },
     ]);
     const aliceRow = (await repo.listForUser('alice'))[0];
-    await repo.deleteForUser('bob', aliceRow.id); // wrong owner → no-op
+    expect(await repo.deleteForUser('bob', aliceRow.id)).toBe(false); // wrong owner → no-op
     expect(await repo.listForUser('alice')).toHaveLength(1);
-    await repo.deleteForUser('alice', aliceRow.id);
+    expect(await repo.deleteForUser('alice', aliceRow.id)).toBe(true);
     expect(await repo.listForUser('alice')).toHaveLength(0);
     expect(await repo.listForUser('bob')).toHaveLength(1);
   });

--- a/lib/prices/manualRepository.test.ts
+++ b/lib/prices/manualRepository.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ManualPriceRepository } from './manualRepository';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('ManualPriceRepository', () => {
+  let ctx: TestDbContext;
+  let repo: ManualPriceRepository;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('manual-price-');
+    await ctx.insertUser('alice', 'alice', 'alice@example.com');
+    repo = new ManualPriceRepository(ctx.db);
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('inserts and lists rows newest-first', async () => {
+    await repo.upsertMany([
+      {
+        userId: 'alice',
+        symbol: 'KIRT',
+        quote: 'USD',
+        price: 0.0000033,
+        pricedAt: new Date('2026-01-01T23:59:59Z'),
+      },
+      {
+        userId: 'alice',
+        symbol: 'KIRT',
+        quote: 'USD',
+        price: 0.000004,
+        pricedAt: new Date('2026-06-27T23:59:59Z'),
+      },
+    ]);
+    const rows = await repo.listForUser('alice');
+    expect(rows.map((r) => r.pricedAt.toISOString())).toEqual([
+      '2026-06-27T23:59:59.000Z',
+      '2026-01-01T23:59:59.000Z',
+    ]);
+  });
+
+  it('upserts on (userId, symbol, quote, pricedAt) conflict', async () => {
+    const at = new Date('2026-06-27T23:59:59Z');
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 1, pricedAt: at },
+    ]);
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 2, pricedAt: at },
+    ]);
+    const rows = await repo.listForUser('alice');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].price).toBe(2);
+  });
+
+  it('collapses duplicate conflict keys within one batch (last-wins)', async () => {
+    const at = new Date('2026-06-27T23:59:59Z');
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 1, pricedAt: at },
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 5, pricedAt: at },
+    ]);
+    const rows = await repo.listForUser('alice');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].price).toBe(5);
+  });
+
+  it('deleteForUser removes only the owner row', async () => {
+    await ctx.insertUser('bob', 'bob', 'bob@example.com');
+    const at = new Date('2026-06-27T23:59:59Z');
+    await repo.upsertMany([
+      { userId: 'alice', symbol: 'KIRT', quote: 'USD', price: 1, pricedAt: at },
+      { userId: 'bob', symbol: 'KIRT', quote: 'USD', price: 2, pricedAt: at },
+    ]);
+    const aliceRow = (await repo.listForUser('alice'))[0];
+    await repo.deleteForUser('bob', aliceRow.id); // wrong owner → no-op
+    expect(await repo.listForUser('alice')).toHaveLength(1);
+    await repo.deleteForUser('alice', aliceRow.id);
+    expect(await repo.listForUser('alice')).toHaveLength(0);
+    expect(await repo.listForUser('bob')).toHaveLength(1);
+  });
+});

--- a/lib/prices/manualRepository.ts
+++ b/lib/prices/manualRepository.ts
@@ -1,0 +1,57 @@
+import { and, desc, eq, sql } from 'drizzle-orm';
+import { manualPrice, type ManualPrice } from '@/db/schema';
+import type { DbInstance } from '@/lib/db/connection';
+
+export type ManualPriceInput = {
+  userId: string;
+  symbol: string;
+  quote: string;
+  price: number;
+  pricedAt: Date;
+};
+
+export class ManualPriceRepository {
+  constructor(private readonly db: DbInstance) {}
+
+  /** Upsert rows by (userId, symbol, quote, pricedAt) in a single statement. */
+  async upsertMany(rows: ManualPriceInput[]): Promise<void> {
+    if (rows.length === 0) return;
+    // Collapse duplicate conflict keys before the batched upsert: a single
+    // ON CONFLICT DO UPDATE that targets the same row twice throws Postgres
+    // 21000. Last-wins matches the upsert's intent.
+    const deduped = [
+      ...new Map(
+        rows.map((r) => [
+          `${r.userId}|${r.symbol}|${r.quote}|${r.pricedAt.toISOString()}`,
+          r,
+        ])
+      ).values(),
+    ];
+    await this.db
+      .insert(manualPrice)
+      .values(deduped)
+      .onConflictDoUpdate({
+        target: [
+          manualPrice.userId,
+          manualPrice.symbol,
+          manualPrice.quote,
+          manualPrice.pricedAt,
+        ],
+        set: { price: sql`excluded.price` },
+      });
+  }
+
+  async listForUser(userId: string): Promise<ManualPrice[]> {
+    return this.db
+      .select()
+      .from(manualPrice)
+      .where(eq(manualPrice.userId, userId))
+      .orderBy(desc(manualPrice.pricedAt), desc(manualPrice.id));
+  }
+
+  async deleteForUser(userId: string, id: number): Promise<void> {
+    await this.db
+      .delete(manualPrice)
+      .where(and(eq(manualPrice.userId, userId), eq(manualPrice.id, id)));
+  }
+}

--- a/lib/prices/manualRepository.ts
+++ b/lib/prices/manualRepository.ts
@@ -49,9 +49,12 @@ export class ManualPriceRepository {
       .orderBy(desc(manualPrice.pricedAt), desc(manualPrice.id));
   }
 
-  async deleteForUser(userId: string, id: number): Promise<void> {
-    await this.db
+  /** Returns true when a row owned by the user was actually removed. */
+  async deleteForUser(userId: string, id: number): Promise<boolean> {
+    const deleted = await this.db
       .delete(manualPrice)
-      .where(and(eq(manualPrice.userId, userId), eq(manualPrice.id, id)));
+      .where(and(eq(manualPrice.userId, userId), eq(manualPrice.id, id)))
+      .returning({ id: manualPrice.id });
+    return deleted.length > 0;
   }
 }

--- a/lib/prices/manualSchema.test.ts
+++ b/lib/prices/manualSchema.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { manualPriceDraftSchema, buildPricedAt } from './manualSchema';
+
+describe('manualPriceDraftSchema', () => {
+  const valid = {
+    date: '2026-06-27',
+    quote: 'USD',
+    rows: [{ symbol: 'KIRT', price: 0.0000033 }],
+  };
+
+  it('accepts a well-formed draft', () => {
+    expect(manualPriceDraftSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects a malformed date', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, date: '27/06/2026' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a non-positive price', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({
+        ...valid,
+        rows: [{ symbol: 'KIRT', price: 0 }],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects an empty rows array', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, rows: [] }).success
+    ).toBe(false);
+  });
+
+  it('rejects a bad time format', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, time: '9am' }).success
+    ).toBe(false);
+  });
+
+  it('allows an empty-string time (means "no time")', () => {
+    expect(
+      manualPriceDraftSchema.safeParse({ ...valid, time: '' }).success
+    ).toBe(true);
+  });
+});
+
+describe('buildPricedAt', () => {
+  it('defaults blank time to end-of-day UTC', () => {
+    expect(buildPricedAt('2026-06-27')?.toISOString()).toBe(
+      '2026-06-27T23:59:59.000Z'
+    );
+    expect(buildPricedAt('2026-06-27', '')?.toISOString()).toBe(
+      '2026-06-27T23:59:59.000Z'
+    );
+  });
+
+  it('uses an explicit time as UTC', () => {
+    expect(buildPricedAt('2026-06-27', '14:30')?.toISOString()).toBe(
+      '2026-06-27T14:30:00.000Z'
+    );
+  });
+
+  it('returns null for an unparseable date', () => {
+    expect(buildPricedAt('2026-13-40')).toBeNull();
+  });
+});

--- a/lib/prices/manualSchema.ts
+++ b/lib/prices/manualSchema.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_RE = /^\d{2}:\d{2}$/;
+
+export const manualPriceDraftSchema = z.object({
+  date: z.string().regex(DATE_RE, 'Date must be YYYY-MM-DD'),
+  time: z
+    .union([z.string().regex(TIME_RE, 'Time must be HH:MM'), z.literal('')])
+    .optional(),
+  quote: z.string().min(1, 'Quote currency is required'),
+  rows: z
+    .array(
+      z.object({
+        symbol: z.string().min(1),
+        price: z.number().finite().positive(),
+      })
+    )
+    .min(1, 'Add at least one price'),
+});
+
+export type ManualPriceDraft = z.infer<typeof manualPriceDraftSchema>;
+
+/**
+ * Build the UTC instant a manual rate applies to. Blank time → end-of-day
+ * (23:59:59Z) so a date-only rate is authoritative for the whole calendar day
+ * and beats any intraday fetched rate. Returns null if the result is invalid.
+ */
+export const buildPricedAt = (date: string, time?: string): Date | null => {
+  const t = time && time.length > 0 ? `${time}:00` : '23:59:59';
+  const d = new Date(`${date}T${t}Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+};

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { BANNER_MARKER } from './formatter';
 import { __resetPriceLockForTests } from './lock';
+import { ManualPriceRepository } from './manualRepository';
 import {
   CommodityPriceRepository,
   PriceFetchRunRepository,
@@ -43,6 +44,7 @@ describe('PriceService.refreshAll', () => {
       commodityRepo: new CommodityPriceRepository(ctx.db),
       runRepo: new PriceFetchRunRepository(ctx.db),
       journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
     });
   });
 
@@ -239,5 +241,122 @@ describe('PriceService.refreshAll', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(ra.status).toBe('success');
     expect(rb.status).toBe('success');
+  });
+});
+
+describe('PriceService manual prices', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  const make = () =>
+    new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+    });
+
+  beforeEach(async () => {
+    __resetPriceLockForTests();
+    ctx = await setupTestDb('prices-manual-svc-');
+    service = make();
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    vi.restoreAllMocks();
+  });
+
+  const readPriceDb = async (userId: string) =>
+    fs.readFile(path.join(getJournalDir(userId), 'price-db.ledger'), 'utf-8');
+
+  it('emits a never-transacted manual symbol into price-db', async () => {
+    await seedUser(
+      ctx,
+      'alice',
+      '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n',
+      'USD'
+    );
+    const result = await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'KIRT', price: 0.0000033 }],
+    });
+    expect(result).toEqual({ ok: true });
+    const file = await readPriceDb('alice');
+    expect(file).toContain('KIRT');
+    expect(file).toContain('0.0000033');
+    expect(file).toContain('2026/06/27 23:59:59');
+  });
+
+  it('normalizes $ to USD and rejects pricing a symbol in itself', async () => {
+    await seedUser(
+      ctx,
+      'alice',
+      '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n',
+      'USD'
+    );
+    const ok = await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: '$',
+      rows: [{ symbol: 'kirt', price: 2 }],
+    });
+    expect(ok).toEqual({ ok: true });
+    expect(await readPriceDb('alice')).toContain('KIRT 2 USD');
+
+    const bad = await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'USD', price: 2 }],
+    });
+    expect(bad.ok).toBe(false);
+  });
+
+  it('manual rate beats a same-day fetched rate via end-of-day ordering', async () => {
+    await seedUser(
+      ctx,
+      'alice',
+      '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n',
+      'USD'
+    );
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'BTC',
+        quote: 'USD',
+        price: 60000,
+        fetchedAt: new Date('2026-06-27T12:00:00Z'),
+        fetchedDate: '2026-06-27',
+      },
+    ]);
+    await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'BTC', price: 65000 }],
+    });
+    const file = await readPriceDb('alice');
+    // both lines present; the 23:59:59 manual line sorts after the 12:00:00 one
+    const idxFetched = file.indexOf('60000');
+    const idxManual = file.indexOf('65000');
+    expect(idxFetched).toBeGreaterThan(-1);
+    expect(idxManual).toBeGreaterThan(idxFetched);
+  });
+
+  it('deleteManualPrice removes the row and regenerates without it', async () => {
+    await seedUser(
+      ctx,
+      'alice',
+      '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n',
+      'USD'
+    );
+    await service.addManualPrices('alice', {
+      date: '2026-06-27',
+      quote: 'USD',
+      rows: [{ symbol: 'KIRT', price: 3 }],
+    });
+    const row = (await service.listManualPrices('alice'))[0];
+    await service.deleteManualPrice('alice', row.id);
+    expect(await service.listManualPrices('alice')).toHaveLength(0);
+    expect(await readPriceDb('alice')).not.toContain('KIRT');
   });
 });

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -355,8 +355,18 @@ describe('PriceService manual prices', () => {
       rows: [{ symbol: 'KIRT', price: 3 }],
     });
     const row = (await service.listManualPrices('alice'))[0];
-    await service.deleteManualPrice('alice', row.id);
+    expect(await service.deleteManualPrice('alice', row.id)).toBe(true);
     expect(await service.listManualPrices('alice')).toHaveLength(0);
     expect(await readPriceDb('alice')).not.toContain('KIRT');
+  });
+
+  it('deleteManualPrice returns false for a non-existent / unowned row', async () => {
+    await seedUser(
+      ctx,
+      'alice',
+      '2026/01/01 X\n  Assets:Cash  1 BTC\n  Income\n',
+      'USD'
+    );
+    expect(await service.deleteManualPrice('alice', 999999)).toBe(false);
   });
 });

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import { eq } from 'drizzle-orm';
 import 'server-only';
 import { renderPriceDb, hasGeneratedBanner } from './formatter';
+import type { CommodityPriceRow } from './formatter';
 import { withPriceLock } from './lock';
+import type { ManualPriceRepository } from './manualRepository';
+import { buildPricedAt, type ManualPriceDraft } from './manualSchema';
 import { parseLegacyPriceDb } from './migration';
 import { fetchPrices, type QuotePair } from './provider';
 import {
@@ -12,6 +15,7 @@ import {
 } from './repository';
 import { normalizeCommoditySymbol } from './symbols';
 import { userSetting } from '@/db/schema';
+import type { ManualPrice } from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
 import { env } from '@/lib/env';
 import { PRICE_DB_NAME, getJournalCacheTag } from '@/lib/journal/layout';
@@ -43,6 +47,7 @@ type Deps = {
   commodityRepo: CommodityPriceRepository;
   runRepo: PriceFetchRunRepository;
   journalRepo: JournalRepository;
+  manualRepo: ManualPriceRepository;
 };
 
 export class PriceService {
@@ -63,16 +68,81 @@ export class PriceService {
     const userSymbols = new Set(
       await this.listNormalizedSymbolsForUser(userId)
     );
-    const filtered = all.filter((r) => userSymbols.has(r.symbol));
-    const body = renderPriceDb(filtered);
+    const fetched = all.filter((r) => userSymbols.has(r.symbol));
+    const manual = await this.deps.manualRepo.listForUser(userId);
+    const manualRows: CommodityPriceRow[] = manual.map((m) => ({
+      symbol: m.symbol,
+      quote: m.quote,
+      price: m.price,
+      fetchedAt: m.pricedAt,
+      fetchedDate: utcDate(m.pricedAt),
+    }));
+    // Concatenate fetched-first, then stable-sort by instant: equal timestamps
+    // keep fetched before manual, so manual ends up later in the file and wins.
+    const merged = [...fetched, ...manualRows].sort(
+      (a, b) => a.fetchedAt.getTime() - b.fetchedAt.getTime()
+    );
+    const body = renderPriceDb(merged);
     const target = path.join(layout.dir, PRICE_DB_NAME);
     await this.deps.journalRepo.writeFileAtomic(target, body);
     try {
       revalidateTag(getJournalCacheTag(userId), 'max');
     } catch {
-      // revalidateTag throws outside a Next.js request context (e.g. cron, tests).
-      // This is acceptable — the cache will be invalidated on the next request.
+      // revalidateTag throws outside a Next.js request context (cron, tests).
+      // Acceptable — the cache invalidates on the next request.
     }
+  }
+
+  async addManualPrices(
+    userId: string,
+    draft: ManualPriceDraft
+  ): Promise<{ ok: true } | { ok: false; formError: string }> {
+    const quote = normalizeCommoditySymbol(draft.quote);
+    if (!quote) return { ok: false, formError: 'Invalid quote currency' };
+    const pricedAt = buildPricedAt(draft.date, draft.time);
+    if (!pricedAt) return { ok: false, formError: 'Invalid date or time' };
+
+    const byKey = new Map<
+      string,
+      {
+        userId: string;
+        symbol: string;
+        quote: string;
+        price: number;
+        pricedAt: Date;
+      }
+    >();
+    for (const row of draft.rows) {
+      const symbol = normalizeCommoditySymbol(row.symbol);
+      if (!symbol) {
+        return { ok: false, formError: `Invalid commodity: ${row.symbol}` };
+      }
+      if (symbol === quote) {
+        return { ok: false, formError: `Cannot price ${symbol} in itself` };
+      }
+      byKey.set(symbol, { userId, symbol, quote, price: row.price, pricedAt });
+    }
+
+    await this.deps.manualRepo.upsertMany([...byKey.values()]);
+    await this.regenerateUserPriceDb(userId);
+    return { ok: true };
+  }
+
+  async listManualPrices(userId: string): Promise<ManualPrice[]> {
+    return this.deps.manualRepo.listForUser(userId);
+  }
+
+  async deleteManualPrice(userId: string, id: number): Promise<void> {
+    await this.deps.manualRepo.deleteForUser(userId, id);
+    await this.regenerateUserPriceDb(userId);
+  }
+
+  async getBaseCurrency(userId: string): Promise<string> {
+    return this.resolveBaseCurrency(userId);
+  }
+
+  async listCommoditiesForUser(userId: string): Promise<string[]> {
+    return this.listNormalizedSymbolsForUser(userId);
   }
 
   private async runOnce(): Promise<RefreshResult> {
@@ -155,7 +225,7 @@ export class PriceService {
     return rows.map((r) => r.id);
   }
 
-  private async resolveBaseCurrency(userId: string): Promise<string> {
+  async resolveBaseCurrency(userId: string): Promise<string> {
     const rows = await this.deps.db
       .select({ baseCurrency: userSetting.baseCurrency })
       .from(userSetting)
@@ -164,9 +234,7 @@ export class PriceService {
     return rows[0]?.baseCurrency ?? env.DEFAULT_CURRENCY;
   }
 
-  private async listNormalizedSymbolsForUser(
-    userId: string
-  ): Promise<string[]> {
+  async listNormalizedSymbolsForUser(userId: string): Promise<string[]> {
     let stdout: string;
     try {
       stdout = await runLedgerForUser(

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -32,6 +32,12 @@ export type RefreshResult =
   | { status: 'partial'; fetched: number; failed: string[] }
   | { status: 'failed'; message: string };
 
+/**
+ * Outcome of a manual-price mutation. Shared between the service and the
+ * server actions so the success/error shape can't drift between the two.
+ */
+export type ManualPriceResult = { ok: true } | { ok: false; formError: string };
+
 const sanitize = (msg: string): string =>
   msg.replace(/\/[^\s]+/g, '<path>').slice(0, 500);
 
@@ -96,7 +102,7 @@ export class PriceService {
   async addManualPrices(
     userId: string,
     draft: ManualPriceDraft
-  ): Promise<{ ok: true } | { ok: false; formError: string }> {
+  ): Promise<ManualPriceResult> {
     const quote = normalizeCommoditySymbol(draft.quote);
     if (!quote) return { ok: false, formError: 'Invalid quote currency' };
     const pricedAt = buildPricedAt(draft.date, draft.time);
@@ -132,17 +138,11 @@ export class PriceService {
     return this.deps.manualRepo.listForUser(userId);
   }
 
-  async deleteManualPrice(userId: string, id: number): Promise<void> {
-    await this.deps.manualRepo.deleteForUser(userId, id);
-    await this.regenerateUserPriceDb(userId);
-  }
-
-  async getBaseCurrency(userId: string): Promise<string> {
-    return this.resolveBaseCurrency(userId);
-  }
-
-  async listCommoditiesForUser(userId: string): Promise<string[]> {
-    return this.listNormalizedSymbolsForUser(userId);
+  /** Returns true when a row owned by the user was actually removed. */
+  async deleteManualPrice(userId: string, id: number): Promise<boolean> {
+    const removed = await this.deps.manualRepo.deleteForUser(userId, id);
+    if (removed) await this.regenerateUserPriceDb(userId);
+    return removed;
   }
 
   private async runOnce(): Promise<RefreshResult> {

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -33,13 +33,29 @@ export default formatDate;
 
 const pad = (n: number) => String(n).padStart(2, '0');
 
+/** UTC calendar date as `YYYY/MM/DD`, without a time component. */
+export const formatLedgerDate = (d: Date): string =>
+  `${d.getUTCFullYear()}/${pad(d.getUTCMonth() + 1)}/${pad(d.getUTCDate())}`;
+
 /**
  * Format a Date as ledger's `P` directive timestamp: `YYYY/MM/DD HH:MM:SS`
  * in UTC. Stable across server timezones so price-db files diff cleanly.
  */
-export const formatLedgerDateTime = (d: Date): string => {
-  return (
-    `${d.getUTCFullYear()}/${pad(d.getUTCMonth() + 1)}/${pad(d.getUTCDate())} ` +
-    `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`
-  );
-};
+export const formatLedgerDateTime = (d: Date): string =>
+  `${formatLedgerDate(d)} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+
+/**
+ * Sentinel UTC time stamped on date-only manual rates (`23:59:59`) so they sort
+ * last within their day. Used to detect "no real time was given".
+ */
+const isEndOfDaySentinel = (d: Date): boolean =>
+  d.getUTCHours() === 23 &&
+  d.getUTCMinutes() === 59 &&
+  d.getUTCSeconds() === 59;
+
+/**
+ * Like {@link formatLedgerDateTime}, but renders a plain date when the time is
+ * the end-of-day sentinel used purely for ledger ordering of date-only rates.
+ */
+export const formatLedgerInstant = (d: Date): string =>
+  isEndOfDaySentinel(d) ? formatLedgerDate(d) : formatLedgerDateTime(d);

--- a/utils/formatLedgerDateTime.test.ts
+++ b/utils/formatLedgerDateTime.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { formatLedgerDateTime } from './formatDate';
+import {
+  formatLedgerDate,
+  formatLedgerDateTime,
+  formatLedgerInstant,
+} from './formatDate';
 
 describe('formatLedgerDateTime', () => {
   it('formats a Date as YYYY/MM/DD HH:MM:SS in UTC', () => {
@@ -15,5 +19,33 @@ describe('formatLedgerDateTime', () => {
   it('handles end-of-year boundary', () => {
     const d = new Date('2026-12-31T23:59:59.000Z');
     expect(formatLedgerDateTime(d)).toBe('2026/12/31 23:59:59');
+  });
+});
+
+describe('formatLedgerDate', () => {
+  it('formats a Date as YYYY/MM/DD in UTC', () => {
+    expect(formatLedgerDate(new Date('2026-01-02T03:04:05.000Z'))).toBe(
+      '2026/01/02'
+    );
+  });
+});
+
+describe('formatLedgerInstant', () => {
+  it('suppresses the time for the end-of-day sentinel (date-only rate)', () => {
+    expect(formatLedgerInstant(new Date('2026-06-27T23:59:59.000Z'))).toBe(
+      '2026/06/27'
+    );
+  });
+
+  it('keeps the time when a real time was given', () => {
+    expect(formatLedgerInstant(new Date('2026-06-27T06:07:08.000Z'))).toBe(
+      '2026/06/27 06:07:08'
+    );
+  });
+
+  it('keeps the time when only seconds differ from the sentinel', () => {
+    expect(formatLedgerInstant(new Date('2026-06-27T23:59:58.000Z'))).toBe(
+      '2026/06/27 23:59:58'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds a top-level **`/prices`** page where a user records dated exchange rates for commodities their price provider doesn't cover — e.g. **KIRT** (Kilo IRT), a custom unit no feed knows about. Manual rates are stored per-user and merged into the regenerated `price-db.ledger`, so ledger's `-X` conversions and historical valuation use them and they survive every provider refresh.

Closes the gap noted in the price-db banner ("Manual price overrides belong in your main journal") with a first-class, DB-backed flow instead.

## How it works

- **New per-user `manual_price` table** (the existing `commodity_price` table is global — `BTC=USD` is the same for everyone; a custom KIRT valuation is not, so it gets its own table scoped by `userId`).
- **Batch entry:** pick a shared **date** (+ optional **time**) and **quote currency**, then add one or more rows of **commodity** (autocomplete that also accepts brand-new symbols like KIRT) + **rate**.
- **Valuation over time:** every rate is a separate dated `P` directive — old dates are never overwritten, so ledger picks the rate in effect at each report date. Blank time defaults to end-of-day UTC, making a date-only manual rate authoritative for that day (and it beats a same-day fetched rate via "later timestamp wins").
- **Merged into `price-db.ledger`:** manual rows are always emitted — even for symbols never transacted — through the same `formatLedgerDateTime` render path as fetched rows.

## Changes

- `db/schema/manualPrice.ts` + migration `0009` — per-user table, unique on `(userId, symbol, quote, pricedAt)`.
- `lib/prices/manualRepository.ts` — CRUD (`upsertMany`, `listForUser`, `deleteForUser`).
- `lib/prices/manualSchema.ts` — Zod draft schema + `buildPricedAt` (end-of-day default).
- `lib/prices/service.ts` — `addManualPrices` / `listManualPrices` / `deleteManualPrice` / `getBaseCurrency` / `listCommoditiesForUser`; `regenerateUserPriceDb` now merges manual rows (manual-wins-on-tie).
- `features/prices/actions/` — `addManualPrices` / `deleteManualPrice` server actions (auth → rate-limit → validate → service → audit → revalidate); `price.add`/`price.delete` audit actions.
- `app/prices/page.tsx` + `features/prices/PricesView.tsx` — page shell + batch form & history/delete.
- `components/nav/config.ts` — Prices nav entry.

## Testing

- 619 tests pass (added repository, schema, and service tests — including real-DB assertions that a never-transacted KIRT lands in `price-db.ledger` and that a same-day manual rate sorts after the fetched one).
- `pnpm type-check` and `pnpm lint` clean.

## Follow-ups (non-blocking)

- Per-row Rate label association for rows 2+ (a11y polish).
- Dynamic-row keys use index (mid-list delete focus).
- `price.delete` audit records `success` even on a 0-row no-op.

Design spec and implementation plan are committed under `docs/superpowers/`.