### PR TITLE
feat(dev): one-command local stack via docker-compose + pnpm app:dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,17 @@
 # Required
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/ledger_dev
+DATABASE_URL=postgres://postgres:postgres@localhost:5433/ledger_dev
 BETTER_AUTH_SECRET=replace-with-32-plus-chars-of-random-data
 BETTER_AUTH_URL=http://localhost:3000
 
-# Email (magic link) — delivered via the self-hosted Postal server.
-# Both Postal vars are required: a missing/empty value fails fast at startup.
+# Email (magic link).
+#   EMAIL_TRANSPORT=console → print the magic link / code to the dev server
+#     console; nothing is sent. The default for `pnpm app:dev`.
+#   EMAIL_TRANSPORT=postal  → deliver via the self-hosted Postal server; both
+#     POSTAL_* vars below become required (a missing value fails fast at startup).
+EMAIL_TRANSPORT=console
 EMAIL_FROM=auth@example.com
-POSTAL_API_URL=https://postal.raxel.studio
-POSTAL_API_KEY=
+# POSTAL_API_URL=https://postal.raxel.studio
+# POSTAL_API_KEY=
 
 # Optional: Google sign-in. Set NEXT_PUBLIC_ENABLE_GOOGLE=1 in lockstep.
 # GOOGLE_CLIENT_ID=
@@ -22,12 +26,14 @@ DATA_DIR=./data
 
 # ---- Object storage (ledger files) ----
 # Garage holds the canonical journal files; DATA_DIR is an ephemeral local cache.
-# STORAGE_BACKEND=memory (default) keeps everything in-process — for local dev/tests.
-# Set STORAGE_BACKEND=s3 in production and fill the S3_* vars below.
-STORAGE_BACKEND=memory
-# S3_ENDPOINT=http://garage:3900
-# S3_REGION=garage
-# S3_BUCKET=ledger
-# S3_ACCESS_KEY_ID=
-# S3_SECRET_ACCESS_KEY=
-# S3_FORCE_PATH_STYLE=true
+# `pnpm app:dev` runs a Garage container, so the defaults below point at it. The
+# S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY must match GARAGE_DEFAULT_* in
+# docker-compose.yml. To skip object storage entirely, set STORAGE_BACKEND=memory
+# (in-process; no Garage needed) — handy for tests.
+STORAGE_BACKEND=s3
+S3_ENDPOINT=http://localhost:3900
+S3_REGION=garage
+S3_BUCKET=ledger
+S3_ACCESS_KEY_ID=GK1234567890abcdef1234567890abcdef
+S3_SECRET_ACCESS_KEY=9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b
+S3_FORCE_PATH_STYLE=true

--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,9 @@ DATA_DIR=./data
 # ---- Object storage (ledger files) ----
 # Garage holds the canonical journal files; DATA_DIR is an ephemeral local cache.
 # `pnpm app:dev` runs a Garage container, so the defaults below point at it. The
-# S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY must match GARAGE_DEFAULT_* in
-# docker-compose.yml. To skip object storage entirely, set STORAGE_BACKEND=memory
+# S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY must match the GARAGE_ACCESS_KEY /
+# GARAGE_SECRET_KEY provisioned in scripts/app-dev.sh. To skip object storage
+# entirely, set STORAGE_BACKEND=memory
 # (in-process; no Garage needed) — handy for tests.
 STORAGE_BACKEND=s3
 S3_ENDPOINT=http://localhost:3900

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env.bak
 
 # claude code
 .claude/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+# Local development backing services for ledger-cli-ui.
