### PR TITLE
feat(mobile): m4 overlays and m5 viewport/pwa/safe-area polish

### DIFF
--- a/MOBILE-ROADMAP.md
+++ b/MOBILE-ROADMAP.md
@@ -146,9 +146,10 @@ including adding/removing posting rows, with the submit button reachable.
   optionally trim to ~16rem. `components/ui/sidebar.tsx:30`
   → Kept at 18rem: now that it auto-closes the overlay width is acceptable, and
   trimming risks truncating longer labels ("Add transaction", "Periodic Balance").
-- [ ] ⚪ **Header height / safe area** — `h-14` sticky header has no notch awareness;
-  fold into M5 safe-area work. `components/Header/AppHeader.tsx:51`
-  → Deferred to M5 (safe-area / `viewport-fit=cover` work lands there).
+- [x] ⚪ **Header height / safe area** — `h-14` sticky header now folds in
+  `env(safe-area-inset-top)` (height + `pt`) and `env(safe-area-inset-left)`
+  (px), so notched devices clear the cutout. Done in M5 alongside the
+  `viewport-fit=cover` export. `components/Header/AppHeader.tsx:51`
 - [x] ⚪ **Content bottom padding** `pb-20` is heavy on short mobile viewports; make
   responsive (`pb-12 sm:pb-20`). `components/AppShell/AppShell.tsx:54`
 
@@ -161,16 +162,21 @@ one-handed.
 
 These mostly matter on the smallest phones (≤ 320px) and in landscape.
 
-- [ ] 🟠 **Popover fixed `w-72`** (288px) overflows < 320px. Make responsive
+- [x] 🟠 **Popover fixed `w-72`** (288px) overflows < 320px. Made responsive
   (`w-[min(18rem,calc(100vw-2rem))]`). `components/ui/popover.tsx:39`
-- [ ] 🟡 **Select `min-w-36`** dropdown can clip near screen edge; verify Base UI
-  flip + cap to viewport. `components/ui/select.tsx:86`
-- [ ] 🟡 **Command palette `max-h-72`** eats ~40% of portrait height; make it
+- [x] 🟡 **Select `min-w-36`** dropdown can clip near screen edge; Base UI
+  Positioner already flips/repositions — added `max-w-[calc(100vw-1rem)]` so the
+  popup can never exceed the viewport. `components/ui/select.tsx:86`
+- [x] 🟡 **Command palette `max-h-72`** eats ~40% of portrait height; made it
   viewport-relative (`max-h-[60dvh]`). `components/ui/command.tsx:96`
-- [ ] 🟡 **Dialog tablet breakpoint** — `sm:max-w-sm` (448px) can exceed landscape
-  tablet width; add a sane upper cap. `components/ui/dialog.tsx:55`
-- [ ] 🟡 **Generic Sheet `w-3/4`** — only used outside the sidebar; verify any such
-  usages aren't dominating small screens. `components/ui/sheet.tsx:55`
+- [x] 🟡 **Dialog tablet breakpoint** — `sm:max-w-sm` (448px) is already capped by
+  the base `max-w-[calc(100%-2rem)]` so it never exceeds the viewport; also added
+  `max-h-[calc(100dvh-2rem)] overflow-y-auto` so tall dialogs scroll on short
+  screens instead of overflowing. `components/ui/dialog.tsx:55`
+- [x] 🟡 **Generic Sheet `w-3/4`** — its only consumer is the sidebar drawer, which
+  overrides width via `--sidebar-width` (18rem). The generic left/right `w-3/4`
+  is already capped by `data-[side=*]:sm:max-w-sm`, so no usage dominates a small
+  screen. Left as-is (verified). `components/ui/sheet.tsx:55`
 
 **Acceptance:** open every overlay on a 320px device — nothing renders off-screen
 or clips its content.
@@ -179,14 +185,33 @@ or clips its content.
 
 ## M5 — Polish & PWA
 
