### PR TITLE
feat(mobile): m1 remainder tables responsive

### DIFF
--- a/MOBILE-ROADMAP.md
+++ b/MOBILE-ROADMAP.md
@@ -85,15 +85,15 @@ Wrap in scroll container + de-overflow (all 🟠 unless noted):
   dates. `app/accounts/[account]/page.tsx:41,62`
 - [x] 🟠 **Dashboard "recent"** — 4 cols + `whitespace-nowrap` date.
   `features/dashboard/Dashboard.tsx:191,210`
-- [ ] 🟠 **Prices** — 6 cols, timestamps overflow. `features/prices/PricesView.tsx:174`
-- [ ] 🟠 **Portfolio** — 4 cols, long account/commodity names.
+- [x] 🟠 **Prices** — 6 cols, timestamps overflow. `features/prices/PricesView.tsx:174`
+- [x] 🟠 **Portfolio** — 4 cols, long account/commodity names.
   `features/portfolio/Portfolio.tsx:116`
-- [ ] 🟠 **Cash flow / monthly comparison** — 4 cols, comma numbers overflow.
+- [x] 🟠 **Cash flow / monthly comparison** — 4 cols, comma numbers overflow.
   `features/monthlyComparison/MonthlyComparison.tsx:35`
 - [x] 🟠 **Balance** — 2 cols, long account names. `app/balance/page.tsx:54`
-- [ ] 🟠 **Debts** — 2 cols, long payee names. `app/debts/page.tsx:47`
-- [ ] 🟠 **Monthly register** — 2 cols. `app/registers/monthly/[account]/page.tsx:51`
-- [ ] 🟡 **Payees** — 2 cols, marginal. `features/payees/Payees.tsx:96`
+- [x] 🟠 **Debts** — 2 cols, long payee names. `app/debts/page.tsx:47`
+- [x] 🟠 **Monthly register** — 2 cols. `app/registers/monthly/[account]/page.tsx:51`
+- [x] 🟡 **Payees** — 2 cols, marginal. `features/payees/Payees.tsx:96`
 
 Grid/layout:
 
@@ -102,8 +102,10 @@ Grid/layout:
   `features/dashboard/Dashboard.tsx:244`
 - [x] 🟡 **Allow account-name wrapping** in narrow cells (drop `whitespace-nowrap`
   on the long text columns; keep it only on dates/amounts).
-- [ ] 🟡 **recharts responsiveness** — confirm charts use `<ResponsiveContainer>` and
-  don't set fixed pixel widths (portfolio / net-worth / monthly).
+- [x] 🟡 **recharts responsiveness** — confirm charts use `<ResponsiveContainer>` and
+  don't set fixed pixel widths (portfolio / net-worth / monthly). Verified: all
+  charts route through `Chart` → `ChartContainer` → `ResponsiveContainer` with a
+  `w-full` box and `height` set via CSS only; no fixed pixel widths anywhere.
 
 **Acceptance:** every table is either fully readable stacked, or scrolls smoothly
 inside a contained area with the rest of the page static. Numbers/dates never clip.

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -1,5 +1,6 @@
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import { TableScroll } from '@/components/ui/table';
 import { getBaseCurrency } from '@/lib/settings';
 import formatAmount from '@/utils/formatAmount';
 import runLedger from '@/utils/runLedger';