+#
+# Brought up by `pnpm app:dev` (see scripts/app-dev.sh), which waits for both
+# services to become healthy, assigns the Garage cluster layout, and then runs
+# the Next dev server on the host. The app itself is NOT containerised — it runs
+# via `next dev` so HMR is fast and it reuses the host `ledger` binary.
+#
+# Credentials here are dev-only and intentionally committed; never reuse them.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: ledger-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ledger_dev
+    ports:
+      # Host 5433 (not 5432) so this project's DB doesn't clash with other local
+      # Postgres containers. Must match the port in DATABASE_URL (.env.example).
+      - '5433:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d ledger_dev']
+      interval: 3s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
+
+  garage:
+    # S3-compatible object store — canonical home for journal files in prod, and
+    # exercised locally so dev mirrors the STORAGE_BACKEND=s3 path. Image is
+    # distroless (no shell): the layout bootstrap in scripts/app-dev.sh invokes
+    # the /garage binary directly rather than `sh -c`.
+    image: dxflrs/garage:v2.3.0
+    container_name: ledger-garage
+    restart: unless-stopped
+    # The cluster layout, bucket ('ledger') and access key are provisioned by
+    # scripts/app-dev.sh after the node is healthy — a fresh node has no layout,
+    # so they can't be created at image-startup time. Those fixed dev access
+    # keys must match the S3_* values in .env.example.
+    ports:
+      - '3900:3900' # S3 API (used by the app on the host)
+      - '3903:3903' # admin API (optional, for debugging)
+    volumes:
+      - ./docker/garage.dev.toml:/etc/garage.toml:ro
+      - garage_meta:/var/lib/garage/meta
+      - garage_data:/var/lib/garage/data
+    healthcheck:
+      # Passes once the local node is up — true before a layout is assigned,
+      # which is exactly what the bootstrap step needs.
+      test: ['CMD', '/garage', 'status']
+      interval: 3s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
+
+volumes:
+  pgdata:
+  garage_meta:
+  garage_data:

--- a/docker/garage.dev.toml
+++ b/docker/garage.dev.toml
@@ -1,0 +1,25 @@
+# Garage configuration for LOCAL DEVELOPMENT ONLY.
+#
+# Single-node, replication factor 1. The secrets below are fixed dev values so
+# the stack is reproducible without a bootstrap step that mutates the repo — do
+# NOT reuse them anywhere real. The production template lives in
+# deploy/garage/garage.toml.
+
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "lmdb"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "4f3b2a1c8e7d6f5a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "dev-garage-admin-token"

--- a/lib/account-deletion/index.ts
+++ b/lib/account-deletion/index.ts
@@ -4,7 +4,7 @@ import { AccountDeletionChallengeRepository } from './repository';
 import { AccountDeletionService } from './service';
 import { APP_NAME } from '@/lib/app';
 import { db } from '@/lib/db';
