### PR TITLE
fix(crypto): share session DEK + rate-limit stores across server contexts

### DIFF
--- a/lib/crypto/sessionKeys.ts
+++ b/lib/crypto/sessionKeys.ts
@@ -1,7 +1,21 @@
 // lib/crypto/sessionKeys.ts
 import { DEK_BYTES } from './constants';
 
-const keys = new Map<string, Buffer>();
+// The in-RAM DEK store MUST live on `globalThis`, not in a plain module-level
+// `const`. Next.js evaluates this module in separate instances per server
+// context (route handlers, RSC render, instrumentation), so a module-scoped Map
+// would let the unlock API route (setSessionDek) and the CryptoGate render
+// (hasSessionDek) write to and read from *different* maps — the gate would never
+// see the unlocked DEK and would bounce every unlocked user back to
+// /crypto/unlock. Pinning the Map on globalThis gives every instance one shared
+// store for the lifetime of the process.
+const globalForSessionKeys = globalThis as typeof globalThis & {
+  __ledgerSessionDeks?: Map<string, Buffer>;
+};
+const keys = (globalForSessionKeys.__ledgerSessionDeks ??= new Map<
+  string,
+  Buffer
+>());
 
 /** Thrown when an operation needs the DEK but the session is locked. */
 export class LockedError extends Error {

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -5,7 +5,17 @@ import {
   type RateLimitResult,
 } from './store';
 
-const store = new MemoryStore();
+// Pinned on globalThis rather than a plain module-level `const`: Next.js
+// evaluates this module in separate instances per server context (route
+// handlers, RSC render, instrumentation), so a module-scoped store would give
+// each context its own bucket map — counting hits separately and silently
+// weakening every limit. A single globalThis-backed store keeps the count
+// honest across the whole process. See lib/crypto/sessionKeys.ts for the same
+// rationale.
+const globalForRateLimit = globalThis as typeof globalThis & {
+  __ledgerRateLimitStore?: MemoryStore;
+};
+const store = (globalForRateLimit.__ledgerRateLimitStore ??= new MemoryStore());
 
 /** Per-user rate-limit check against a named policy. */
 export function rateLimit(


### PR DESCRIPTION
## Problem

Entering a correct passphrase on **Your journal is locked** appeared to do nothing: after a few seconds the page "refreshed" back onto the unlock screen. The unlock was actually *succeeding* — the delay was Argon2 key derivation, and the reload only fires on success.

## Root cause

The in-RAM session DEK was held in a **module-level `Map`** in `lib/crypto/sessionKeys.ts`. Next.js evaluates that module as **separate instances per server context** (route handler, RSC render, instrumentation), so:

- the unlock API route (`/api/crypto/unlock` → `setSessionDek`) wrote the DEK into **one** copy of the map, while
- `CryptoGate`, running during the page render (`hasSessionDek`), read a **different, empty** copy.

`cryptoStatus` therefore returned `locked` on every request after unlock, and the gate redirected straight back to `/crypto/unlock`. This affected all unlock methods (passphrase, recovery code, passkey), since they all funnel through `setSessionDek`.

## Fix

Pin the store on `globalThis` so every module instance in the process shares one map. The same latent split existed in the rate-limit `MemoryStore` singleton (`lib/rate-limit/index.ts`) — per-context buckets silently weakening every limit — so it gets the same treatment.

## Verification

Reproduced the split directly with throwaway probes (a route handler that writes + an RSC page that reads, no passphrase/DB needed):

| | write (route layer) | read (RSC layer) | DEK visible |
|---|---|---|---|
| Before | `size=1` | `size=0` | **false** |
| After  | `size=1` | `size=1` | **true** |

- `vitest` sessionKeys / gate / unlock-route / reset / rate-limit-store: **15 passed**
- `tsc --noEmit`: clean
- `eslint`: clean

## Note (out of scope)

`globalThis` is per-*process*, which fully covers local dev and single-instance Node deployments. A multi-instance / serverless topology would need a shared external store for the DEK to be visible across instances — flagging for the future, not addressed here.