### PR TITLE
feat(mobile): m1 read-first views responsive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BETTER_AUTH_SECRET: ci-dummy-secret-32-chars-minimum-XX
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -32,3 +46,15 @@ jobs:
       - run: pnpm type-check
 
       - run: pnpm test
+
+      # Production build — catches client/server import violations (e.g. a
+      # `'use client'` component pulling in a `server-only` module) that lint,
+      # type-check, and unit tests do not. Runs migrations against the Postgres
+      # service first via the `prebuild` hook.
+      - name: Build
+        run: pnpm build
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/ledger_ci
+          BETTER_AUTH_URL: http://localhost:3000
+          POSTAL_API_URL: https://postal.example.com
+          POSTAL_API_KEY: ci-dummy-postal-key

--- a/MOBILE-ROADMAP.md
+++ b/MOBILE-ROADMAP.md
@@ -79,28 +79,28 @@ tables, card-reflow for the read-first views (transactions, dashboard, balance).
 
 Wrap in scroll container + de-overflow (all 🟠 unless noted):
 
-- [ ] 🔴 **Transactions** — 7 cols, no scroll. `features/transactions/TransactionTable.tsx:37`
+- [x] 🔴 **Transactions** — 7 cols, no scroll. `features/transactions/TransactionTable.tsx:37`
   *(highest-traffic; do card-reflow here, not just scroll)*
-- [ ] 🔴 **Account register** — 5 cols, multi-currency overflow, `whitespace-nowrap`
+- [x] 🔴 **Account register** — 5 cols, multi-currency overflow, `whitespace-nowrap`
   dates. `app/accounts/[account]/page.tsx:41,62`
-- [ ] 🟠 **Dashboard "recent"** — 4 cols + `whitespace-nowrap` date.
+- [x] 🟠 **Dashboard "recent"** — 4 cols + `whitespace-nowrap` date.
   `features/dashboard/Dashboard.tsx:191,210`
 - [ ] 🟠 **Prices** — 6 cols, timestamps overflow. `features/prices/PricesView.tsx:174`
 - [ ] 🟠 **Portfolio** — 4 cols, long account/commodity names.
   `features/portfolio/Portfolio.tsx:116`
 - [ ] 🟠 **Cash flow / monthly comparison** — 4 cols, comma numbers overflow.
   `features/monthlyComparison/MonthlyComparison.tsx:35`
-- [ ] 🟠 **Balance** — 2 cols, long account names. `app/balance/page.tsx:54`
+- [x] 🟠 **Balance** — 2 cols, long account names. `app/balance/page.tsx:54`
 - [ ] 🟠 **Debts** — 2 cols, long payee names. `app/debts/page.tsx:47`
 - [ ] 🟠 **Monthly register** — 2 cols. `app/registers/monthly/[account]/page.tsx:51`
 - [ ] 🟡 **Payees** — 2 cols, marginal. `features/payees/Payees.tsx:96`
 
 Grid/layout:
 
