### PR TITLE
feat(mobile): m2 transaction form responsive authoring

### DIFF
--- a/MOBILE-ROADMAP.md
+++ b/MOBILE-ROADMAP.md
@@ -112,16 +112,16 @@ inside a contained area with the rest of the page static. Numbers/dates never cl
 
 ## M2 — Forms & authoring
 
-- [ ] 🔴 **Transaction posting grid** `grid-cols-[1fr_140px_90px_auto]` is fixed-pixel
+- [x] 🔴 **Transaction posting grid** `grid-cols-[1fr_140px_90px_auto]` is fixed-pixel
   and overflows < ~360px; the core authoring flow breaks. Reflow to stacked rows
   on mobile (`grid-cols-1` / wrap), full-width on phones.
   `features/transactions/TransactionForm.tsx:370`
-- [ ] 🟡 **Transaction form two-column** `lg:grid-cols-[minmax(280px,360px)_1fr]` —
+- [x] 🟡 **Transaction form two-column** `lg:grid-cols-[minmax(280px,360px)_1fr]` —
   verify it collapses cleanly before `lg`; details col is cramped on tablets.
   `features/transactions/TransactionForm.tsx:179`
-- [ ] 🟡 **Prices add-rate form** `sm:grid-cols-3` date/time/quote inputs are narrow
+- [x] 🟡 **Prices add-rate form** `sm:grid-cols-3` date/time/quote inputs are narrow
   pre-`sm`; verify stacked layout on phones. `features/prices/PricesView.tsx:68`
-- [ ] 🟡 **Textarea / labels** — `min-h-16` textarea and `text-[0.7rem]` labels are
+- [x] 🟡 **Textarea / labels** — `min-h-16` textarea and `text-[0.7rem]` labels are
   cramped on phones; bump on mobile. `TransactionForm.tsx:334`, `ui/textarea.tsx:9`
 
 **Acceptance:** add/edit transaction is fully usable thumb-only on a 375px phone,

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        'flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'flex field-sizing-content min-h-24 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors md:min-h-16 outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className
       )}
       {...props}

--- a/features/prices/PricesView.tsx
+++ b/features/prices/PricesView.tsx
@@ -112,7 +112,10 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
 
         <div className="space-y-2">
           {rows.map((row, i) => (
-            <div key={i} className="flex items-end gap-2">
+            <div
+              key={i}
+              className="flex flex-col gap-2 rounded-lg border p-2 sm:flex-row sm:items-end sm:rounded-none sm:border-0 sm:p-0"
+            >
               <div className="flex-1 space-y-1">
                 {i === 0 && <Label>Commodity</Label>}
                 <Combobox
@@ -123,29 +126,31 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
                   allowFreeText
                 />
               </div>
-              <div className="flex-1 space-y-1">
-                {i === 0 && <Label htmlFor={`price-${i}`}>Rate</Label>}
-                <Input
-                  id={`price-${i}`}
-                  type="number"
-                  step="any"
-                  min="0"
-                  inputMode="decimal"
-                  value={row.price}
-                  onChange={(e) => updateRow(i, { price: e.target.value })}
-                  placeholder="0.0000033"
-                />
+              <div className="flex items-end gap-2 sm:contents">
+                <div className="flex-1 space-y-1">
+                  {i === 0 && <Label htmlFor={`price-${i}`}>Rate</Label>}
+                  <Input
+                    id={`price-${i}`}
+                    type="number"
+                    step="any"
+                    min="0"
+                    inputMode="decimal"
+                    value={row.price}
+                    onChange={(e) => updateRow(i, { price: e.target.value })}
+                    placeholder="0.0000033"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove row"
+                  onClick={() => removeRow(i)}
+                  disabled={rows.length === 1}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
               </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="Remove row"
-                onClick={() => removeRow(i)}
-                disabled={rows.length === 1}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
             </div>
           ))}
           <Button type="button" variant="outline" size="sm" onClick={addRow}>

--- a/features/transactions/TransactionForm.tsx
+++ b/features/transactions/TransactionForm.tsx
@@ -176,7 +176,7 @@ const TransactionForm = ({
             />
           )}
 
-          <div className="grid gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+          <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
             <section className="flex flex-col gap-5">
               <SectionLabel>Details</SectionLabel>
 
