### PR TITLE
feat(mobile): m3 nav drawer auto-close and responsive chrome

### DIFF
--- a/MOBILE-ROADMAP.md
+++ b/MOBILE-ROADMAP.md
@@ -133,17 +133,23 @@ including adding/removing posting rows, with the submit button reachable.
 
 ## M3 — Navigation & chrome
 
-- [ ] 🟠 **Sidebar drawer doesn't auto-close on navigation.** `SidebarMenuButton`
+- [x] 🟠 **Sidebar drawer doesn't auto-close on navigation.** `SidebarMenuButton`
   fires `onClick` but never calls `setOpenMobile(false)`, so the drawer stays
   open over the content after tapping a nav link. Close it on mobile navigation
   (either in `SidebarMenuButton` or via a pathname effect in `AppSidebar`).
   `components/ui/sidebar.tsx:255-288`, `components/Sidebar/AppSidebar.tsx`
-- [ ] 🟡 **Mobile sidebar width** `SIDEBAR_WIDTH_MOBILE = '18rem'` (288px ≈ 77% of a
+  → Done via a pathname `useEffect` in `AppSidebar` (least intrusive; leaves the
+  shared `SidebarMenuButton` primitive untouched; covers every navigation entry
+  point — nav links, command palette, breadcrumbs, browser back/forward).
+- [x] 🟡 **Mobile sidebar width** `SIDEBAR_WIDTH_MOBILE = '18rem'` (288px ≈ 77% of a
   375px screen). Acceptable since it's an overlay that auto-closes after M3.1;
   optionally trim to ~16rem. `components/ui/sidebar.tsx:30`
+  → Kept at 18rem: now that it auto-closes the overlay width is acceptable, and
+  trimming risks truncating longer labels ("Add transaction", "Periodic Balance").
 - [ ] ⚪ **Header height / safe area** — `h-14` sticky header has no notch awareness;
   fold into M5 safe-area work. `components/Header/AppHeader.tsx:51`
-- [ ] ⚪ **Content bottom padding** `pb-20` is heavy on short mobile viewports; make
+  → Deferred to M5 (safe-area / `viewport-fit=cover` work lands there).
+- [x] ⚪ **Content bottom padding** `pb-20` is heavy on short mobile viewports; make
   responsive (`pb-12 sm:pb-20`). `components/AppShell/AppShell.tsx:54`
 
 **Acceptance:** tapping a nav item navigates *and* dismisses the drawer; nav usable

--- a/components/AppShell/AppShell.tsx
+++ b/components/AppShell/AppShell.tsx
@@ -51,7 +51,7 @@ const AppShell = ({ children, headerSlot, bannerSlot }: Props) => {
           <AppSidebar />
           <SidebarInset>
             <AppHeader slot={headerSlot} />
-            <div className="mx-auto w-full max-w-7xl px-4 pb-20 pt-8 sm:px-6 lg:px-8">
+            <div className="mx-auto w-full max-w-7xl px-4 pb-12 pt-8 sm:px-6 sm:pb-20 lg:px-8">
               {bannerSlot}
               {children}
             </div>

--- a/components/Sidebar/AppSidebar.tsx
+++ b/components/Sidebar/AppSidebar.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  useSidebar,
 } from '@/components/ui/sidebar';
 import { APP_NAME } from '@/lib/app';
 import Link from 'next/link';
@@ -23,6 +24,17 @@ const AppSidebar = () => {
   const pathname = usePathname();
   const sections = React.useMemo(() => getNavSections(), []);
   const { isActive } = useActiveMenu(pathname);
+  const { setOpenMobile } = useSidebar();
+
+  // Close the mobile drawer whenever navigation lands on a new route. The
+  // shadcn SidebarMenuButton only fires onClick and never dismisses the
+  // overlay, so without this the drawer stays open on top of the content
+  // after tapping a nav link. Keying off the pathname covers every entry
+  // point (nav links, command palette, breadcrumbs, browser back/forward),
+  // not just the menu buttons.
+  React.useEffect(() => {
+    setOpenMobile(false);
+  }, [pathname, setOpenMobile]);
 
   return (
     <Sidebar collapsible="icon">


### PR DESCRIPTION
## M3 — Navigation & chrome

Mobile-responsiveness roadmap, Phase M3. Makes the sidebar nav usable one-handed on phones and trims heavy mobile chrome.

### Changes
- **Sidebar drawer auto-close on navigation** (the important one). The shadcn `SidebarMenuButton` only fires `onClick` and never calls `setOpenMobile(false)`, so on mobile the drawer stayed open over the content after tapping a nav link. Fixed with a pathname `useEffect` in `components/Sidebar/AppSidebar.tsx`:
  - Chose approach (b) over editing the shared `SidebarMenuButton` primitive — it's the least intrusive option, leaves the primitive (used for non-nav purposes too) untouched, and closes the drawer on **every** navigation entry point: nav links, command palette, breadcrumbs, and browser back/forward. The effect keys off `pathname`; `setOpenMobile` is a stable memoized setter, so it only runs on real route changes and is a no-op on mount (drawer already closed).
- **Responsive content bottom padding** — `pb-20` → `pb-12 sm:pb-20` in `components/AppShell/AppShell.tsx`, lighter on short mobile viewports.
- **Mobile sidebar width** — kept at `18rem`. Now that the overlay auto-closes the width is acceptable, and trimming to 16rem risked truncating longer labels ("Add transaction", "Periodic Balance"). Documented in the roadmap.
- **Header height / safe area** — deferred to M5 (the `viewport-fit=cover` / `env(safe-area-inset-*)` work lands there), per the roadmap. No change here.

### Verification
- `pnpm lint` — clean
- `pnpm type-check` — clean
- `pnpm test` — **624 passed / 124 files** (baseline unchanged; pino audit-log error logs are expected test noise)

No DOM testing library (jsdom / @testing-library) is installed — existing component tests are server static-markup only, so there's no seam to test a client `useEffect` reacting to pathname changes without adding an out-of-scope dependency. The change is a small, well-understood pattern; no brittle test fabricated.

Stacked PR (5/6) — stacked on #39 (M1 remainder). Merge after #39.
