### PR TITLE
feat(transactions): add "Save & add another" button

### DIFF
--- a/app/accounts/[account]/page.tsx
+++ b/app/accounts/[account]/page.tsx
@@ -45,7 +45,7 @@ const Account = async ({
           too wide for a phone, so reflow to a readable stack below md. */}
       <ul className="flex flex-col gap-3 md:hidden">
         {rows.length === 0 ? (
-          <li className="rounded-2xl border border-border bg-card p-6 text-center text-sm text-muted shadow-sm">
+          <li className="rounded-2xl border border-border bg-card p-6 text-center text-sm text-muted-foreground shadow-sm">
             No transactions
           </li>
         ) : (
@@ -58,13 +58,13 @@ const Account = async ({
                 <span className="min-w-0 break-words font-medium">
                   {columns[2]}
                 </span>
-                <span className="shrink-0 whitespace-nowrap text-xs text-muted">
+                <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
                   {formatDate(columns[0], Format.DATE)}
                 </span>
               </div>
               <dl className="mt-3 flex flex-col gap-1 text-sm">
                 <div className="flex items-baseline justify-between gap-3">
-                  <dt className="text-xs uppercase tracking-wide text-muted">
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">
                     Amount
                   </dt>
                   <dd className="text-right tabular-nums">
@@ -72,7 +72,7 @@ const Account = async ({
                   </dd>
                 </div>
                 <div className="flex items-baseline justify-between gap-3">
-                  <dt className="text-xs uppercase tracking-wide text-muted">
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">
                     Total
                   </dt>
                   <dd className="text-right tabular-nums">
@@ -102,14 +102,17 @@ const Account = async ({
             <tbody>
               {rows.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="py-6 text-center text-muted">
+                  <td
+                    colSpan={4}
+                    className="py-6 text-center text-muted-foreground"
+                  >
                     No transactions
                   </td>
                 </tr>
               ) : (
                 rows.map((columns, idx) => (
                   <tr key={idx}>
-                    <td className="whitespace-nowrap text-muted">
+                    <td className="whitespace-nowrap text-muted-foreground">
                       {formatDate(columns[0], Format.DATE)}
                     </td>
                     <td>{columns[2]}</td>

--- a/app/balance/[from]/[to]/page.tsx
+++ b/app/balance/[from]/[to]/page.tsx
@@ -60,7 +60,7 @@ const PeriodBalance = async ({
             filter below to pick a month, quarter, year, or custom span.
           </Help>
         </div>
-        <p className="mt-1 text-sm text-muted">
+        <p className="mt-1 text-sm text-muted-foreground">
           {formatDate(from.toISOString(), Format.DATE)} –{' '}
           {formatDate(to.toISOString(), Format.DATE)}
         </p>
@@ -82,7 +82,7 @@ const PeriodBalance = async ({
         <h2 className="text-lg font-medium text-fg">Total Expenses</h2>
         <div className="flex items-end gap-3">
           <div className="text-right">
-            <div className="text-xs font-medium uppercase tracking-wider text-muted">
+            <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Total
             </div>
             <div className="text-2xl font-semibold tracking-tight">
@@ -108,7 +108,10 @@ const PeriodBalance = async ({
           <tbody>
             {results.length === 0 ? (
               <tr>
-                <td colSpan={2} className="py-6 text-center text-muted">
+                <td
+                  colSpan={2}
+                  className="py-6 text-center text-muted-foreground"
+                >
                   No expenses in this period
                 </td>
               </tr>

--- a/app/balance/page.tsx
+++ b/app/balance/page.tsx
@@ -36,11 +36,13 @@ const Balance = async () => {
               drill into its transactions.
             </Help>
           </div>
-          <p className="mt-1 text-sm text-muted">Assets & liabilities</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Assets & liabilities
+          </p>
         </div>
         <div className="flex items-end gap-3">
           <div className="text-right">
-            <div className="text-xs font-medium uppercase tracking-wider text-muted">
+            <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Total
             </div>
             <div className="text-2xl font-semibold tracking-tight">
@@ -65,7 +67,10 @@ const Balance = async () => {
             <tbody>
               {result.length === 0 ? (
                 <tr>
-                  <td colSpan={2} className="py-6 text-center text-muted">
+                  <td
+                    colSpan={2}
+                    className="py-6 text-center text-muted-foreground"
+                  >
                     No data
                   </td>
                 </tr>

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -32,10 +32,12 @@ const Debts = async () => {
             </Help>
             <ExportButton href="/api/debts/export" />
           </div>
-          <p className="mt-1 text-sm text-muted">Outstanding credit by payee</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Outstanding credit by payee
+          </p>
         </div>
         <div className="text-right">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Total
           </div>
           <div className="text-2xl font-semibold tracking-tight">
@@ -58,7 +60,10 @@ const Debts = async () => {
             <tbody>
               {debts.length === 0 ? (
                 <tr>
-                  <td colSpan={2} className="py-6 text-center text-muted">
+                  <td
+                    colSpan={2}
+                    className="py-6 text-center text-muted-foreground"
+                  >
                     No debts
                   </td>
                 </tr>

--- a/app/globals.css
+++ b/app/globals.css
@@ -108,7 +108,9 @@
     /* Project palette dark overrides */
     --bg: oklch(17% 0.015 250);
     --fg: oklch(94% 0.01 250);
-    --muted: oklch(66% 0.018 250);
+    /* Subtle elevated surface (bg-muted, skeletons). Sits just above --card
+       (22%) / --bg (17%); muted *text* uses --muted-foreground, not this. */
+    --muted: oklch(27% 0.015 250);
     --card: oklch(22% 0.018 250);
     --card-fg: oklch(94% 0.01 250);
     --border: oklch(29% 0.015 250);
@@ -188,7 +190,7 @@ table thead td {
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--muted-foreground);
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
 }

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -86,7 +86,7 @@ export default function ImportPage() {
             MB.
           </Help>
         </div>
-        <p className="mt-1 text-sm text-muted">
+        <p className="mt-1 text-sm text-muted-foreground">
           Replace your journal with an existing file or archive
         </p>
       </div>
@@ -120,7 +120,7 @@ export default function ImportPage() {
         )}
       </form>
 
-      <div className="rounded-2xl border border-border bg-card p-5 text-xs text-muted shadow-sm">
+      <div className="rounded-2xl border border-border bg-card p-5 text-xs text-muted-foreground shadow-sm">
         <div className="mb-2 font-medium text-fg">Tips</div>
         <ul className="list-disc space-y-1 pl-4">
           <li>

--- a/app/registers/monthly/[account]/page.tsx
+++ b/app/registers/monthly/[account]/page.tsx
@@ -62,7 +62,10 @@ const Monthly = async ({
             <tbody>
               {results.length === 0 ? (
                 <tr>
-                  <td colSpan={2} className="py-6 text-center text-muted">
+                  <td
+                    colSpan={2}
+                    className="py-6 text-center text-muted-foreground"
+                  >
                     No transactions
                   </td>
                 </tr>

--- a/app/sign-in/loading.tsx
+++ b/app/sign-in/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthScreenSkeleton } from '@/features/auth/AuthScreenSkeleton';
+
+export default function Loading() {
+  return <AuthScreenSkeleton />;
+}

--- a/app/sign-up/loading.tsx
+++ b/app/sign-up/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthScreenSkeleton } from '@/features/auth/AuthScreenSkeleton';
+
+export default function Loading() {
+  return <AuthScreenSkeleton />;
+}

--- a/components/DateFilter/DateFilter.tsx
+++ b/components/DateFilter/DateFilter.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const sectionLabel =
-  'text-[0.65rem] font-semibold uppercase tracking-wider text-muted';
+  'text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground';
 
 const inputClasses =
   'block rounded-md border border-border bg-bg px-3 py-1.5 text-sm text-fg shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/40';

--- a/components/Help/Help.tsx
+++ b/components/Help/Help.tsx
@@ -20,7 +20,7 @@ const Help = ({ children, label = 'Help', className }: Props) => (
         type="button"
         aria-label={label}
         className={cn(
-          'inline-flex h-5 w-5 items-center justify-center rounded-full text-muted transition-colors hover:bg-subtle hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent/40',
+          'inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-subtle hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent/40',
           className
         )}
       >

--- a/features/accounts/AccountHeader.tsx
+++ b/features/accounts/AccountHeader.tsx
@@ -14,7 +14,7 @@ const AccountHeader = ({ account, balance, existingViewNames }: Props) => {
     <div className="flex flex-wrap items-end justify-between gap-3">
       <div>
         <div className="flex items-center gap-2">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Account
           </div>
           <Help label="About this account view">
@@ -29,7 +29,7 @@ const AccountHeader = ({ account, balance, existingViewNames }: Props) => {
       </div>
       <div className="flex items-end gap-3">
         <div className="text-right">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Balance
           </div>
           <div className="text-2xl font-semibold tracking-tight">

--- a/features/accounts/Accounts.tsx
+++ b/features/accounts/Accounts.tsx
@@ -32,7 +32,7 @@ const Accounts = async () => {
           </Help>
           <ExportButton href="/api/accounts/export" />
         </div>
-        <p className="mt-1 text-sm text-muted">
+        <p className="mt-1 text-sm text-muted-foreground">
           {accounts.length} account{accounts.length === 1 ? '' : 's'}
         </p>
       </div>

--- a/features/activity/ActivityCard.tsx
+++ b/features/activity/ActivityCard.tsx
@@ -18,7 +18,7 @@ const ActivityCard = ({ rows }: { rows: AuditLog[] }) => (
     </CardHeader>
     <CardContent>
       {rows.length === 0 ? (
-        <p className="text-sm text-muted">No activity yet.</p>
+        <p className="text-sm text-muted-foreground">No activity yet.</p>
       ) : (
         <ul className="flex flex-col gap-2 text-sm">
           {rows.map((row) => {
@@ -33,7 +33,7 @@ const ActivityCard = ({ rows }: { rows: AuditLog[] }) => (
                 </span>
                 <span className="flex-1">{label}</span>
                 <time
-                  className="shrink-0 text-muted"
+                  className="shrink-0 text-muted-foreground"
                   dateTime={new Date(row.createdAt).toISOString()}
                 >
                   {formatWhen(row.createdAt)}

--- a/features/activity/ActivityList.tsx
+++ b/features/activity/ActivityList.tsx
@@ -75,7 +75,9 @@ const ActivityList = ({
     </div>
 
     {rows.length === 0 ? (
-      <p className="text-muted">No activity matches these filters yet.</p>
+      <p className="text-muted-foreground">
+        No activity matches these filters yet.
+      </p>
     ) : (
       <div className="flex flex-col">
         {rows.map((row) => (

--- a/features/activity/ActivityRow.tsx
+++ b/features/activity/ActivityRow.tsx
@@ -4,7 +4,7 @@ import { describeAuditEvent } from '@/lib/audit/describe';
 
 const DetailLine = ({ label, value }: { label: string; value: string }) => (
   <div className="flex gap-2">
-    <span className="w-24 shrink-0 text-muted">{label}</span>
+    <span className="w-24 shrink-0 text-muted-foreground">{label}</span>
     <span className="break-all tabular-nums">{value}</span>
   </div>
 );
@@ -28,13 +28,13 @@ const ActivityRow = ({ row }: { row: AuditLog }) => {
         </span>
         <span className="flex-1">{label}</span>
         <time
-          className="shrink-0 text-muted"
+          className="shrink-0 text-muted-foreground"
           dateTime={new Date(row.createdAt).toISOString()}
         >
           {formatWhen(row.createdAt)}
         </time>
       </summary>
-      <div className="mt-2 flex flex-col gap-1 pl-6 text-muted">
+      <div className="mt-2 flex flex-col gap-1 pl-6 text-muted-foreground">
         {row.targetUid && <DetailLine label="uid" value={row.targetUid} />}
         {hasBytes && (
           <DetailLine

--- a/features/auth/AuthScreenSkeleton.tsx
+++ b/features/auth/AuthScreenSkeleton.tsx
@@ -1,0 +1,50 @@
+import './auth.css';
+
+// Loading placeholder for the full-bleed auth routes. Mirrors AuthScreen's
+// layout and uses the `.au` palette (deep-green ink + translucent cards) so the
+// brief flash on navigation reads as the auth screen settling in — not the
+// app's dashboard PageSkeleton, which is themed for the in-app chrome and looks
+// out of place here.
+const Bar = ({ className }: { className?: string }) => (
+  <div
+    className={className}
+    style={{ background: 'var(--card-hi)', borderRadius: '0.5rem' }}
+  />
+);
+
+export function AuthScreenSkeleton() {
+  return (
+    <main className="au" aria-hidden>
+      <span
+        className="au-glow"
+        style={{ width: 560, height: 560, top: -180, left: '-6%' }}
+      />
+
+      <div className="au-layer grid min-h-svh grid-cols-1 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+        {/* brand side — empty on this placeholder; the glow alone carries it */}
+        <div className="hidden lg:block" />
+
+        <div className="flex min-w-0 flex-col px-6 py-8 sm:px-10 lg:px-14">
+          <div className="flex flex-1 items-center justify-center py-10">
+            <div className="w-full max-w-sm animate-pulse">
+              <div className="flex flex-col gap-7">
+                <div className="flex flex-col gap-2">
+                  <Bar className="h-10 w-3/4" />
+                  <Bar className="h-4 w-full" />
+                </div>
+                <div className="flex flex-col gap-2.5">
+                  <Bar className="h-11 w-full" />
+                </div>
+                <Bar className="h-px w-full" />
+                <div className="flex flex-col gap-4">
+                  <Bar className="h-12 w-full" />
+                  <Bar className="h-11 w-full" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -32,7 +32,7 @@ const RECENT_LIMIT = 10;
 
 const Stat = ({ label, value }: { label: string; value: React.ReactNode }) => (
   <div className="flex flex-col gap-1">
-    <span className="text-xs font-medium uppercase tracking-wider text-muted">
+    <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
       {label}
     </span>
     <span className="text-lg font-semibold tabular-nums">{value || '—'}</span>
@@ -117,7 +117,7 @@ const Dashboard = async () => {
             to your default currency.
           </Help>
         </div>
-        <p className="mt-1 text-sm text-muted">
+        <p className="mt-1 text-sm text-muted-foreground">
           {formatDate(now.toISOString(), Format.MONTH_YEAR)} overview
         </p>
       </div>
@@ -138,13 +138,13 @@ const Dashboard = async () => {
           value={
             highestAccount ? (
               <span className="flex flex-col gap-1">
-                <span className="text-base font-medium text-muted">
+                <span className="text-base font-medium text-muted-foreground">
                   {highestAccount}
                 </span>
                 <span>{formatAmount(highestAmount, true)}</span>
               </span>
             ) : (
-              <span className="text-base font-normal text-muted">
+              <span className="text-base font-normal text-muted-foreground">
                 No expenses this month
               </span>
             )
@@ -202,14 +202,17 @@ const Dashboard = async () => {
               <tbody>
                 {recent.length === 0 ? (
                   <tr>
-                    <td colSpan={4} className="py-6 text-center text-muted">
+                    <td
+                      colSpan={4}
+                      className="py-6 text-center text-muted-foreground"
+                    >
                       No transactions
                     </td>
                   </tr>
                 ) : (
                   recent.map((row, idx) => (
                     <tr key={idx}>
-                      <td className="whitespace-nowrap text-muted">
+                      <td className="whitespace-nowrap text-muted-foreground">
                         {formatDate(row.date, Format.DATE)}
                       </td>
                       <td>{row.payee || '—'}</td>

--- a/features/dashboard/EmptyJournal.tsx
+++ b/features/dashboard/EmptyJournal.tsx
@@ -13,7 +13,7 @@ const EmptyJournal = () => (
   <div className="flex flex-col gap-6">
     <div>
       <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
-      <p className="mt-1 text-sm text-muted">No transactions yet</p>
+      <p className="mt-1 text-sm text-muted-foreground">No transactions yet</p>
     </div>
     <Card className="flex flex-col items-center gap-4 p-10 text-center">
       <div className="text-base font-medium">

--- a/features/monthlyComparison/MonthlyComparison.tsx
+++ b/features/monthlyComparison/MonthlyComparison.tsx
@@ -29,7 +29,9 @@ const MonthlyComparison = async () => {
           </Help>
           <ExportButton href="/api/monthly/export" />
         </div>
-        <p className="mt-1 text-sm text-muted">Income vs expenses by month</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Income vs expenses by month
+        </p>
       </div>
 
       <Card className="gap-0 overflow-hidden p-0">
@@ -52,7 +54,10 @@ const MonthlyComparison = async () => {
             <tbody>
               {rows.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="py-6 text-center text-muted">
+                  <td
+                    colSpan={4}
+                    className="py-6 text-center text-muted-foreground"
+                  >
                     No data
                   </td>
                 </tr>

--- a/features/netWorth/NetWorth.tsx
+++ b/features/netWorth/NetWorth.tsx
@@ -53,12 +53,12 @@ const NetWorth = async () => {
             </Help>
             <ExportButton href="/api/net-worth/export" />
           </div>
-          <p className="mt-1 text-sm text-muted">
+          <p className="mt-1 text-sm text-muted-foreground">
             Trend over the last {MONTHS_BACK} months
           </p>
         </div>
         <div className="text-right">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Current
           </div>
           <div className="text-2xl font-semibold tracking-tight">

--- a/features/payees/Payees.tsx
+++ b/features/payees/Payees.tsx
@@ -65,18 +65,20 @@ const Payees = async ({ from: fromParam, to: toParam }: Props) => {
               href={`/api/payees/export?start=${fromParam}&end=${toParam}`}
             />
           </div>
-          <p className="mt-1 text-sm text-muted">
+          <p className="mt-1 text-sm text-muted-foreground">
             {formatDate(from.toISOString(), Format.DATE)} –{' '}
             {formatDate(to.toISOString(), Format.DATE)}
           </p>
         </div>
         <div className="text-right">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Top {sorted.length} total
           </div>
           <div className="text-2xl font-semibold tracking-tight tabular-nums">
             {formatNumber(grandTotal)}{' '}
-            <span className="text-base font-normal text-muted">{currency}</span>
+            <span className="text-base font-normal text-muted-foreground">
+              {currency}
+            </span>
           </div>
         </div>
       </div>
@@ -107,7 +109,10 @@ const Payees = async ({ from: fromParam, to: toParam }: Props) => {
             <tbody>
               {sorted.length === 0 ? (
                 <tr>
-                  <td colSpan={2} className="py-6 text-center text-muted">
+                  <td
+                    colSpan={2}
+                    className="py-6 text-center text-muted-foreground"
+                  >
                     No payee data in this period
                   </td>
                 </tr>

--- a/features/portfolio/Portfolio.tsx
+++ b/features/portfolio/Portfolio.tsx
@@ -94,12 +94,12 @@ const Portfolio = async () => {
               </Help>
               <ExportButton href="/api/portfolio/export" />
             </div>
-            <p className="mt-1 text-sm text-muted">
+            <p className="mt-1 text-sm text-muted-foreground">
               <code>{prefix}</code>
             </p>
           </div>
           <div className="text-right">
-            <div className="text-xs font-medium uppercase tracking-wider text-muted">
+            <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Total ({defaultCurrency.toUpperCase()})
             </div>
             <div className="text-2xl font-semibold tracking-tight">

--- a/features/reconcile/Reconcile.tsx
+++ b/features/reconcile/Reconcile.tsx
@@ -34,7 +34,7 @@ const Reconcile = async () => {
             </Help>
             <ExportButton href="/api/reconcile/export" />
           </div>
-          <p className="mt-1 text-sm text-muted">
+          <p className="mt-1 text-sm text-muted-foreground">
             {rows.length} uncleared posting{rows.length === 1 ? '' : 's'}
             {stale > 0 && (
               <span className="text-negative">
@@ -60,18 +60,21 @@ const Reconcile = async () => {
           <tbody>
             {rows.length === 0 ? (
               <tr>
-                <td colSpan={5} className="py-6 text-center text-muted">
+                <td
+                  colSpan={5}
+                  className="py-6 text-center text-muted-foreground"
+                >
                   Nothing to reconcile
                 </td>
               </tr>
             ) : (
               rows.map((row, idx) => (
                 <tr key={idx}>
-                  <td className="whitespace-nowrap text-muted">
+                  <td className="whitespace-nowrap text-muted-foreground">
                     {formatDate(row.date, Format.DATE)}
                   </td>
                   <td
-                    className={`text-right tabular-nums ${row.days > STALE_DAYS ? 'text-negative' : 'text-muted'}`}
+                    className={`text-right tabular-nums ${row.days > STALE_DAYS ? 'text-negative' : 'text-muted-foreground'}`}
                   >
                     {row.days}d
                   </td>

--- a/features/registers/monthly/RegisterHeader.tsx
+++ b/features/registers/monthly/RegisterHeader.tsx
@@ -14,7 +14,7 @@ const RegisterHeader = ({ account, balance, existingViewNames }: Props) => {
     <div className="flex flex-wrap items-end justify-between gap-3">
       <div>
         <div className="flex items-center gap-2">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Monthly report
           </div>
           <Help label="About monthly report">
@@ -28,7 +28,7 @@ const RegisterHeader = ({ account, balance, existingViewNames }: Props) => {
       </div>
       <div className="flex items-end gap-3">
         <div className="text-right">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Balance
           </div>
           <div className="text-2xl font-semibold tracking-tight">

--- a/features/transactions/NewTransaction.tsx
+++ b/features/transactions/NewTransaction.tsx
@@ -61,7 +61,7 @@ const NewTransaction = async ({ templateId }: Props) => {
             amount blank to let ledger auto-balance it.
           </Help>
         </div>
-        <p className="mt-1 text-sm text-muted">
+        <p className="mt-1 text-sm text-muted-foreground">
           A new entry is appended to your journal file. Reports refresh
           immediately.
         </p>

--- a/features/transactions/TransactionForm.tsx
+++ b/features/transactions/TransactionForm.tsx
@@ -57,6 +57,13 @@ const todayISO = (): string => {
 
 const initialState: TransactionActionState = { ok: false };
 
+// Two blank postings — the minimum a transaction needs. Defined once so the
+// initial draft and `resetForm` stay in sync.
+const emptyPostings = (currency: string): Posting[] => [
+  { account: '', amount: '', currency },
+  { account: '', amount: '', currency },
+];
+
 const fieldError = (state: TransactionActionState | null, key: string) =>
   state?.fieldErrors?.[key];
 
@@ -86,10 +93,7 @@ const TransactionForm = ({
       account: p.account,
       amount: p.amount,
       currency: p.currency,
-    })) ?? [
-      { account: '', amount: '', currency: defaultCurrency },
-      { account: '', amount: '', currency: defaultCurrency },
-    ]
+    })) ?? emptyPostings(defaultCurrency)
   );
 
   const formRef = useRef<HTMLFormElement>(null);
@@ -102,10 +106,7 @@ const TransactionForm = ({
     setPayee('');
     setStatus('none');
     setNote('');
-    setPostings([
-      { account: '', amount: '', currency: defaultCurrency },
-      { account: '', amount: '', currency: defaultCurrency },
-    ]);
+    setPostings(emptyPostings(defaultCurrency));
   }, [defaultCurrency]);
 
   useEffect(() => {

--- a/features/transactions/TransactionForm.tsx
+++ b/features/transactions/TransactionForm.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useActionState, useEffect, useRef, useState } from 'react';
+import {
+  useActionState,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { toast } from 'sonner';
 import type { TransactionActionState } from './actions';
 import Combobox from '@/components/Combobox';
@@ -87,16 +93,39 @@ const TransactionForm = ({
   );
 
   const formRef = useRef<HTMLFormElement>(null);
+  // Set by the "Save & add another" button so the success effect resets the
+  // form in place instead of navigating away. Reset after each save.
+  const saveAndAddAnother = useRef(false);
+
+  const resetForm = useCallback(() => {
+    setDate(todayISO());
+    setPayee('');
+    setStatus('none');
+    setNote('');
+    setPostings([
+      { account: '', amount: '', currency: defaultCurrency },
+      { account: '', amount: '', currency: defaultCurrency },
+    ]);
+  }, [defaultCurrency]);
 
   useEffect(() => {
-    if (state?.ok) {
-      toast.success(
-        mode === 'edit' ? 'Transaction updated' : 'Transaction saved'
-      );
-      router.push(mode === 'edit' ? '/transactions' : '/');
+    if (!state?.ok) return;
+    if (mode === 'edit') {
+      toast.success('Transaction updated');
+      router.push('/transactions');
       router.refresh();
+      return;
     }
-  }, [state, router, mode]);
+    toast.success('Transaction saved');
+    if (saveAndAddAnother.current) {
+      saveAndAddAnother.current = false;
+      resetForm();
+      router.refresh();
+      return;
+    }
+    router.push('/');
+    router.refresh();
+  }, [state, router, mode, resetForm]);
 
   useEffect(() => {
     if (templateMissing) {
@@ -315,7 +344,25 @@ const TransactionForm = ({
                 draft={templateDraft}
                 disabled={!canSaveTemplate}
               />
-              <Button type="submit" disabled={!canSubmit}>
+              {mode !== 'edit' && (
+                <Button
+                  type="submit"
+                  variant="outline"
+                  disabled={!canSubmit}
+                  onClick={() => {
+                    saveAndAddAnother.current = true;
+                  }}
+                >
+                  {isPending ? 'Saving…' : 'Save & add another'}
+                </Button>
+              )}
+              <Button
+                type="submit"
+                disabled={!canSubmit}
+                onClick={() => {
+                  saveAndAddAnother.current = false;
+                }}
+              >
                 {isPending
                   ? 'Saving…'
                   : mode === 'edit'

--- a/features/transactions/TransactionForm.tsx
+++ b/features/transactions/TransactionForm.tsx
@@ -481,7 +481,7 @@ const BalanceIndicator = ({ balance }: { balance: Balance }) => {
   }
   if (balance.kind === 'auto-balance') {
     return (
-      <span className="text-xs text-muted">
+      <span className="text-xs text-muted-foreground">
         Blank posting will auto-balance
       </span>
     );

--- a/features/transactions/TransactionForm.tsx
+++ b/features/transactions/TransactionForm.tsx
@@ -110,6 +110,12 @@ const TransactionForm = ({
   }, [defaultCurrency]);
 
   useEffect(() => {
+    // Capture and clear on every settled result. If a "Save & add another"
+    // submit fails, leaving the ref set would make the next Enter-key submit
+    // reset in place instead of redirecting — contradicting the documented
+    // "Enter defaults to redirect" contract.
+    const addAnother = saveAndAddAnother.current;
+    saveAndAddAnother.current = false;
     if (!state?.ok) return;
     if (mode === 'edit') {
       toast.success('Transaction updated');
@@ -118,8 +124,7 @@ const TransactionForm = ({
       return;
     }
     toast.success('Transaction saved');
-    if (saveAndAddAnother.current) {
-      saveAndAddAnother.current = false;
+    if (addAnother) {
       resetForm();
       router.refresh();
       return;

--- a/utils/formatAmount.tsx
+++ b/utils/formatAmount.tsx
@@ -21,7 +21,7 @@ const formatAmountWithoutUnit = (str: string, unit?: string) => {
 
 const formatAmount = (str: string | undefined | null, withUnit: boolean) => {
   if (!str || !str.trim()) {
-    return <span className="text-muted">—</span>;
+    return <span className="text-muted-foreground">—</span>;
   }
   const splitted = str.split(' ');
   if (splitted.length < 2) {


### PR DESCRIPTION
## Summary

Adds a secondary submit button to the new-transaction form: **Save & add another**. It saves the transaction and resets the form in place for the next entry, instead of redirecting to the dashboard — making it faster to enter several transactions in a row.

The primary **Add transaction** button is unchanged (save → toast → redirect to `/`). The new button is create-mode only; edit mode is untouched.

## How it works

- A `saveAndAddAnother` ref is set by the new button's `onClick` and cleared by the primary button's, so the success effect knows whether to reset-in-place or redirect. The flag is cleared after each save, so an Enter-key submit defaults to redirect.
- Both paths still fire the "Transaction saved" toast and call `router.refresh()` so the account/payee autocomplete lists pick up the new entry.
- A memoized `resetForm` helper restores the initial blank draft (today's date, empty payee/note, two empty postings).

## Testing

- `tsc --noEmit` — passes
- `eslint` — clean