@@ -44,44 +45,46 @@ const Debts = async () => {
       </div>
 
       <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-        <table>
-          <thead>
-            <tr>
-              <th>Payee</th>
-              <th className="text-right">
-                Amount ({defaultCurrency.toUpperCase()})
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {debts.length === 0 ? (
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={2} className="py-6 text-center text-muted">
-                  No debts
-                </td>
+                <th>Payee</th>
+                <th className="text-right whitespace-nowrap">
+                  Amount ({defaultCurrency.toUpperCase()})
+                </th>
               </tr>
-            ) : (
-              debts.map((debt, idx) => {
-                const columns = debt.split('|').map((each) => each.trim());
-                return (
-                  <tr key={idx}>
-                    <td>
-                      <Link
-                        className="block text-fg hover:text-accent"
-                        href={`/accounts/${encodeURIComponent(columns[0])}`}
-                      >
-                        {columns[0]}
-                      </Link>
-                    </td>
-                    <td className="text-right">
-                      {formatAmount(columns[1], false)}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {debts.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="py-6 text-center text-muted">
+                    No debts
+                  </td>
+                </tr>
+              ) : (
+                debts.map((debt, idx) => {
+                  const columns = debt.split('|').map((each) => each.trim());
+                  return (
+                    <tr key={idx}>
+                      <td>
+                        <Link
+                          className="block text-fg hover:text-accent"
+                          href={`/accounts/${encodeURIComponent(columns[0])}`}
+                        >
+                          {columns[0]}
+                        </Link>
+                      </td>
+                      <td className="text-right whitespace-nowrap">
+                        {formatAmount(columns[1], false)}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </TableScroll>
       </div>
     </div>
   );

--- a/app/registers/monthly/[account]/page.tsx
+++ b/app/registers/monthly/[account]/page.tsx
@@ -1,5 +1,6 @@
 import Chart from '@/components/Chart';
 import { Card, CardContent } from '@/components/ui/card';
+import { TableScroll } from '@/components/ui/table';
 import RegisterHeader from '@/features/registers/monthly/RegisterHeader';
 import { requireUser } from '@/lib/auth/require-user';
 import { savedViewService } from '@/lib/savedViews';
@@ -48,35 +49,41 @@ const Monthly = async ({
       />
 
       <Card className="gap-0 overflow-hidden p-0">
-        <table>
-          <thead>
-            <tr>
-              <th>Month</th>
-              <th className="text-right">Balance ({defaultCurrency})</th>
-            </tr>
-          </thead>
-          <tbody>
-            {results.length === 0 ? (
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={2} className="py-6 text-center text-muted">
-                  No transactions
-                </td>
+                <th className="whitespace-nowrap">Month</th>
+                <th className="text-right whitespace-nowrap">
+                  Balance ({defaultCurrency})
+                </th>
               </tr>
-            ) : (
-              results.map((item, index) => {
-                const columns = item.split('|');
-                return (
-                  <tr key={index}>
-                    <td>{formatDate(columns[0], Format.MONTH_YEAR)}</td>
-                    <td className="text-right">
-                      {formatAmount(columns[1], false)}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {results.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="py-6 text-center text-muted">
+                    No transactions
+                  </td>
+                </tr>
+              ) : (
+                results.map((item, index) => {
+                  const columns = item.split('|');
+                  return (
+                    <tr key={index}>
+                      <td className="whitespace-nowrap">
+                        {formatDate(columns[0], Format.MONTH_YEAR)}
+                      </td>
+                      <td className="text-right whitespace-nowrap">
+                        {formatAmount(columns[1], false)}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </TableScroll>
       </Card>
 
       {results.length > 0 && (

--- a/features/monthlyComparison/MonthlyComparison.tsx
+++ b/features/monthlyComparison/MonthlyComparison.tsx
@@ -3,6 +3,7 @@ import Chart from '@/components/Chart';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
 import { Card, CardContent } from '@/components/ui/card';
+import { TableScroll } from '@/components/ui/table';
 import { getBaseCurrency } from '@/lib/settings';
 import formatDate, { Format } from '@/utils/formatDate';
 
@@ -32,50 +33,56 @@ const MonthlyComparison = async () => {
       </div>
 
       <Card className="gap-0 overflow-hidden p-0">
-        <table>
-          <thead>
-            <tr>
-              <th>Month</th>
-              <th className="text-right">Income ({currency.toUpperCase()})</th>
-              <th className="text-right">
-                Expenses ({currency.toUpperCase()})
-              </th>
-              <th className="text-right">Net ({currency.toUpperCase()})</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.length === 0 ? (
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={4} className="py-6 text-center text-muted">
-                  No data
-                </td>
+                <th className="whitespace-nowrap">Month</th>
+                <th className="text-right whitespace-nowrap">
+                  Income ({currency.toUpperCase()})
+                </th>
+                <th className="text-right whitespace-nowrap">
+                  Expenses ({currency.toUpperCase()})
+                </th>
+                <th className="text-right whitespace-nowrap">
+                  Net ({currency.toUpperCase()})
+                </th>
               </tr>
-            ) : (
-              [...rows].reverse().map((r) => {
-                const net = r.income - r.expenses;
-                const netClass = net >= 0 ? 'text-positive' : 'text-negative';
-                return (
-                  <tr key={r.date.toISOString()}>
-                    <td>
-                      {formatDate(r.date.toISOString(), Format.MONTH_YEAR)}
-                    </td>
-                    <td className="text-right tabular-nums text-positive">
-                      {formatNumber(r.income)}
-                    </td>
-                    <td className="text-right tabular-nums text-negative">
-                      {formatNumber(r.expenses)}
-                    </td>
-                    <td
-                      className={`text-right font-medium tabular-nums ${netClass}`}
-                    >
-                      {formatNumber(net)}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="py-6 text-center text-muted">
+                    No data
+                  </td>
+                </tr>
+              ) : (
+                [...rows].reverse().map((r) => {
+                  const net = r.income - r.expenses;
+                  const netClass = net >= 0 ? 'text-positive' : 'text-negative';
+                  return (
+                    <tr key={r.date.toISOString()}>
+                      <td className="whitespace-nowrap">
+                        {formatDate(r.date.toISOString(), Format.MONTH_YEAR)}
+                      </td>
+                      <td className="text-right tabular-nums whitespace-nowrap text-positive">
+                        {formatNumber(r.income)}
+                      </td>
+                      <td className="text-right tabular-nums whitespace-nowrap text-negative">
+                        {formatNumber(r.expenses)}
+                      </td>
+                      <td
+                        className={`text-right font-medium tabular-nums whitespace-nowrap ${netClass}`}
+                      >
+                        {formatNumber(net)}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </TableScroll>
       </Card>
 
       {rows.length > 0 && (

--- a/features/payees/Payees.tsx
+++ b/features/payees/Payees.tsx
@@ -3,6 +3,7 @@ import DateFilter from '@/components/DateFilter';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
 import { Card, CardContent } from '@/components/ui/card';
+import { TableScroll } from '@/components/ui/table';
 import SaveViewButton from '@/features/savedViews/SaveViewButton';
 import { requireUser } from '@/lib/auth/require-user';
 import { parsePayeeRows } from '@/lib/payees/parse';
@@ -93,32 +94,36 @@ const Payees = async ({ from: fromParam, to: toParam }: Props) => {
       />
 
       <Card className="gap-0 overflow-hidden p-0">
-        <table>
-          <thead>
-            <tr>
-              <th>Payee</th>
-              <th className="text-right">Total ({currency})</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.length === 0 ? (
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
               <tr>
-                <td colSpan={2} className="py-6 text-center text-muted">
-                  No payee data in this period
-                </td>
+                <th>Payee</th>
+                <th className="text-right whitespace-nowrap">
+                  Total ({currency})
+                </th>
               </tr>
-            ) : (
-              sorted.map((r) => (
-                <tr key={r.payee}>
-                  <td>{r.payee}</td>
-                  <td className="text-right tabular-nums text-negative">
-                    {formatNumber(r.total)}
+            </thead>
+            <tbody>
+              {sorted.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="py-6 text-center text-muted">
+                    No payee data in this period
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+              ) : (
+                sorted.map((r) => (
+                  <tr key={r.payee}>
+                    <td>{r.payee}</td>
+                    <td className="text-right tabular-nums whitespace-nowrap text-negative">
+                      {formatNumber(r.total)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </TableScroll>
       </Card>
 
       {sorted.length > 0 && (

--- a/features/portfolio/Portfolio.tsx
+++ b/features/portfolio/Portfolio.tsx
@@ -11,6 +11,7 @@ import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
 import { buttonVariants } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { TableScroll } from '@/components/ui/table';
 import { env } from '@/lib/env';
 import { getBaseCurrency } from '@/lib/settings';
 import { cn } from '@/lib/utils';
@@ -113,39 +114,43 @@ const Portfolio = async () => {
       </header>
 
       <Card className="gap-0 overflow-hidden p-0">
-        <table>
-          <thead>
-            <tr>
-              <th>Account</th>
-              <th className="text-right">Native</th>
-              <th className="text-right">
-                Value ({defaultCurrency.toUpperCase()})
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.account}>
-                <td>
-                  <Link
-                    className="block text-fg hover:text-accent"
-                    href={`/accounts/${encodeURIComponent(row.account)}`}
-                  >
-                    {row.account}
-                  </Link>
-                </td>
-                <td className="text-right">{formatAmount(row.native, true)}</td>
-                <td className="text-right">
-                  {row.converted ? (
-                    formatAmount(row.converted, true)
-                  ) : (
-                    <span className="text-xs text-muted-foreground">—</span>
-                  )}
-                </td>
+        <TableScroll bleed={false}>
+          <table>
+            <thead>
+              <tr>
+                <th>Account</th>
+                <th className="text-right whitespace-nowrap">Native</th>
+                <th className="text-right whitespace-nowrap">
+                  Value ({defaultCurrency.toUpperCase()})
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.account}>
+                  <td>
+                    <Link
+                      className="block text-fg hover:text-accent"
+                      href={`/accounts/${encodeURIComponent(row.account)}`}
+                    >
+                      {row.account}
+                    </Link>
+                  </td>
+                  <td className="text-right whitespace-nowrap">
+                    {formatAmount(row.native, true)}
+                  </td>
+                  <td className="text-right whitespace-nowrap">
+                    {row.converted ? (
+                      formatAmount(row.converted, true)
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TableScroll>
       </Card>
     </div>
   );

--- a/features/prices/PricesView.tsx
+++ b/features/prices/PricesView.tsx
@@ -6,6 +6,7 @@ import Combobox from '@/components/Combobox/Combobox';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { TableScroll } from '@/components/ui/table';
 import type { ManualPrice } from '@/db/schema';
 import {
   addManualPricesAction,
@@ -176,41 +177,45 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
         {prices.length === 0 ? (
           <p className="text-muted-foreground text-sm">No manual prices yet.</p>
         ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-muted-foreground text-left">
-                <th className="py-1">When</th>
-                <th>Commodity</th>
-                <th className="text-right">Rate</th>
-                <th>Quote</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {prices.map((p) => (
-                <tr key={p.id} className="border-t">
-                  <td className="py-1">
-                    {formatLedgerInstant(new Date(p.pricedAt))}
-                  </td>
-                  <td>{p.symbol}</td>
-                  <td className="text-right tabular-nums">{p.price}</td>
-                  <td>{p.quote}</td>
-                  <td className="text-right">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Delete ${p.symbol} rate`}
-                      disabled={isDeleting && deletingId === p.id}
-                      onClick={() => handleDelete(p.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </td>
+          <TableScroll>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground text-left">
+                  <th className="py-1 whitespace-nowrap">When</th>
+                  <th>Commodity</th>
+                  <th className="text-right whitespace-nowrap">Rate</th>
+                  <th>Quote</th>
+                  <th />
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {prices.map((p) => (
+                  <tr key={p.id} className="border-t">
+                    <td className="py-1 whitespace-nowrap">
+                      {formatLedgerInstant(new Date(p.pricedAt))}
+                    </td>
+                    <td>{p.symbol}</td>
+                    <td className="text-right tabular-nums whitespace-nowrap">
+                      {p.price}
+                    </td>
+                    <td>{p.quote}</td>
+                    <td className="text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${p.symbol} rate`}
+                        disabled={isDeleting && deletingId === p.id}
+                        onClick={() => handleDelete(p.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
         )}
       </section>
     </div>


### PR DESCRIPTION
## Summary

Completes the **M1 remainder** of the mobile-responsiveness roadmap — wraps the last data tables in the shared `<TableScroll>` container so they scroll smoothly inside a contained area on phones instead of overflowing the viewport, and verifies recharts is responsive.

### Tables wrapped (`<TableScroll>` + de-overflow)
- **Prices** history table — `features/prices/PricesView.tsx`
- **Portfolio** — `features/portfolio/Portfolio.tsx`
- **Cash flow / monthly comparison** — `features/monthlyComparison/MonthlyComparison.tsx`
- **Debts** — `app/debts/page.tsx`
- **Monthly register** — `app/registers/monthly/[account]/page.tsx`
- **Payees** — `features/payees/Payees.tsx`

### Pattern (consistent with M1 read-first work)
- `bleed={false}` on `<TableScroll>` where the table lives inside an `overflow-hidden` card (portfolio, cashflow, debts, monthly register, payees); default bleed for the prices history table (not card-wrapped).
- Dropped `whitespace-nowrap` on long text columns (account / commodity / payee names) so they wrap; **kept** `whitespace-nowrap` on date and amount columns so numbers/dates never clip.
- Mobile-first; desktop unchanged.

### recharts responsiveness
Verified, no code change needed: every chart routes through `Chart` → `ChartContainer` → recharts `<ResponsiveContainer>` with a `w-full` box and `height` set via CSS only. No fixed pixel widths anywhere in `features/`. (The `LineChart`/`PieChart` references in `Landing.tsx` are lucide icons, not recharts.)

### Roadmap
All M1 remainder checkboxes ticked in `MOBILE-ROADMAP.md` (prices, portfolio, cashflow, debts, monthly register, payees, recharts). After this PR, **all M1 items are done**.

## Verification
- `pnpm lint` — pass
- `pnpm type-check` — pass
- `pnpm test` — **624 passed / 124 files** (baseline held; pino audit-log error logs are expected test-env noise)

Stacked PR (4/6) — stacked on #38 (M2). Merge after #38.