-- [ ] ⚪ **Explicit `viewport` export** with `viewportFit: 'cover'` + `themeColor`
-  (light/dark) and safe-area-inset padding on the sticky header / bottom of
-  scroll areas (`env(safe-area-inset-*)`) for notched devices. `app/layout.tsx`
-- [ ] ⚪ **PWA metadata** — `mobile-web-app-capable`, theme color, apple touch icon.
-- [ ] ⚪ **Tablet (768–1023px) pass** — several layouts only optimize at `lg:`;
-  add `md:` adjustments for iPad / landscape phone.
-- [ ] ⚪ **Hover-only affordances** — ensure `:active`/`focus-visible` parity for
-  touch where the UI relies on `hover:` (sidebar items, links).
+- [x] ⚪ **Explicit `viewport` export** with `viewportFit: 'cover'` + `themeColor`
+  (light/dark `#fbfaf7` / `#0a1016`, via `prefers-color-scheme` media) added to
+  `app/layout.tsx`. Sticky header now grows by `env(safe-area-inset-top)`
+  (`h-[calc(3.5rem+env(safe-area-inset-top))]` + matching `pt`) and uses
+  `px-[max(…,env(safe-area-inset-left))]` so content clears the notch; the
+  scroll-area bottom padding folds in `env(safe-area-inset-bottom)`
+  (`pb-[max(3rem,env(safe-area-inset-bottom))]`). This also covers M3's deferred
+  header/safe-area item. `app/layout.tsx`, `components/Header/AppHeader.tsx`,
+  `components/AppShell/AppShell.tsx`
+- [x] ⚪ **PWA metadata** — added `mobile-web-app-capable: yes`, `appleWebApp`
+  (capable + title), `applicationName`, and `themeColor`. **Apple-touch / manifest
+  icon deferred:** no icon asset exists in `public/` or `app/`; referencing one
+  would 404, so it is left as a follow-up (drop `app/apple-icon.png` +
+  `app/icon.png` and Next wires them automatically). `app/layout.tsx`
+- [x] ⚪ **Tablet (768–1023px) pass** — audited every `lg:`/`md:` grid in-app. The
+  read-first views are tables (already handled by `TableScroll` in M1); the
+  dashboard stat/health grids ramp cleanly `sm:grid-cols-2/3 → lg:grid-cols-3/6`
+  (2-/3-up on tablet is comfortable) and the transaction form already gained its
+  `md:` two-column layout in M2. No in-app layout was found cramped enough to
+  need a new `md:` breakpoint; remaining `lg:`-only splits are full-bleed
+  marketing/auth pages (intentional). No change required.
+- [x] ⚪ **Hover-only affordances** — verified `:active`/`focus-visible` parity. The
+  mobile nav (`SidebarMenuButton`) base class already carries `active:bg-…` +
+  `focus-visible:ring-2` (so all cva variants inherit touch feedback); the
+  `SidebarMenuSubButton` likewise. The header mega-menu is desktop-only
+  (`hidden md:flex`). No hover-only affordance is invisible to touch; no change
+  required.
 
 ---
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import AppShell from '@/components/AppShell';
 import BaseCurrencyBanner from '@/components/BaseCurrencyBanner';
@@ -13,6 +13,34 @@ const geist = Geist({ subsets: ['latin'], variable: '--font-sans' });
 export const metadata: Metadata = {
   title: APP_NAME,
   description: 'NextJS reporting tool for ledger-cli journals',
+  applicationName: APP_NAME,
+  appleWebApp: {
+    capable: true,
+    title: APP_NAME,
+    statusBarStyle: 'default',
+  },
+  // `mobile-web-app-capable` (the modern replacement for the deprecated
+  // `apple-mobile-web-app-capable`) is emitted via the `other` map so the app
+  // is installable as a standalone PWA shell.
+  other: {
+    'mobile-web-app-capable': 'yes',
+  },
+  // NOTE: no apple-touch-icon / manifest icon is referenced yet — none exists
+  // in public/ or app/. Adding the meta below without the asset would 404, so
+  // the icon is left as a follow-up (drop an app/apple-icon.png + app/icon.png
+  // and Next will wire them automatically).
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  // Let content extend into the notch / home-indicator area; the sticky header
+  // and scroll areas add their own env(safe-area-inset-*) padding to clear it.
+  viewportFit: 'cover',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#fbfaf7' },
+    { media: '(prefers-color-scheme: dark)', color: '#0a1016' },
+  ],
 };
 
 export default function RootLayout({

--- a/components/AppShell/AppShell.tsx
+++ b/components/AppShell/AppShell.tsx
@@ -51,7 +51,7 @@ const AppShell = ({ children, headerSlot, bannerSlot }: Props) => {
           <AppSidebar />
           <SidebarInset>
             <AppHeader slot={headerSlot} />
-            <div className="mx-auto w-full max-w-7xl px-4 pb-12 pt-8 sm:px-6 sm:pb-20 lg:px-8">
+            <div className="mx-auto w-full max-w-7xl px-4 pb-[max(3rem,env(safe-area-inset-bottom))] pt-8 sm:px-6 sm:pb-[max(5rem,env(safe-area-inset-bottom))] lg:px-8">
               {bannerSlot}
               {children}
             </div>

--- a/components/Header/AppHeader.tsx
+++ b/components/Header/AppHeader.tsx
@@ -46,7 +46,7 @@ const AppHeader = ({ slot }: Props) => {
   };
 
   return (
-    <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-3 border-b border-border bg-bg/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-bg/60 sm:px-6 lg:px-8">
+    <header className="sticky top-0 z-30 flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 items-center gap-3 border-b border-border bg-bg/95 px-[max(1rem,env(safe-area-inset-left))] pt-[env(safe-area-inset-top)] backdrop-blur supports-[backdrop-filter]:bg-bg/60 sm:px-[max(1.5rem,env(safe-area-inset-left))] lg:px-[max(2rem,env(safe-area-inset-left))]">
       <SidebarTrigger />
 
       <NavigationMenu className="hidden md:flex" align="start">

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -93,7 +93,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        'no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none',
+        'no-scrollbar max-h-[60dvh] scroll-py-1 overflow-x-hidden overflow-y-auto outline-none',
         className
       )}
       {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -52,7 +52,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className
         )}
         {...props}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -36,7 +36,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            'z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            'z-50 flex w-[min(18rem,calc(100vw-2rem))] origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             className
           )}
           {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -83,7 +83,7 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            'relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            'relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 max-w-[calc(100vw-1rem)] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             className
           )}
           {...props}