@@ -243,7 +243,7 @@ const TransactionForm = ({
               </Field>
             </section>
 
-            <section className="flex flex-col gap-3 lg:border-l lg:border-border lg:pl-8">
+            <section className="flex flex-col gap-3 md:border-l md:border-border md:pl-8">
               <div className="flex items-baseline justify-between">
                 <SectionLabel>Postings</SectionLabel>
                 <BalanceIndicator balance={balance} />
@@ -331,7 +331,7 @@ const TransactionForm = ({
 };
 
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground sm:text-[0.7rem]">
     {children}
   </div>
 );
@@ -367,37 +367,40 @@ const PostingRow = ({
   onChange: (patch: Partial<Posting>) => void;
   onRemove: () => void;
 }) => (
-  <div className="grid grid-cols-[1fr_140px_90px_auto] items-center gap-2">
+  <div className="grid grid-cols-1 items-center gap-2 rounded-lg border border-border p-2 sm:grid-cols-[1fr_140px_90px_auto] sm:rounded-none sm:border-0 sm:p-0">
     <Combobox
       value={posting.account}
       onChange={(v) => onChange({ account: v })}
       options={accounts}
       placeholder="Account (e.g. Expenses:Food)"
     />
-    <Input
-      type="text"
-      inputMode="decimal"
-      value={posting.amount}
-      onChange={(e) => onChange({ amount: e.target.value })}
-      placeholder="Amount"
-      className="text-right tabular-nums"
-    />
-    <Input
-      type="text"
-      value={posting.currency}
-      onChange={(e) => onChange({ currency: e.target.value })}
-      placeholder="Currency"
-    />
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      onClick={onRemove}
-      disabled={!canRemove}
-      title={canRemove ? 'Remove posting' : 'At least two postings required'}
-    >
-      ×
-    </Button>
+    <div className="flex items-center gap-2 sm:contents">
+      <Input
+        type="text"
+        inputMode="decimal"
+        value={posting.amount}
+        onChange={(e) => onChange({ amount: e.target.value })}
+        placeholder="Amount"
+        className="flex-1 text-right tabular-nums sm:flex-none"
+      />
+      <Input
+        type="text"
+        value={posting.currency}
+        onChange={(e) => onChange({ currency: e.target.value })}
+        placeholder="Currency"
+        className="w-24 sm:w-auto"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onRemove}
+        disabled={!canRemove}
+        title={canRemove ? 'Remove posting' : 'At least two postings required'}
+      >
+        ×
+      </Button>
+    </div>
   </div>
 );
 


### PR DESCRIPTION
## M2 — Forms & authoring (mobile responsiveness)

Makes the transaction authoring flow fully usable thumb-only on a 375px phone, with no desktop/tablet regression.

### Changes
- **Posting grid reflow** (`features/transactions/TransactionForm.tsx`): the fixed-pixel `grid-cols-[1fr_140px_90px_auto]` posting row that overflowed below ~360px now reflows on mobile. Mobile (`<sm`): the row becomes a bordered card with `grid-cols-1` — the account combobox is full-width on its own line, then a flex row holds amount (grows) + currency (96px) + the remove button (already 44px via M0's `icon-sm` = `size-11`). At `sm:+`, an inner `sm:contents` wrapper flattens so amount/currency/remove become direct grid children again, restoring the original 4-column layout pixel-for-pixel. Add/remove posting controls stay ≥44px touch targets.
- **Two-column form layout**: added an `md:` two-column grid (`md:grid-cols-[minmax(240px,1fr)_1.6fr]`) so tablets/landscape phones get the side-by-side Details/Postings layout instead of staying single-column until `lg`. Moved the postings-section divider (`border-l`/`pl-8`) from `lg:` to `md:` to match. `lg:` keeps the original tighter `[minmax(280px,360px)_1fr]`.
- **Prices add-rate form** (`features/prices/PricesView.tsx`): the date/time/quote grid already stacked (`grid-cols-1 sm:grid-cols-3`). Improved the commodity/rate rows to stack on phones (bordered card, commodity full-width then rate + remove side by side) using the same `sm:contents` flatten technique to restore the original `flex-row` layout at `sm:+`. Did NOT touch the prices table (reserved for PR4).
- **Textarea / labels**: bumped the section labels from `text-[0.7rem]` to `text-xs` on mobile (`sm:text-[0.7rem]` restores compact). **Touched shared `components/ui/textarea.tsx`**: `min-h-16` → `min-h-24` on mobile with `md:min-h-16` restoring desktop density.

### Verification
- `pnpm lint` — pass
- `pnpm type-check` — pass
- `pnpm test` — 624 passed / 124 files (baseline held; expected pino audit-failure logs are normal noise). No TransactionForm component test exists, so no test assertions were affected.

Stacked PR (3/6) — stacked on #37 (M1). Merge after #37.