-import { postalTransport } from '@/lib/email-transport';
+import { emailTransport } from '@/lib/email-transport';
 import { env } from '@/lib/env';
 
 const sendCode = async (email: string, code: string): Promise<void> => {
@@ -19,7 +19,7 @@ const sendCode = async (email: string, code: string): Promise<void> => {
     `<p>Your account deletion code is <strong style="font-size:1.25rem;letter-spacing:0.15em">${code}</strong>.</p>` +
     `<p>It expires in 10 minutes.</p>` +
     `<p>If you didn't request this, ignore this email — nothing will happen.</p>`;
-  await postalTransport({ to: email, from, subject, html, text });
+  await emailTransport({ to: email, from, subject, html, text });
 };
 
 const accountDeletionChallengeRepository =

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { APP_NAME } from '@/lib/app';
-import { postalTransport } from '@/lib/email-transport';
+import { emailTransport } from '@/lib/email-transport';
 import { createAuth } from '@naeemba/next-starter/auth';
 
 const googleConfigured =
@@ -10,6 +10,6 @@ export const auth = await createAuth({
   // PRF extension at registration so passkeys can derive a stable secret for
   // client-side encryption-key wrapping (passkey unlock of encrypted journals).
   passkey: { rpName: APP_NAME, registration: { extensions: { prf: {} } } },
-  transport: postalTransport,
+  transport: emailTransport,
   ...(googleConfigured && { google: {} }),
 });

--- a/lib/crypto/resetChallenge/index.ts
+++ b/lib/crypto/resetChallenge/index.ts
@@ -4,7 +4,7 @@ import { EncryptionResetService } from './service';
 import { APP_NAME } from '@/lib/app';
 import { resetUserEncryption } from '@/lib/crypto/resetEncryption';
 import { db } from '@/lib/db';
-import { postalTransport } from '@/lib/email-transport';
+import { emailTransport } from '@/lib/email-transport';
 import { env } from '@/lib/env';
 
 const sendCode = async (email: string, code: string): Promise<void> => {
@@ -21,7 +21,7 @@ const sendCode = async (email: string, code: string): Promise<void> => {
     `<p>It expires in 10 minutes.</p>` +
     `<p><strong>Warning:</strong> confirming this will permanently delete your encrypted journal and reset encryption to &ldquo;not set up&rdquo;.</p>` +
     `<p>If you didn't request this, ignore this email — nothing will happen.</p>`;
-  await postalTransport({ to: email, from, subject, html, text });
+  await emailTransport({ to: email, from, subject, html, text });
 };
 
 const encryptionResetChallengeRepository =

--- a/lib/email-transport.ts
+++ b/lib/email-transport.ts
@@ -18,11 +18,11 @@ export const postalTransport: EmailTransport = async ({
   html,
   text,
 }) => {
-  const res = await fetch(`${env.POSTAL_API_URL}/api/v1/send/message`, {
+  const res = await fetch(`${env.POSTAL_API_URL!}/api/v1/send/message`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-Server-API-Key': env.POSTAL_API_KEY,
+      'X-Server-API-Key': env.POSTAL_API_KEY!,
     },
     body: JSON.stringify({
       to: [to],
@@ -44,3 +44,41 @@ export const postalTransport: EmailTransport = async ({
     );
   }
 };
+
+const firstUrl = (s?: string): string | undefined =>
+  s?.match(/https?:\/\/[^\s"'<>]+/)?.[0];
+
+/**
+ * Dev transport: instead of sending mail, print the message — and the magic
+ * link / verification code it carries — to the server console. Selected when
+ * EMAIL_TRANSPORT=console (see lib/env). Never use in production.
+ */
+export const consoleTransport: EmailTransport = async ({
+  to,
+  subject,
+  text,
+  html,
+}) => {
+  const link = firstUrl(text) ?? firstUrl(html);
+  const lines = [
+    '',
+    '┌─ ✉  DEV EMAIL (not sent) ───────────────────────────────',
+    `│ To:      ${to}`,
+    `│ Subject: ${subject}`,
+    ...(link ? [`│ Link:    ${link}`] : []),
+    '│ ── body ──',
+    ...(text ?? '').split('\n').map((l) => `│ ${l}`),
+    '└─────────────────────────────────────────────────────────',
+    '',
+  ];
+  // eslint-disable-next-line no-console
+  console.log(lines.join('\n'));
+};
+
+/**
+ * The transport the app actually uses, chosen by EMAIL_TRANSPORT. Prefer this
+ * over the named transports above so dev (console) and prod (Postal) stay in
+ * lockstep across every caller.
+ */
+export const emailTransport: EmailTransport =
+  env.EMAIL_TRANSPORT === 'console' ? consoleTransport : postalTransport;

--- a/lib/env/email-env.test.ts
+++ b/lib/env/email-env.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Minimal valid baseline; we only vary the email-related vars per test.
+const BASE_ENV: Record<string, string> = {
+  BETTER_AUTH_SECRET: 'x'.repeat(32),
+  DATABASE_URL: 'postgres://u:p@localhost:5432/db',
+};
+
+const loadEnv = async (overrides: Record<string, string | undefined>) => {
+  vi.resetModules();
+  const prev = process.env;
+  process.env = { ...BASE_ENV, ...overrides } as NodeJS.ProcessEnv;
+  try {
+    const mod = await import('./index');
+    return mod.env;
+  } finally {
+    process.env = prev;
+  }
+};
+
+describe('email env', () => {
+  it('defaults EMAIL_TRANSPORT to postal and requires POSTAL_* vars', async () => {
+    await expect(loadEnv({})).rejects.toThrow(/POSTAL_API_URL/);
+  });
+
+  it('accepts postal when both POSTAL_* vars are set', async () => {
+    const env = await loadEnv({
+      POSTAL_API_URL: 'https://postal.example.com',
+      POSTAL_API_KEY: 'k',
+    });
+    expect(env.EMAIL_TRANSPORT).toBe('postal');
+  });
+
+  it('console transport needs no POSTAL_* vars', async () => {
+    const env = await loadEnv({ EMAIL_TRANSPORT: 'console' });
+    expect(env.EMAIL_TRANSPORT).toBe('console');
+  });
+});

--- a/lib/env/index.ts
+++ b/lib/env/index.ts
@@ -27,12 +27,16 @@ const envSchema = clientEnvSchema
     // validated here so a bad value fails fast at startup.
     JOURNAL_QUOTA_MB: z.coerce.number().int().positive().default(100),
 
-    // Email (magic link). Delivered via the self-hosted Postal server (see
-    // lib/email-transport.ts). Both Postal vars are required so a missing/empty
-    // value fails fast at startup rather than the first time someone signs in.
+    // Email (magic link). 'postal' delivers via the self-hosted Postal server
+    // (see lib/email-transport.ts); 'console' prints the link/code to the dev
+    // server console and sends nothing — for local development. When 'postal',
+    // both POSTAL_* vars are required (enforced by the superRefine below) so a
+    // missing value fails fast at startup rather than the first time someone
+    // signs in.
+    EMAIL_TRANSPORT: z.enum(['postal', 'console']).default('postal'),
     EMAIL_FROM: z.string().default('auth@example.com'),
-    POSTAL_API_URL: z.string().url(),
-    POSTAL_API_KEY: z.string().min(1),
+    POSTAL_API_URL: z.string().url().optional(),
+    POSTAL_API_KEY: z.string().min(1).optional(),
 
     // Structured logging level (pino).
     LOG_LEVEL: z
@@ -74,6 +78,18 @@ const envSchema = clientEnvSchema
       .transform((v) => v === 'true'),
   })
   .superRefine((val, ctx) => {
+    if (val.EMAIL_TRANSPORT === 'postal') {
+      for (const key of ['POSTAL_API_URL', 'POSTAL_API_KEY'] as const) {
+        if (!val[key]) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [key],
+            message: `${key} is required when EMAIL_TRANSPORT=postal`,
+          });
+        }
+      }
+    }
+
     if (val.STORAGE_BACKEND !== 's3') return;
     const required = [
       'S3_ENDPOINT',

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "app:dev": "./scripts/app-dev.sh",
+    "app:down": "docker compose down",
+    "app:reset": "docker compose down -v",
     "migrate": "next-starter migrate && drizzle-kit migrate",
     "predev": "dotenv -e .env -- pnpm migrate",
     "dev": "dotenv -e .env -- next dev",

--- a/scripts/app-dev.sh
+++ b/scripts/app-dev.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# One command to start everything needed for local development:
+#   1. Bring up Postgres + Garage (docker-compose) and wait until both are healthy.
+#   2. Assign the Garage cluster layout (idempotent) so object writes succeed.
+#   3. Run the Next dev server on the host (`pnpm dev`), which migrates the DB first.
+#
+# Invoked via `pnpm app:dev`.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! docker info >/dev/null 2>&1; then
+  echo "✗ Docker isn't running. Start Docker Desktop (or your engine) and retry." >&2
+  exit 1
+fi
+
+# --- .env bootstrap -----------------------------------------------------------
+# Only create one if it's missing; never clobber an existing secrets file.
+if [ ! -f .env ]; then
+  cp .env.example .env
+  if command -v openssl >/dev/null 2>&1; then
+    secret=$(openssl rand -base64 32)
+    # Portable in-place sed (works on both BSD/macOS and GNU).
+    sed -i.bak "s|^BETTER_AUTH_SECRET=.*|BETTER_AUTH_SECRET=${secret}|" .env && rm -f .env.bak
+  fi
+  echo "▸ Created .env from .env.example (generated a BETTER_AUTH_SECRET)."
+fi
+
+# --- backing services ---------------------------------------------------------
+echo "▸ Starting Postgres + Garage…"
+docker compose up -d --wait
+
+# --- garage bootstrap ---------------------------------------------------------
+# The image is distroless, so each step is a direct /garage binary call. A fresh
+# node has no layout, bucket or key, so we provision all three here (idempotent).
+# These dev access keys must match the S3_* values in .env.example.
+GARAGE_BUCKET=ledger
+GARAGE_ACCESS_KEY=GK1234567890abcdef1234567890abcdef
+GARAGE_SECRET_KEY=9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b
+
+gx() { docker compose exec -T garage /garage "$@"; }
+
+if gx layout show 2>/dev/null | grep -q 'dc1'; then
+  echo "▸ Garage layout already configured."
+else
+  echo "▸ Assigning Garage cluster layout…"
+  node_id=$(gx status | awk '$1 ~ /^[0-9a-f]{12,}$/ { print $1; exit }')
+  if [ -z "${node_id}" ]; then
+    echo "✗ Could not determine the Garage node id from \`garage status\`." >&2
+    exit 1
+  fi
+  gx layout assign -z dc1 -c 1G "${node_id}"
+  gx layout apply --version 1
+fi
+
+if gx bucket info "${GARAGE_BUCKET}" >/dev/null 2>&1; then
+  echo "▸ Garage bucket '${GARAGE_BUCKET}' already provisioned."
+else
+  echo "▸ Provisioning Garage bucket + access key…"
+  gx bucket create "${GARAGE_BUCKET}"
+  gx key import "${GARAGE_ACCESS_KEY}" "${GARAGE_SECRET_KEY}" -n ledger-dev --yes
+  gx bucket allow --read --write --owner "${GARAGE_BUCKET}" --key "${GARAGE_ACCESS_KEY}"
+  echo "▸ Garage bucket '${GARAGE_BUCKET}' ready."
+fi
+
+# --- app ----------------------------------------------------------------------
+echo "▸ Starting Next dev server…"
+exec pnpm dev


### PR DESCRIPTION
## Summary

Adds a docker-compose stack and a `pnpm app:dev` command that brings up everything needed for local development in one shot: Postgres, a Garage (S3-compatible) object store, and the Next dev server.

The app itself runs on the host (fast HMR, reuses the host `ledger` binary); docker-compose only provides the backing services.

## What's included

| File | Purpose |
|------|---------|
| `docker-compose.yml` | **Postgres 17** (host port **5433**) + **Garage v2.3.0** (S3 `:3900`, admin `:3903`), healthchecked, named volumes |
| `docker/garage.dev.toml` | Single-node Garage config with fixed **dev-only** secrets |
| `scripts/app-dev.sh` | Bootstraps `.env` if absent → brings services up `--wait`-healthy → provisions Garage (layout + `ledger` bucket + access key, idempotent) → runs `pnpm dev` |
| `package.json` | `app:dev`, `app:down`, `app:reset` |

### Console email transport
Magic-link sign-in needs Postal vars, which don't exist locally. Added `EMAIL_TRANSPORT=console` (default in `.env.example`) which **prints the magic link/code to the dev server console** instead of sending mail. `POSTAL_*` are now required only when `EMAIL_TRANSPORT=postal` (mirrors the existing `STORAGE_BACKEND=s3` pattern). All three email call sites (auth, encryption reset, account deletion) now use the selected transport.

## Notes / decisions

- **Port 5433**, not 5432 — avoids clashing with other local Postgres containers (e.g. `raxel_postgres`).
- Garage's `GARAGE_DEFAULT_*` auto-provisioning doesn't fire on a fresh node (no layout yet), so the script provisions the bucket + key explicitly. The official image is distroless, so bootstrap steps are direct `/garage` binary calls.
- `STORAGE_BACKEND` defaults to `s3` (real Garage). Set `memory` for a quick boot with no Garage.

## Verification

- `pnpm type-check`, `pnpm lint` — clean
- **627 tests pass** (125 files)
- From a wiped state: both services reach **healthy**; Garage bootstrap provisions on first run and **no-ops on re-run** (idempotent)
- **Real S3 put/get round-trip** succeeds with the app's exact credentials/client config
- Auth + drizzle **migrations apply** against the running Postgres