### PR DESCRIPTION
Final phase of the mobile-responsiveness roadmap: **M4 (overlays)** + **M5 (polish & PWA)**, including M3's deferred header/safe-area work.

## M4 — Overlays (matter on ≤320px / landscape)
- **Popover** (`components/ui/popover.tsx`): fixed `w-72` (288px, overflows <320px) → `w-[min(18rem,calc(100vw-2rem))]`.
- **Select** (`components/ui/select.tsx`): Base UI Positioner already flips/repositions; added `max-w-[calc(100vw-1rem)]` so the `min-w-36` popup can never exceed the viewport near a screen edge.
- **Command palette** (`components/ui/command.tsx`): `max-h-72` → `max-h-[60dvh]` (viewport-relative, stops eating ~40% of portrait height).
- **Dialog** (`components/ui/dialog.tsx`): `sm:max-w-sm` width is already capped by the base `max-w-[calc(100%-2rem)]`; added `max-h-[calc(100dvh-2rem)] overflow-y-auto` so tall dialogs scroll on short screens instead of overflowing.
- **Sheet** (`components/ui/sheet.tsx`): verified — its only consumer is the sidebar drawer (which overrides width via `--sidebar-width`); the generic left/right `w-3/4` is already capped by `sm:max-w-sm`. No change needed.

## M5 — Polish & PWA
- **Viewport export** (`app/layout.tsx`): explicit `Viewport` with `viewportFit: 'cover'`, `width: 'device-width'`, and light/dark `themeColor` (`#fbfaf7` / `#0a1016`) via `prefers-color-scheme` media.
- **PWA metadata**: `mobile-web-app-capable: yes`, `appleWebApp` (capable + title), `applicationName`. **apple-touch/manifest icon deferred** — no icon asset exists in `public/` or `app/`; referencing one would 404, so it's left as a follow-up (drop `app/apple-icon.png` + `app/icon.png` and Next wires them automatically).
- **Safe-area (covers M3's deferred item)**: sticky header now `h-[calc(3.5rem+env(safe-area-inset-top))]` + matching `pt`, and `px-[max(…,env(safe-area-inset-left))]`, so content clears the notch (zero-cost on non-notched devices). Scroll-area bottom padding folds in `env(safe-area-inset-bottom)` in `AppShell`.
- **Tablet pass** + **hover/touch affordance audit**: documented in the roadmap; no code change needed (dashboard grids ramp cleanly, transaction form already has `md:` from M2; `SidebarMenuButton` base already has `active:`/`focus-visible:` parity).

## Verification
- `pnpm lint` ✅ clean
- `pnpm type-check` ✅ clean (also enforced by pre-commit hook)
- `pnpm test` ✅ **124 files / 624 passed** (baseline held; pino DB-auth error logs are expected noise)
- `viewport`/`metadata` use the correct Next.js `Viewport`/`Metadata` types (validated by type-check).

Roadmap (`MOBILE-ROADMAP.md`): all M4 + M5 items ticked; the deferred icon asset is noted inline rather than ticked.

Stacked PR (6/6 — final) — stacked on #40 (M3). Merge after #40. Completes the mobile roadmap.