-- [ ] 🟡 **Dashboard journal-health grid** collapses to 2-up on mobile for 6 stats;
+- [x] 🟡 **Dashboard journal-health grid** collapses to 2-up on mobile for 6 stats;
   go 1-col (or keep 2 but verify it isn't cramped).
   `features/dashboard/Dashboard.tsx:244`
-- [ ] 🟡 **Allow account-name wrapping** in narrow cells (drop `whitespace-nowrap`
+- [x] 🟡 **Allow account-name wrapping** in narrow cells (drop `whitespace-nowrap`
   on the long text columns; keep it only on dates/amounts).
 - [ ] 🟡 **recharts responsiveness** — confirm charts use `<ResponsiveContainer>` and
   don't set fixed pixel widths (portfolio / net-worth / monthly).

--- a/app/accounts/[account]/page.tsx
+++ b/app/accounts/[account]/page.tsx
@@ -1,3 +1,4 @@
+import { TableScroll } from '@/components/ui/table';
 import AccountHeader from '@/features/accounts/AccountHeader';
 import { requireUser } from '@/lib/auth/require-user';
 import { savedViewService } from '@/lib/savedViews';
@@ -29,6 +30,9 @@ const Account = async ({
     { sortByDate: false }
   );
   const results = stdout.split('NNN').filter(Boolean);
+  const rows = [...results]
+    .reverse()
+    .map((result) => result.split('|').map((each) => each.trim()));
   return (
     <div className="flex flex-col gap-6">
       <AccountHeader
@@ -37,46 +41,92 @@ const Account = async ({
         existingViewNames={existingViewNames}
       />
 
-      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-        <table>
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Payee</th>
-              <th className="text-right">Amount</th>
-              <th className="text-right">Total</th>
-            </tr>
-          </thead>
-          <tbody>
-            {results.length === 0 ? (
+      {/* Mobile: stacked card rows. Multi-currency totals make the 4-col table
+          too wide for a phone, so reflow to a readable stack below md. */}
+      <ul className="flex flex-col gap-3 md:hidden">
+        {rows.length === 0 ? (
+          <li className="rounded-2xl border border-border bg-card p-6 text-center text-sm text-muted shadow-sm">
+            No transactions
+          </li>
+        ) : (
+          rows.map((columns, idx) => (
+            <li
+              key={idx}
+              className="rounded-2xl border border-border bg-card p-4 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <span className="min-w-0 break-words font-medium">
+                  {columns[2]}
+                </span>
+                <span className="shrink-0 whitespace-nowrap text-xs text-muted">
+                  {formatDate(columns[0], Format.DATE)}
+                </span>
+              </div>
+              <dl className="mt-3 flex flex-col gap-1 text-sm">
+                <div className="flex items-baseline justify-between gap-3">
+                  <dt className="text-xs uppercase tracking-wide text-muted">
+                    Amount
+                  </dt>
+                  <dd className="text-right tabular-nums">
+                    {formatAmount(columns[7], true)}
+                  </dd>
+                </div>
+                <div className="flex items-baseline justify-between gap-3">
+                  <dt className="text-xs uppercase tracking-wide text-muted">
+                    Total
+                  </dt>
+                  <dd className="text-right tabular-nums">
+                    {columns[8].split('\n').map((each, i) => (
+                      <div key={i}>{formatAmount(each, true)}</div>
+                    ))}
+                  </dd>
+                </div>
+              </dl>
+            </li>
+          ))
+        )}
+      </ul>
+
+      {/* Desktop: original table, scrollable inside its card for safety. */}
+      <div className="hidden overflow-hidden rounded-2xl border border-border bg-card shadow-sm md:block">
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={4} className="py-6 text-center text-muted">
-                  No transactions
-                </td>
+                <th>Date</th>
+                <th>Payee</th>
+                <th className="text-right">Amount</th>
+                <th className="text-right">Total</th>
               </tr>
-            ) : (
-              [...results].reverse().map((result, idx) => {
-                const columns = result.split('|').map((each) => each.trim());
-                return (
+            </thead>
+            <tbody>
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="py-6 text-center text-muted">
+                    No transactions
+                  </td>
+                </tr>
+              ) : (
+                rows.map((columns, idx) => (
                   <tr key={idx}>
                     <td className="whitespace-nowrap text-muted">
                       {formatDate(columns[0], Format.DATE)}
                     </td>
                     <td>{columns[2]}</td>
-                    <td className="text-right">
+                    <td className="text-right whitespace-nowrap">
                       {formatAmount(columns[7], true)}
                     </td>
-                    <td className="text-right">
+                    <td className="text-right whitespace-nowrap">
                       {columns[8].split('\n').map((each, i) => (
                         <div key={i}>{formatAmount(each, true)}</div>
                       ))}
                     </td>
                   </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+                ))
+              )}
+            </tbody>
+          </table>
+        </TableScroll>
       </div>
     </div>
   );

--- a/app/balance/page.tsx
+++ b/app/balance/page.tsx
@@ -1,6 +1,7 @@
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
 import { Card } from '@/components/ui/card';
+import { TableScroll } from '@/components/ui/table';
 import { parseBalanceRows } from '@/lib/balance/parse';
 import { getBaseCurrency } from '@/lib/settings';
 import formatAmount from '@/utils/formatAmount';
@@ -51,44 +52,46 @@ const Balance = async () => {
       </div>
 
       <Card className="gap-0 overflow-hidden p-0">
-        <table>
-          <thead>
-            <tr>
-              <th>Account</th>
-              <th className="text-right">
-                Balance ({defaultCurrency.toUpperCase()})
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {result.length === 0 ? (
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={2} className="py-6 text-center text-muted">
-                  No data
-                </td>
+                <th>Account</th>
+                <th className="text-right whitespace-nowrap">
+                  Balance ({defaultCurrency.toUpperCase()})
+                </th>
               </tr>
-            ) : (
-              result.map((item, index) => {
-                const columns = item.split('|');
-                return (
-                  <tr key={index}>
-                    <td>
-                      <Link
-                        className="block text-fg hover:text-accent"
-                        href={`/accounts/${encodeURIComponent(columns[0])}`}
-                      >
-                        {columns[0]}
-                      </Link>
-                    </td>
-                    <td className="text-right">
-                      {formatAmount(columns[1], false)}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {result.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="py-6 text-center text-muted">
+                    No data
+                  </td>
+                </tr>
+              ) : (
+                result.map((item, index) => {
+                  const columns = item.split('|');
+                  return (
+                    <tr key={index}>
+                      <td>
+                        <Link
+                          className="block text-fg hover:text-accent"
+                          href={`/accounts/${encodeURIComponent(columns[0])}`}
+                        >
+                          {columns[0]}
+                        </Link>
+                      </td>
+                      <td className="text-right whitespace-nowrap">
+                        {formatAmount(columns[1], false)}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </TableScroll>
       </Card>
     </div>
   );

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import Card from '@/components/Card';
 import Help from '@/components/Help';
 import { buttonVariants } from '@/components/ui/button';
 import { Card as ShadcnCard } from '@/components/ui/card';
+import { TableScroll } from '@/components/ui/table';
 import { requireUser } from '@/lib/auth/require-user';
 import { savedViewService } from '@/lib/savedViews';
 import { getBaseCurrency } from '@/lib/settings';
@@ -188,45 +189,47 @@ const Dashboard = async () => {
           </div>
         </div>
         <ShadcnCard className="gap-0 overflow-hidden p-0">
-          <table>
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Payee</th>
-                <th>Account</th>
-                <th className="text-right">Amount</th>
-              </tr>
-            </thead>
-            <tbody>
-              {recent.length === 0 ? (
+          <TableScroll bleed={false}>
+            <table>
+              <thead>
                 <tr>
-                  <td colSpan={4} className="py-6 text-center text-muted">
-                    No transactions
-                  </td>
+                  <th>Date</th>
+                  <th>Payee</th>
+                  <th>Account</th>
+                  <th className="text-right">Amount</th>
                 </tr>
-              ) : (
-                recent.map((row, idx) => (
-                  <tr key={idx}>
-                    <td className="whitespace-nowrap text-muted">
-                      {formatDate(row.date, Format.DATE)}
-                    </td>
-                    <td>{row.payee || '—'}</td>
-                    <td>
-                      <Link
-                        className="text-fg hover:text-accent"
-                        href={`/accounts/${encodeURIComponent(row.account)}`}
-                      >
-                        {row.account}
-                      </Link>
-                    </td>
-                    <td className="text-right">
-                      {formatAmount(row.amount, true)}
+              </thead>
+              <tbody>
+                {recent.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="py-6 text-center text-muted">
+                      No transactions
                     </td>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
+                ) : (
+                  recent.map((row, idx) => (
+                    <tr key={idx}>
+                      <td className="whitespace-nowrap text-muted">
+                        {formatDate(row.date, Format.DATE)}
+                      </td>
+                      <td>{row.payee || '—'}</td>
+                      <td>
+                        <Link
+                          className="text-fg hover:text-accent"
+                          href={`/accounts/${encodeURIComponent(row.account)}`}
+                        >
+                          {row.account}
+                        </Link>
+                      </td>
+                      <td className="text-right whitespace-nowrap">
+                        {formatAmount(row.amount, true)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </TableScroll>
         </ShadcnCard>
       </section>
 
@@ -241,7 +244,7 @@ const Dashboard = async () => {
             reconcile.
           </Help>
         </div>
-        <ShadcnCard className="grid grid-cols-2 gap-6 px-6 sm:grid-cols-3 lg:grid-cols-6">
+        <ShadcnCard className="grid grid-cols-1 gap-6 px-6 sm:grid-cols-3 lg:grid-cols-6">
           <Stat label="Postings" value={stats.postings} />
           <Stat label="Uncleared" value={stats.uncleared} />
           <Stat label="Last 7 days" value={stats.last7} />

--- a/features/prices/PricesView.tsx
+++ b/features/prices/PricesView.tsx
@@ -12,7 +12,7 @@ import {
   deleteManualPriceAction,
   type PriceActionState,
 } from '@/features/prices/actions';
-import { formatLedgerInstant } from '@/utils/formatDate';
+import { formatLedgerInstant } from '@/utils/formatDateCore';
 
 type Row = { symbol: string; price: string };
 

--- a/features/transactions/TransactionTable.tsx
+++ b/features/transactions/TransactionTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import RowActions from './RowActions';
+import { TableScroll } from '@/components/ui/table';
 import type { Transaction } from '@/lib/journal/parser';
 import formatAmount from '@/utils/formatAmount';
 import Link from 'next/link';
@@ -12,6 +13,19 @@ const statusBadge = (status: Transaction['status']) => {
   if (status === 'pending') return <span className="text-warning">!</span>;
   return null;
 };
+
+const formatTxDate = (date: string) =>
+  new Date(date).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+const accountsSummary = (t: Transaction) =>
+  `${t.postings
+    .slice(0, 2)
+    .map((p) => p.account)
+    .join(' → ')}${t.postings.length > 2 ? ' …' : ''}`;
 
 const magnitudeByCurrency = (t: Transaction): Array<[string, number]> => {
   const sums = new Map<string, number>();
@@ -34,73 +48,125 @@ const TransactionTable = ({ transactions }: Props) => {
   }
 
   return (
-    <table className="w-full text-left text-sm">
-      <thead className="text-xs uppercase tracking-wide text-muted-foreground">
-        <tr>
-          <th className="py-2">Date</th>
-          <th className="py-2 w-6"></th>
-          <th className="py-2">Payee</th>
-          <th className="py-2">Accounts</th>
-          <th className="py-2 text-right">Amount</th>
-          <th className="py-2 w-24"></th>
-        </tr>
-      </thead>
-      <tbody>
+    <>
+      {/* Mobile: stacked card rows (more readable than a 7-col table on a phone). */}
+      <ul className="flex flex-col gap-3 md:hidden">
         {transactions.map((t) => (
-          <tr
+          <li
             key={t.uid ?? `${t.file}:${t.startLine}`}
-            className="border-t border-border"
+            className="rounded-lg border border-border p-3 text-sm"
           >
-            <td className="py-2 tabular-nums">
-              {new Date(t.date).toLocaleDateString(undefined, {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-              })}
-            </td>
-            <td className="py-2">{statusBadge(t.status)}</td>
-            <td className="py-2">
-              {t.uid ? (
-                <Link
-                  href={`/transactions/${t.uid}/edit`}
-                  className="hover:underline"
-                >
-                  {t.payee}
-                </Link>
-              ) : (
-                <span>{t.payee}</span>
-              )}
-            </td>
-            <td className="py-2 text-muted-foreground">
-              {t.postings
-                .slice(0, 2)
-                .map((p) => p.account)
-                .join(' → ')}
-              {t.postings.length > 2 ? ' …' : ''}
-            </td>
-            <td className="py-2 text-right tabular-nums">
-              {magnitudeByCurrency(t).map(([ccy, amt]) => (
-                <div key={ccy}>
-                  {formatAmount(`${ccy} ${amt.toFixed(2)}`, true)}
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5 font-medium">
+                  {statusBadge(t.status)}
+                  {t.uid ? (
+                    <Link
+                      href={`/transactions/${t.uid}/edit`}
+                      className="break-words hover:underline"
+                    >
+                      {t.payee}
+                    </Link>
+                  ) : (
+                    <span className="break-words">{t.payee}</span>
+                  )}
                 </div>
-              ))}
-            </td>
-            <td className="py-2 text-right">
-              {t.uid ? (
-                <RowActions transaction={t} />
-              ) : (
-                <span
-                  className="text-xs text-muted-foreground"
-                  title="Re-import the journal to enable editing for this transaction"
-                >
-                  no uid
-                </span>
-              )}
-            </td>
-          </tr>
+                <div className="mt-0.5 text-xs tabular-nums text-muted-foreground">
+                  {formatTxDate(t.date)}
+                </div>
+              </div>
+              <div className="shrink-0">
+                {t.uid ? (
+                  <RowActions transaction={t} />
+                ) : (
+                  <span
+                    className="text-xs text-muted-foreground"
+                    title="Re-import the journal to enable editing for this transaction"
+                  >
+                    no uid
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="mt-2 flex items-end justify-between gap-3">
+              <span className="min-w-0 break-words text-xs text-muted-foreground">
+                {accountsSummary(t)}
+              </span>
+              <span className="shrink-0 text-right tabular-nums">
+                {magnitudeByCurrency(t).map(([ccy, amt]) => (
+                  <span key={ccy} className="block">
+                    {formatAmount(`${ccy} ${amt.toFixed(2)}`, true)}
+                  </span>
+                ))}
+              </span>
+            </div>
+          </li>
         ))}
-      </tbody>
-    </table>
+      </ul>
+
+      {/* Desktop: original table, wrapped so it scrolls inside its card on narrow widths. */}
+      <TableScroll className="hidden md:block">
+        <table className="w-full text-left text-sm">
+          <thead className="text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="py-2">Date</th>
+              <th className="py-2 w-6"></th>
+              <th className="py-2">Payee</th>
+              <th className="py-2">Accounts</th>
+              <th className="py-2 text-right">Amount</th>
+              <th className="py-2 w-24"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((t) => (
+              <tr
+                key={t.uid ?? `${t.file}:${t.startLine}`}
+                className="border-t border-border"
+              >
+                <td className="py-2 whitespace-nowrap tabular-nums">
+                  {formatTxDate(t.date)}
+                </td>
+                <td className="py-2">{statusBadge(t.status)}</td>
+                <td className="py-2">
+                  {t.uid ? (
+                    <Link
+                      href={`/transactions/${t.uid}/edit`}
+                      className="hover:underline"
+                    >
+                      {t.payee}
+                    </Link>
+                  ) : (
+                    <span>{t.payee}</span>
+                  )}
+                </td>
+                <td className="py-2 text-muted-foreground">
+                  {accountsSummary(t)}
+                </td>
+                <td className="py-2 text-right whitespace-nowrap tabular-nums">
+                  {magnitudeByCurrency(t).map(([ccy, amt]) => (
+                    <div key={ccy}>
+                      {formatAmount(`${ccy} ${amt.toFixed(2)}`, true)}
+                    </div>
+                  ))}
+                </td>
+                <td className="py-2 text-right">
+                  {t.uid ? (
+                    <RowActions transaction={t} />
+                  ) : (
+                    <span
+                      className="text-xs text-muted-foreground"
+                      title="Re-import the journal to enable editing for this transaction"
+                    >
+                      no uid
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableScroll>
+    </>
   );
 };
 

--- a/features/transactions/TransactionTable.tsx
+++ b/features/transactions/TransactionTable.tsx
@@ -4,6 +4,7 @@ import RowActions from './RowActions';
 import { TableScroll } from '@/components/ui/table';
 import type { Transaction } from '@/lib/journal/parser';
 import formatAmount from '@/utils/formatAmount';
+import { Format, formatDateWithLocale } from '@/utils/formatDateCore';
 import Link from 'next/link';
 
 type Props = { transactions: Transaction[] };
@@ -13,13 +14,6 @@ const statusBadge = (status: Transaction['status']) => {
   if (status === 'pending') return <span className="text-warning">!</span>;
   return null;
 };
-
-const formatTxDate = (date: string) =>
-  new Date(date).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
 
 const accountsSummary = (t: Transaction) =>
   `${t.postings
@@ -72,7 +66,7 @@ const TransactionTable = ({ transactions }: Props) => {
                   )}
                 </div>
                 <div className="mt-0.5 text-xs tabular-nums text-muted-foreground">
-                  {formatTxDate(t.date)}
+                  {formatDateWithLocale(t.date, Format.DATE)}
                 </div>
               </div>
               <div className="shrink-0">
@@ -124,7 +118,7 @@ const TransactionTable = ({ transactions }: Props) => {
                 className="border-t border-border"
               >
                 <td className="py-2 whitespace-nowrap tabular-nums">
-                  {formatTxDate(t.date)}
+                  {formatDateWithLocale(t.date, Format.DATE)}
                 </td>
                 <td className="py-2">{statusBadge(t.status)}</td>
                 <td className="py-2">

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -4,39 +4,16 @@ import getDefaultDateLocale from './getDefaultDateLocale';
 // Re-exported so existing `import formatDate, { Format } from '@/utils/formatDate'`
 // call sites keep working; client components should import the client-safe
 // primitives from './formatDateCore' directly.
-export { Format, formatDateWithLocale } from './formatDateCore';
+export {
+  Format,
+  formatDateWithLocale,
+  formatLedgerDate,
+  formatLedgerDateTime,
+  formatLedgerInstant,
+} from './formatDateCore';
 
 /** Format a date using the server-configured default locale (`DATE_LOCALE`). */
 const formatDate = (date: string, format: Format) =>
   formatDateWithLocale(date, format, getDefaultDateLocale());
 
 export default formatDate;
-
-const pad = (n: number) => String(n).padStart(2, '0');
-
-/** UTC calendar date as `YYYY/MM/DD`, without a time component. */
-export const formatLedgerDate = (d: Date): string =>
-  `${d.getUTCFullYear()}/${pad(d.getUTCMonth() + 1)}/${pad(d.getUTCDate())}`;
-
-/**
- * Format a Date as ledger's `P` directive timestamp: `YYYY/MM/DD HH:MM:SS`
- * in UTC. Stable across server timezones so price-db files diff cleanly.
- */
-export const formatLedgerDateTime = (d: Date): string =>
-  `${formatLedgerDate(d)} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
-
-/**
- * Sentinel UTC time stamped on date-only manual rates (`23:59:59`) so they sort
- * last within their day. Used to detect "no real time was given".
- */
-const isEndOfDaySentinel = (d: Date): boolean =>
-  d.getUTCHours() === 23 &&
-  d.getUTCMinutes() === 59 &&
-  d.getUTCSeconds() === 59;
-
-/**
- * Like {@link formatLedgerDateTime}, but renders a plain date when the time is
- * the end-of-day sentinel used purely for ledger ordering of date-only rates.
- */
-export const formatLedgerInstant = (d: Date): string =>
-  isEndOfDaySentinel(d) ? formatLedgerDate(d) : formatLedgerDateTime(d);

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,33 +1,14 @@
+import { Format, formatDateWithLocale } from './formatDateCore';
 import getDefaultDateLocale from './getDefaultDateLocale';
 
-export enum Format {
-  DATE,
-  MONTH_YEAR,
-  SHORT_MONTH_YEAR,
-}
+// Re-exported so existing `import formatDate, { Format } from '@/utils/formatDate'`
+// call sites keep working; client components should import the client-safe
+// primitives from './formatDateCore' directly.
+export { Format, formatDateWithLocale } from './formatDateCore';
 
-const formatOptions: Record<Format, Intl.DateTimeFormatOptions> = {
-  [Format.DATE]: {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  },
-  [Format.MONTH_YEAR]: {
-    year: 'numeric',
-    month: 'long',
-  },
-  [Format.SHORT_MONTH_YEAR]: {
-    year: 'numeric',
-    month: 'short',
-  },
-};
-
-const formatDate = (date: string, format: Format) => {
-  return new Date(date).toLocaleDateString(
-    getDefaultDateLocale(),
-    formatOptions[format]
-  );
-};
+/** Format a date using the server-configured default locale (`DATE_LOCALE`). */
+const formatDate = (date: string, format: Format) =>
+  formatDateWithLocale(date, format, getDefaultDateLocale());
 
 export default formatDate;
 

--- a/utils/formatDateCore.ts
+++ b/utils/formatDateCore.ts
@@ -37,3 +37,32 @@ export const formatDateWithLocale = (
   format: Format,
   locale?: string
 ) => new Date(date).toLocaleDateString(locale, formatOptions[format]);
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+/** UTC calendar date as `YYYY/MM/DD`, without a time component. */
+export const formatLedgerDate = (d: Date): string =>
+  `${d.getUTCFullYear()}/${pad(d.getUTCMonth() + 1)}/${pad(d.getUTCDate())}`;
+
+/**
+ * Format a Date as ledger's `P` directive timestamp: `YYYY/MM/DD HH:MM:SS`
+ * in UTC. Stable across server timezones so price-db files diff cleanly.
+ */
+export const formatLedgerDateTime = (d: Date): string =>
+  `${formatLedgerDate(d)} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+
+/**
+ * Sentinel UTC time stamped on date-only manual rates (`23:59:59`) so they sort
+ * last within their day. Used to detect "no real time was given".
+ */
+const isEndOfDaySentinel = (d: Date): boolean =>
+  d.getUTCHours() === 23 &&
+  d.getUTCMinutes() === 59 &&
+  d.getUTCSeconds() === 59;
+
+/**
+ * Like {@link formatLedgerDateTime}, but renders a plain date when the time is
+ * the end-of-day sentinel used purely for ledger ordering of date-only rates.
+ */
+export const formatLedgerInstant = (d: Date): string =>
+  isEndOfDaySentinel(d) ? formatLedgerDate(d) : formatLedgerDateTime(d);

--- a/utils/formatDateCore.ts
+++ b/utils/formatDateCore.ts
@@ -1,0 +1,39 @@
+/**
+ * Client-safe date-formatting primitives. Deliberately free of any server-only
+ * import (unlike {@link ../utils/formatDate}, whose configured-locale default
+ * pulls in `@/lib/env`), so `'use client'` components can format dates without
+ * dragging the server env into the browser bundle.
+ */
+
+export enum Format {
+  DATE,
+  MONTH_YEAR,
+  SHORT_MONTH_YEAR,
+}
+
+const formatOptions: Record<Format, Intl.DateTimeFormatOptions> = {
+  [Format.DATE]: {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  },
+  [Format.MONTH_YEAR]: {
+    year: 'numeric',
+    month: 'long',
+  },
+  [Format.SHORT_MONTH_YEAR]: {
+    year: 'numeric',
+    month: 'short',
+  },
+};
+
+/**
+ * Format a date string with an explicit locale (defaults to the runtime/browser
+ * locale when omitted). Server code should prefer the configured-locale
+ * {@link ../utils/formatDate} default instead of passing a locale by hand.
+ */
+export const formatDateWithLocale = (
+  date: string,
+  format: Format,
+  locale?: string
+) => new Date(date).toLocaleDateString(locale, formatOptions[format]);


### PR DESCRIPTION
## Phase M1 — read-first data views responsive

Makes the highest-traffic read views usable on a 375px phone by reusing M0's
`<TableScroll>` wrapper and adding a mobile card-reflow to the two widest views.
Desktop appearance is unchanged (all mobile changes are gated behind `md:`/`sm:`).

### Changes

**Card-reflow (stacked rows < `md`, original table at `md:`+):**
- **Transactions** (`features/transactions/TransactionTable.tsx`) — the 7-col table
  is hidden below `md` and replaced by a stacked card list: payee + status badge +
  row actions on the top row, date underneath, accounts summary + per-currency
  amounts on the bottom row. The original table is preserved verbatim, wrapped in
  `<TableScroll className="hidden md:block">`. Shared helpers (`formatTxDate`,
  `accountsSummary`) keep the two renderers in sync.
- **Account register** (`app/accounts/[account]/page.tsx`) — row parsing hoisted to a
  `rows` array reused by both renderers. Below `md`, each register entry renders as a
  card (payee + date header, Amount/Total as a definition list) so the multi-currency
  Total column no longer overflows. Desktop table moved inside `<TableScroll bleed={false}>`
  within its bordered card (`hidden ... md:block`).

**Scroll-wrap + de-overflow:**
- **Dashboard "recent"** (`features/dashboard/Dashboard.tsx`) — raw table wrapped in
  `<TableScroll bleed={false}>` (the card already has `overflow-hidden`, so the no-bleed
  variant keeps the scroll inside it). Amount column kept `whitespace-nowrap`; payee/account
  wrap.
- **Balance** (`app/balance/page.tsx`) — same `<TableScroll bleed={false}>` wrap; account
  column wraps, balance column kept `whitespace-nowrap`.

**Grid/layout:**
- **Dashboard journal-health grid** — was `grid-cols-2` on mobile (cramped for 6 stats);
  now `grid-cols-1` below `sm`, unchanged at `sm:`/`lg:`.
- **Account-name wrapping** — long text columns allowed to wrap across the touched views;
  `whitespace-nowrap` retained only on dates and amounts.

### Verification

- `pnpm lint` — clean
- `pnpm type-check` — clean
- `pnpm test` — **124 files / 624 tests passed** (matches baseline). Pino error logs from
  failure-path tests are expected.

### Notes

- `<TableScroll bleed={false}>` is used wherever the table lives inside an
  `overflow-hidden` card, so the horizontal scroll stays contained instead of being clipped.
- No tests touched the table markup (existing tests cover utils/parsers), so none needed updating.

Stacked PR (2/6) — stacked on #36 (M0). Merge after #36.
