### PR TITLE
feat(crypto): single-tap passkey login + journal unlock

### DIFF
--- a/app/api/crypto/material/route.test.ts
+++ b/app/api/crypto/material/route.test.ts
@@ -48,7 +48,6 @@ describe('GET /api/crypto/material', () => {
         id: 'w1',
         userId: 'alice',
         credentialId: 'cred-A',
-        prfSalt: 'c2FsdA==',
         wrap: 'd3JhcA==',
         label: 'Laptop',
         createdAt: new Date(),
@@ -58,11 +57,10 @@ describe('GET /api/crypto/material', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.passkeys).toEqual([
-      { credentialId: 'cred-A', prfSalt: 'c2FsdA==', wrap: 'd3JhcA==' },
+      { credentialId: 'cred-A', wrap: 'd3JhcA==' },
     ]);
     expect(Object.keys(body.passkeys[0]).sort()).toEqual([
       'credentialId',
-      'prfSalt',
       'wrap',
     ]);
   });

--- a/app/api/crypto/material/route.ts
+++ b/app/api/crypto/material/route.ts
@@ -24,7 +24,6 @@ export async function GET(): Promise<NextResponse> {
     wrapRecovery: row.wrapRecovery,
     passkeys: wraps.map((w) => ({
       credentialId: w.credentialId,
-      prfSalt: w.prfSalt,
       wrap: w.wrap,
     })),
   };

--- a/db/migrations/0010_plain_ink.sql
+++ b/db/migrations/0010_plain_ink.sql
@@ -1,0 +1,3 @@
+DELETE FROM "cryptoPasskeyWrap";
+--> statement-breakpoint
+ALTER TABLE "cryptoPasskeyWrap" DROP COLUMN "prfSalt";

--- a/db/migrations/meta/0010_snapshot.json
+++ b/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,841 @@
+{
+  "id": "4e5de502-e526-4e7a-8add-606cd71cb2e7",
+  "prevId": "523f7087-2b77-4029-ba64-241da651f3cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accountDeletionChallenge": {
+      "name": "accountDeletionChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accountDeletionChallenge_userId_user_id_fk": {
+          "name": "accountDeletionChallenge_userId_user_id_fk",
+          "tableFrom": "accountDeletionChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auditLog": {
+      "name": "auditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUid": {
+          "name": "targetUid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytesBefore": {
+          "name": "bytesBefore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytesAfter": {
+          "name": "bytesAfter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auditLog_user_id": {
+          "name": "auditLog_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auditLog_userId_user_id_fk": {
+          "name": "auditLog_userId_user_id_fk",
+          "tableFrom": "auditLog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commodity_price": {
+      "name": "commodity_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_date": {
+          "name": "fetched_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commodity_price_unique_per_day": {
+          "name": "commodity_price_unique_per_day",
+          "nullsNotDistinct": false,
+          "columns": [
+            "symbol",
+            "quote",
+            "fetched_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cryptoPasskeyWrap": {
+      "name": "cryptoPasskeyWrap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrap": {
+          "name": "wrap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cryptoPasskeyWrap_userId_user_id_fk": {
+          "name": "cryptoPasskeyWrap_userId_user_id_fk",
+          "tableFrom": "cryptoPasskeyWrap",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cryptoPasskeyWrap_user_cred": {
+          "name": "cryptoPasskeyWrap_user_cred",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "credentialId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encryptionResetChallenge": {
+      "name": "encryptionResetChallenge",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encryptionResetChallenge_userId_user_id_fk": {
+          "name": "encryptionResetChallenge_userId_user_id_fk",
+          "tableFrom": "encryptionResetChallenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_price": {
+      "name": "manual_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priced_at": {
+          "name": "priced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "manual_price_user_id_user_id_fk": {
+          "name": "manual_price_user_id_user_id_fk",
+          "tableFrom": "manual_price",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "manual_price_unique_per_instant": {
+          "name": "manual_price_unique_per_instant",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "symbol",
+            "quote",
+            "priced_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_fetch_run": {
+      "name": "price_fetch_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbols_fetched": {
+          "name": "symbols_fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "symbols_failed": {
+          "name": "symbols_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savedView": {
+      "name": "savedView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPath": {
+          "name": "targetPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "savedView_user_name": {
+          "name": "savedView_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "savedView_userId_user_id_fk": {
+          "name": "savedView_userId_user_id_fk",
+          "tableFrom": "savedView",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_user_name": {
+          "name": "template_user_name",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_userId_user_id_fk": {
+          "name": "template_userId_user_id_fk",
+          "tableFrom": "template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userCrypto": {
+      "name": "userCrypto",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wrapPassphrase": {
+          "name": "wrapPassphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passSalt": {
+          "name": "passSalt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "argonParams": {
+          "name": "argonParams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapRecovery": {
+          "name": "wrapRecovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recoveryCreatedAt": {
+          "name": "recoveryCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kdfVersion": {
+          "name": "kdfVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "migratedAt": {
+          "name": "migratedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userCrypto_userId_user_id_fk": {
+          "name": "userCrypto_userId_user_id_fk",
+          "tableFrom": "userCrypto",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "baseCurrency": {
+          "name": "baseCurrency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "journalMain": {
+          "name": "journalMain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main.ledger'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "userSetting_userId_user_id_fk": {
+          "name": "userSetting_userId_user_id_fk",
+          "tableFrom": "userSetting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1782513743588,
       "tag": "0009_odd_sunfire",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1782606834501,
+      "tag": "0010_plain_ink",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/cryptoPasskeyWrap.ts
+++ b/db/schema/cryptoPasskeyWrap.ts
@@ -16,7 +16,6 @@ export const cryptoPasskeyWrap = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
     credentialId: text('credentialId').notNull(),
-    prfSalt: text('prfSalt').notNull(), // base64, 32 bytes
     wrap: text('wrap').notNull(), // opaque base64; DEK wrapped by the PRF-derived KEK
     label: text('label').notNull(), // mirrors the passkey name, for the UI
     createdAt: timestamp('createdAt')

--- a/docs/superpowers/plans/2026-06-28-passkey-single-tap-unlock.md
+++ b/docs/superpowers/plans/2026-06-28-passkey-single-tap-unlock.md
@@ -1,0 +1,735 @@
+# Single-tap passkey login + journal unlock — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make one passkey tap perform both login and encrypted-journal unlock, by capturing the PRF output during the login WebAuthn ceremony using a fixed salt.
+
+**Architecture:** Switch the PRF eval salt from a per-passkey random value (stored server-side, fetched after auth) to a fixed versioned constant known at build time. This lets the login `signIn.passkey()` ceremony request PRF and return its output, which is fed into the existing `derivePrfKek → unwrapDek → postDek` pipeline before redirect. The per-passkey `prfSalt` column/field is removed everywhere. Unlock is best-effort: any failure falls back to today's passphrase/standalone-passkey unlock.
+
+**Tech Stack:** Next.js, TypeScript, better-auth + `@better-auth/passkey` 1.6.10, `@simplewebauthn/browser`, drizzle-orm (Postgres), vitest, WebCrypto (HKDF/AES-GCM).
+
+## Global Constraints
+
+- No self-reference in any artifact (no "Claude"/"Anthropic"/AI mentions in code, comments, commits). Verbatim from user global instructions.
+- No `Co-Authored-By` / "Generated with" trailers in commits.
+- Fixed PRF salt value: `ledger-prf-v1` (UTF-8 bytes). The HKDF info `ledger-passkey-v1` in `derivePrfKek` is unchanged and remains the domain separator.
+- Zero-knowledge invariant preserved: server stores only opaque blobs and never unwraps; the DEK and PRF output exist only client-side except where already POSTed to `/api/crypto/unlock`.
+- Passkey login stays a **modal** prompt (no `autoFill` / conditional UI) so PRF is reliably returned.
+- TDD, DRY, YAGNI, frequent commits.
+
+---
+
+## File Structure
+
+- `features/crypto/lib/clientCrypto.ts` — add `PRF_SALT` constant (Task 1).
+- `features/crypto/lib/webauthn.ts` — assertions use the fixed salt; drop salt params (Task 2).
+- `features/crypto/lib/passkeyFlow.ts` — `EnablePasskeyInput` drops `prfSalt`; new `unlockWithPrfOutput` + `tryUnlockFromWebAuthn`; `unlockWithPasskey`/`buildPasskeyWrap` refactored (Task 2).
+- `lib/crypto/passkeyWrapSchema.ts`, `lib/crypto/setupSchema.ts`, `lib/crypto/passkeyWrapRepository.ts`, `features/crypto/actions/enablePasskeyUnlock.ts`, `app/api/crypto/material/route.ts` — drop `prfSalt` (Task 2).
+- `db/schema/cryptoPasskeyWrap.ts` + generated migration — drop column, wipe stale rows (Task 3).
+- `features/auth/AuthForm.tsx` — single-tap wiring (Task 4).
+- Tests co-located with each (`*.test.ts`/`*.test.tsx`).
+
+---
+
+## Task 1: Fixed PRF salt constant
+
+**Files:**
+- Modify: `features/crypto/lib/clientCrypto.ts`
+- Test: `features/crypto/lib/clientCrypto.test.ts` (create if absent; otherwise append)
+
+**Interfaces:**
+- Produces: `export const PRF_SALT: Uint8Array` — the fixed PRF eval input, used by `webauthn.ts` and `AuthForm.tsx`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `features/crypto/lib/clientCrypto.test.ts` (create the file with this content if it does not exist):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { PRF_SALT } from './clientCrypto';
+
+describe('PRF_SALT', () => {
+  it('is the fixed versioned salt bytes', () => {
+    expect(new TextDecoder().decode(PRF_SALT)).toBe('ledger-prf-v1');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run features/crypto/lib/clientCrypto.test.ts`
+Expected: FAIL — `PRF_SALT` is not exported.
+
+- [ ] **Step 3: Add the constant**
+
+In `features/crypto/lib/clientCrypto.ts`, directly below the existing `PASSKEY_INFO` line (around line 5), add:
+
+```ts
+/**
+ * Fixed PRF eval input for passkey-derived KEKs. Not a secret and not entropy:
+ * the PRF output is already uniquely bound to (authenticator secret, rpId) by the
+ * hardware, and domain separation is handled by derivePrfKek's HKDF info. A fixed
+ * value lets the login ceremony request PRF without a pre-auth salt fetch. The
+ * version suffix leaves a rotation handle.
+ */
+export const PRF_SALT: Uint8Array = new TextEncoder().encode('ledger-prf-v1');
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run features/crypto/lib/clientCrypto.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/crypto/lib/clientCrypto.ts features/crypto/lib/clientCrypto.test.ts
+git commit -m "feat(crypto): add fixed PRF salt constant"
+```
+
+---
+
+## Task 2: Switch to fixed salt and drop prfSalt end-to-end
+
+This is one atomic refactor: removing the `prfSalt` field changes a type
+(`PasskeyMaterial`, `EnablePasskeyInput`) that flows through client and server, so
+all sites move together to keep the tree compiling. It commits in sub-steps but is
+one reviewer gate.
+
+**Files:**
+- Modify: `features/crypto/lib/webauthn.ts`, `features/crypto/lib/webauthn.test.ts`
+- Modify: `features/crypto/lib/passkeyFlow.ts`, `features/crypto/lib/passkeyFlow.test.ts`
+- Modify: `lib/crypto/passkeyWrapSchema.ts`
+- Modify: `lib/crypto/setupSchema.ts`
+- Modify: `lib/crypto/passkeyWrapRepository.ts`, `lib/crypto/passkeyWrapRepository.test.ts`
+- Modify: `features/crypto/actions/enablePasskeyUnlock.ts`, `features/crypto/actions/passkeyUnlock.test.ts`
+- Modify: `app/api/crypto/material/route.ts`, `app/api/crypto/material/route.test.ts`
+
+**Interfaces:**
+- Consumes: `PRF_SALT` from `clientCrypto` (Task 1).
+- Produces:
+  - `assertPrfForCredential(credentialId: string): Promise<PrfAssertion>` (salt param removed)
+  - `assertPrfAny(credentialIds: string[]): Promise<PrfAssertion>` (per-cred salt removed)
+  - `unlockWithPrfOutput(credentialId: string, prfOutput: Uint8Array): Promise<void>`
+  - `tryUnlockFromWebAuthn(webauthn: WebAuthnResult | undefined): Promise<void>` where
+    `WebAuthnResult = { response: { id: string }; clientExtensionResults: { prf?: { results?: { first?: BufferSource } } } }`
+  - `EnablePasskeyInput = { credentialId: string; wrap: string; label: string }` (no `prfSalt`)
+  - `PasskeyMaterial = { credentialId: string; wrap: string }` (no `prfSalt`)
+
+### 2a. webauthn.ts — fixed salt
+
+- [ ] **Step 1: Update the failing tests**
+
+In `features/crypto/lib/webauthn.test.ts`: change the `assertPrfForCredential` calls to drop the salt arg, change `assertPrfAny` to take a string array, and assert the fixed salt is sent. Replace the `assertPrfForCredential` and `assertPrfAny` describe blocks with:
+
+```ts
+import { PRF_SALT } from './clientCrypto';
+
+describe('assertPrfForCredential', () => {
+  it('returns the PRF output and sends the fixed salt', async () => {
+    const out = new Uint8Array(32).fill(7).buffer;
+    let opts: CredentialRequestOptions | undefined;
+    stubGet((o) => {
+      opts = o;
+      return fakeCred('cred-A', out);
+    });
+    const res = await assertPrfForCredential('cred-A');
+    expect(res.credentialId).toBe('cred-A');
+    expect(res.prfOutput).toHaveLength(32);
+    const first = new Uint8Array(
+      opts!.publicKey!.extensions!.prf!.eval!.first as ArrayBuffer
+    );
+    expect(Array.from(first)).toEqual(Array.from(PRF_SALT));
+  });
+
+  it('throws a clear error when PRF is unsupported', async () => {
+    stubGet(() => fakeCred('cred-A', undefined));
+    await expect(assertPrfForCredential('cred-A')).rejects.toThrow(
+      /does not support/i
+    );
+  });
+
+  it('throws when the prompt is dismissed (null credential)', async () => {
+    stubGet(() => null);
+    await expect(assertPrfForCredential('cred-A')).rejects.toThrow(/dismissed/i);
+  });
+});
+
+describe('assertPrfAny', () => {
+  it('identifies which credential answered and returns its PRF output', async () => {
+    const out = new Uint8Array(32).fill(9).buffer;
+    stubGet(() => fakeCred('cred-B', out));
+    const res = await assertPrfAny(['cred-A', 'cred-B']);
+    expect(res.credentialId).toBe('cred-B');
+    expect(res.prfOutput).toHaveLength(32);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm vitest run features/crypto/lib/webauthn.test.ts`
+Expected: FAIL — argument/signature mismatch.
+
+- [ ] **Step 3: Rewrite webauthn.ts assertions**
+
+Replace the body of `features/crypto/lib/webauthn.ts` from the import line and the two `assertPrf*` functions with:
+
+```ts
+import { PRF_SALT } from './clientCrypto';
+
+export const base64urlToBytes = (s: string): Uint8Array<ArrayBuffer> => {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+  return Uint8Array.from(atob(b64), (c) =>
+    c.charCodeAt(0)
+  ) as Uint8Array<ArrayBuffer>;
+};
+
+export type PrfAssertion = { credentialId: string; prfOutput: Uint8Array };
+
+const readPrf = (cred: PublicKeyCredential): Uint8Array => {
+  const first = cred.getClientExtensionResults().prf?.results?.first;
+  if (!first) throw new Error('This device does not support passkey unlock.');
+  return new Uint8Array(first as ArrayBuffer);
+};
+
+const prfExtensions = () => ({
+  prf: { eval: { first: PRF_SALT as unknown as BufferSource } },
+});
+
+/** Single-credential PRF assertion — used when enabling a specific passkey. */
+export const assertPrfForCredential = async (
+  credentialId: string
+): Promise<PrfAssertion> => {
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [
+        { id: base64urlToBytes(credentialId), type: 'public-key' },
+      ],
+      userVerification: 'required',
+      extensions: prfExtensions(),
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('Passkey prompt was dismissed.');
+  return { credentialId, prfOutput: readPrf(cred) };
+};
+
+/** Multi-credential PRF assertion — used by the standalone unlock screen. */
+export const assertPrfAny = async (
+  credentialIds: string[]
+): Promise<PrfAssertion> => {
+  const cred = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: credentialIds.map((id) => ({
+        id: base64urlToBytes(id),
+        type: 'public-key' as const,
+      })),
+      userVerification: 'required',
+      extensions: prfExtensions(),
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('Passkey prompt was dismissed.');
+  return { credentialId: cred.id, prfOutput: readPrf(cred) };
+};
+```
+
+Note: the previous `import { fromBase64 } from './clientCrypto';` is gone — `fromBase64` is no longer used here.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm vitest run features/crypto/lib/webauthn.test.ts`
+Expected: PASS.
+
+### 2b. passkeyFlow.ts — helpers + refactor
+
+- [ ] **Step 5: Update/extend the tests**
+
+In `features/crypto/lib/passkeyFlow.test.ts`:
+
+1. In the `buildPasskeyWrap` test, change the assertion mock call expectation — `assertPrfForCredential` is now called with just `'cred-A'`. The existing assertions on the returned `out` still hold except remove any `prfSalt` expectation (there is none in the current test, so only the call signature matters). Replace its body with:
+
+```ts
+  it('asserts PRF and returns a wrap of the DEK', async () => {
+    const prf = new Uint8Array(32).fill(3);
+    (
+      assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
+    ).mockResolvedValue({ credentialId: 'cred-A', prfOutput: prf });
+    const dek = generateDek();
+    const out = await buildPasskeyWrap(dek, 'cred-A', 'Laptop');
+    expect(out).toEqual({
+      credentialId: 'cred-A',
+      label: 'Laptop',
+      wrap: expect.any(String),
+    });
+    expect(assertPrfForCredential).toHaveBeenCalledWith('cred-A');
+  });
+```
+
+2. In both `getMaterial` mock objects (the `unlockWithPasskey` success test and the empty test), remove the `prfSalt` properties from each passkey entry so the shape matches the new `PasskeyMaterial`. The success test's `passkeys` becomes:
+
+```ts
+      passkeys: [
+        { credentialId: 'cred-A', wrap: 'x' },
+        { credentialId: 'cred-B', wrap },
+      ],
+```
+
+3. In the `unlockWithPasskey` success test, change the `assertPrfAny` mock — it is now called with a string array. No change to its `mockResolvedValue` is needed; optionally assert `expect(assertPrfAny).toHaveBeenCalledWith(['cred-A', 'cred-B'])`.
+
+4. Add a new describe block for the two new helpers:
+
+```ts
+describe('unlockWithPrfOutput', () => {
+  it('unwraps the matching wrap and posts the DEK', async () => {
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [{ credentialId: 'cred-B', wrap }],
+    });
+    await unlockWithPrfOutput('cred-B', prf);
+    const posted = (postDek as MockedFunction<typeof postDek>).mock
+      .calls[0][0] as Uint8Array;
+    expect(Array.from(posted)).toEqual(Array.from(dek));
+  });
+
+  it('throws when the credential has no enrolled wrap', async () => {
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [],
+    });
+    await expect(
+      unlockWithPrfOutput('cred-X', new Uint8Array(32))
+    ).rejects.toThrow(/not enrolled/i);
+  });
+});
+
+describe('tryUnlockFromWebAuthn', () => {
+  it('unlocks when PRF output is present', async () => {
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [{ credentialId: 'cred-B', wrap }],
+    });
+    await tryUnlockFromWebAuthn({
+      response: { id: 'cred-B' },
+      clientExtensionResults: { prf: { results: { first: prf.buffer } } },
+    });
+    expect(postDek).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops when PRF output is absent', async () => {
+    await tryUnlockFromWebAuthn({
+      response: { id: 'cred-B' },
+      clientExtensionResults: {},
+    });
+    expect(postDek).not.toHaveBeenCalled();
+  });
+
+  it('swallows unlock errors (not enrolled) without throwing', async () => {
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [],
+    });
+    await expect(
+      tryUnlockFromWebAuthn({
+        response: { id: 'cred-Z' },
+        clientExtensionResults: {
+          prf: { results: { first: new Uint8Array(32).buffer } },
+        },
+      })
+    ).resolves.toBeUndefined();
+    expect(postDek).not.toHaveBeenCalled();
+  });
+});
+```
+
+Update the import line at the top of the test to include the new exports:
+
+```ts
+import {
+  buildPasskeyWrap,
+  unlockWithPasskey,
+  unlockWithPrfOutput,
+  tryUnlockFromWebAuthn,
+  registerPasskey,
+  enrollPasskeyForUnlock,
+} from './passkeyFlow';
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `pnpm vitest run features/crypto/lib/passkeyFlow.test.ts`
+Expected: FAIL — new exports undefined / signature mismatches.
+
+- [ ] **Step 7: Rewrite passkeyFlow.ts**
+
+Replace `EnablePasskeyInput`, `buildPasskeyWrap`, and `unlockWithPasskey`, and add the two new helpers. The final `features/crypto/lib/passkeyFlow.ts` relevant sections become:
+
+```ts
+export type EnablePasskeyInput = {
+  credentialId: string;
+  wrap: string;
+  label: string;
+};
+```
+
+```ts
+export const buildPasskeyWrap = async (
+  dek: Uint8Array,
+  credentialId: string,
+  label: string
+): Promise<EnablePasskeyInput> => {
+  const { prfOutput } = await assertPrfForCredential(credentialId);
+  const wrap = await wrapDek(dek, await derivePrfKek(prfOutput));
+  return { credentialId, wrap, label };
+};
+```
+
+```ts
+/**
+ * Unwrap the DEK using a PRF output already obtained from a ceremony and post it
+ * to the session. Shared by the standalone unlock and the single-tap login path.
+ * Throws if the responding credential has no enrolled wrap.
+ */
+export const unlockWithPrfOutput = async (
+  credentialId: string,
+  prfOutput: Uint8Array
+): Promise<void> => {
+  const m = await getMaterial();
+  const match = m.passkeys.find((p) => p.credentialId === credentialId);
+  if (!match) throw new Error('Passkey is not enrolled for unlock.');
+  const dek = await unwrapDek(match.wrap, await derivePrfKek(prfOutput)).catch(
+    () => {
+      throw new Error('Passkey unlock failed.');
+    }
+  );
+  await postDek(dek);
+};
+
+/** Shape of better-auth's returned WebAuthn assertion (the bits we read). */
+export type WebAuthnResult = {
+  response: { id: string };
+  clientExtensionResults: { prf?: { results?: { first?: BufferSource } } };
+};
+
+/**
+ * Best-effort unlock from a login ceremony's PRF output. No-ops when PRF is
+ * absent (device unsupported / passkey not registered with PRF) and swallows
+ * unlock failures (passkey not enrolled for unlock, no encryption set up) so the
+ * caller can proceed to the normal passphrase unlock. Never throws.
+ */
+export const tryUnlockFromWebAuthn = async (
+  webauthn: WebAuthnResult | undefined
+): Promise<void> => {
+  const first = webauthn?.clientExtensionResults?.prf?.results?.first;
+  const credentialId = webauthn?.response?.id;
+  if (!first || !credentialId) return;
+  try {
+    await unlockWithPrfOutput(credentialId, new Uint8Array(first as ArrayBuffer));
+  } catch {
+    // Not enrolled for unlock / no encryption — fall through to passphrase unlock.
+  }
+};
+
+/** Unlock the session using any enrolled passkey (standalone unlock screen). */
+export const unlockWithPasskey = async (): Promise<void> => {
+  const m = await getMaterial();
+  if (!m.passkeys.length) throw new Error('No passkey is set up for unlock.');
+  const { credentialId, prfOutput } = await assertPrfAny(
+    m.passkeys.map((p) => p.credentialId)
+  );
+  await unlockWithPrfOutput(credentialId, prfOutput);
+};
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `pnpm vitest run features/crypto/lib/passkeyFlow.test.ts`
+Expected: PASS. (Server files still reference `prfSalt` — typecheck is fixed in 2c; vitest transpiles per-file so this suite passes now.)
+
+### 2c. Server — drop prfSalt
+
+- [ ] **Step 9: Update server tests**
+
+In `features/crypto/actions/passkeyUnlock.test.ts`: remove `prfSalt` from the `validEnable` fixture, and assert `create` is called without it:
+
+```ts
+const validEnable = {
+  credentialId: 'cred-A',
+  wrap: 'd3JhcA==',
+  label: 'Laptop',
+};
+```
+
+In `app/api/crypto/material/route.test.ts`: remove `prfSalt` from any fixtured wrap rows and from the expected `passkeys` shape. Each expected passkey is now `{ credentialId, wrap }`.
+
+In `lib/crypto/passkeyWrapRepository.test.ts`: remove `prfSalt` from any `create` inputs and from `onConflictDoUpdate`/expected `set` assertions.
+
+- [ ] **Step 10: Run to verify they fail**
+
+Run: `pnpm vitest run features/crypto/actions/passkeyUnlock.test.ts app/api/crypto/material/route.test.ts lib/crypto/passkeyWrapRepository.test.ts`
+Expected: FAIL (or still pass with extra field) — proceed regardless; the code edits below make them authoritative.
+
+- [ ] **Step 11: Drop prfSalt from schema, type, repo, action, route**
+
+`lib/crypto/passkeyWrapSchema.ts` — remove the `prfSalt: b64,` line from `enablePasskeyUnlockSchema`:
+
+```ts
+export const enablePasskeyUnlockSchema = z.object({
+  credentialId: b64url,
+  wrap: b64,
+  label: z.string().min(1).max(100),
+});
+```
+
+`lib/crypto/setupSchema.ts` — drop `prfSalt` from `PasskeyMaterial`:
+
+```ts
+export type PasskeyMaterial = {
+  credentialId: string;
+  wrap: string;
+};
+```
+
+`lib/crypto/passkeyWrapRepository.ts` — remove `prfSalt` from the conflict `set`:
+
+```ts
+      .onConflictDoUpdate({
+        target: [cryptoPasskeyWrap.userId, cryptoPasskeyWrap.credentialId],
+        set: { wrap: input.wrap, label: input.label },
+      });
+```
+
+`features/crypto/actions/enablePasskeyUnlock.ts` — remove `prfSalt` from the `create` call:
+
+```ts
+  await getPasskeyWrapRepository().create({
+    id: ulid(),
+    userId: user.id,
+    credentialId: parsed.data.credentialId,
+    wrap: parsed.data.wrap,
+    label: parsed.data.label,
+  });
+```
+
+`app/api/crypto/material/route.ts` — drop `prfSalt` from the mapped passkeys:
+
+```ts
+    passkeys: wraps.map((w) => ({
+      credentialId: w.credentialId,
+      wrap: w.wrap,
+    })),
+```
+
+Note: `NewCryptoPasskeyWrap` still types `prfSalt` as required until Task 3 drops the column, so the `create` input in `enablePasskeyUnlock.ts` will type-error until Task 3. To keep Task 2 self-consistent, complete Task 3's schema edit immediately after Step 11 if running typecheck here; otherwise the vitest suites in Step 12 pass independently and the full typecheck is asserted at the end of Task 3. (Sequence Task 3 right after this step.)
+
+- [ ] **Step 12: Run the affected suites**
+
+Run: `pnpm vitest run features/crypto/actions/passkeyUnlock.test.ts app/api/crypto/material/route.test.ts lib/crypto/passkeyWrapRepository.test.ts`
+Expected: PASS.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add features/crypto/lib/webauthn.ts features/crypto/lib/webauthn.test.ts \
+  features/crypto/lib/passkeyFlow.ts features/crypto/lib/passkeyFlow.test.ts \
+  lib/crypto/passkeyWrapSchema.ts lib/crypto/setupSchema.ts \
+  lib/crypto/passkeyWrapRepository.ts lib/crypto/passkeyWrapRepository.test.ts \
+  features/crypto/actions/enablePasskeyUnlock.ts features/crypto/actions/passkeyUnlock.test.ts \
+  app/api/crypto/material/route.ts app/api/crypto/material/route.test.ts
+git commit -m "feat(crypto): use fixed PRF salt and drop per-passkey prfSalt"
+```
+
+---
+
+## Task 3: Drop the prfSalt column and wipe stale wraps
+
+**Files:**
+- Modify: `db/schema/cryptoPasskeyWrap.ts`
+- Create: `db/migrations/00XX_<generated>.sql` (via drizzle-kit) + updated `db/migrations/meta/*`
+
+**Interfaces:**
+- Consumes: the schema type `NewCryptoPasskeyWrap` is referenced by `passkeyWrapRepository.ts` and `enablePasskeyUnlock.ts` (Task 2); dropping the column makes `prfSalt` no longer a required insert field, resolving Task 2's pending typecheck.
+
+- [ ] **Step 1: Remove the column from the schema**
+
+In `db/schema/cryptoPasskeyWrap.ts`, delete the line:
+
+```ts
+    prfSalt: text('prfSalt').notNull(), // base64, 32 bytes
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `pnpm db:generate`
+Expected: a new file `db/migrations/00XX_*.sql` containing
+`ALTER TABLE "cryptoPasskeyWrap" DROP COLUMN "prfSalt";` and updated snapshot meta.
+
+- [ ] **Step 3: Prepend the data wipe**
+
+Edit the newly generated migration file. Add this line **above** the `ALTER TABLE ... DROP COLUMN` statement (stale wraps were made with random salts and can never decrypt under the fixed salt):
+
+```sql
+DELETE FROM "cryptoPasskeyWrap";
+--> statement-breakpoint
+```
+
+- [ ] **Step 4: Apply the migration and typecheck**
+
+Run: `pnpm db:migrate`
+Expected: migration applies cleanly.
+
+Run: `pnpm type-check`
+Expected: PASS — no remaining `prfSalt` type errors anywhere (confirms Task 2 + Task 3 are consistent).
+
+- [ ] **Step 5: Full test sweep**
+
+Run: `pnpm vitest run`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/schema/cryptoPasskeyWrap.ts db/migrations/
+git commit -m "feat(crypto): drop prfSalt column and wipe stale passkey wraps"
+```
+
+---
+
+## Task 4: Single-tap wiring in the login form
+
+**Files:**
+- Modify: `features/auth/AuthForm.tsx`
+- Test: covered by `features/crypto/lib/passkeyFlow.test.ts` (`tryUnlockFromWebAuthn`, Task 2). The form change is thin wiring; `AuthScreen.test.tsx` keeps the render smoke test green.
+
+**Interfaces:**
+- Consumes: `PRF_SALT` (Task 1), `tryUnlockFromWebAuthn` + `WebAuthnResult` (Task 2).
+
+- [ ] **Step 1: Add imports**
+
+In `features/auth/AuthForm.tsx`, add to the import block:
+
+```ts
+import { PRF_SALT } from '@/features/crypto/lib/clientCrypto';
+import {
+  tryUnlockFromWebAuthn,
+  type WebAuthnResult,
+} from '@/features/crypto/lib/passkeyFlow';
+```
+
+- [ ] **Step 2: Rewrite onPasskey**
+
+Replace the existing `onPasskey` function (currently lines ~109-119) with:
+
+```ts
+  function onPasskey() {
+    let webauthn: WebAuthnResult | undefined;
+    return runAttempt(
+      'passkey',
+      async () => {
+        const res = await authClient.signIn.passkey({
+          extensions: { prf: { eval: { first: PRF_SALT as unknown as BufferSource } } },
+          returnWebAuthnResponse: true,
+        });
+        if (res && 'webauthn' in res && res.webauthn) {
+          webauthn = res.webauthn as unknown as WebAuthnResult;
+        }
+        return res;
+      },
+      async () => {
+        // Best-effort: unlock the journal from the same ceremony's PRF output.
+        // Never throws; falls through to passphrase unlock when unavailable.
+        await tryUnlockFromWebAuthn(webauthn);
+        const callbackURL = resolveCallbackUrl('callbackUrl', CALLBACK_URL);
+        window.location.assign(callbackURL);
+      }
+    );
+  }
+```
+
+Rationale: `runAttempt`'s `call` still returns `{ error }` for state dispatch; the
+full result is captured via the `webauthn` closure variable. `onSuccess` accepts
+an async function (its return value is ignored by `runAttempt`), so no change to
+`runAttempt` is required. The redirect happens inside `onSuccess` after the
+best-effort unlock.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 4: Run the auth + passkey suites**
+
+Run: `pnpm vitest run features/auth features/crypto`
+Expected: PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `pnpm lint`
+Expected: PASS (no unused imports; `onSuccess` async accepted).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/auth/AuthForm.tsx
+git commit -m "feat(auth): unlock journal in the passkey login ceremony"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full typecheck, lint, tests**
+
+Run: `pnpm type-check && pnpm lint && pnpm vitest run`
+Expected: all PASS.
+
+- [ ] **Step 2: Manual smoke (documented for the reviewer)**
+
+With a fresh DB (wraps wiped): register a passkey, set up encryption, enroll the
+passkey for unlock from Settings, lock, then sign out. Sign back in with the
+passkey — verify a **single** prompt and that the dashboard loads unlocked (no
+trip to `/crypto/unlock`). Then test fallback: a passphrase-only user signing in
+with passkey (not enrolled for unlock) still lands logged-in and is asked for the
+passphrase on first encrypted read.
+
+- [ ] **Step 3: Commit (if any doc tweaks)** — otherwise the branch is ready for PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Fixed salt constant → Task 1. ✓
+- Assertions use fixed salt → Task 2a. ✓
+- `unlockWithPrfOutput` + `unlockWithPasskey` refactor → Task 2b. ✓
+- Drop `prfSalt` (schema/type/repo/action/route) → Task 2c. ✓
+- Login merge (`signIn.passkey` + PRF capture + best-effort unlock) → Task 4. ✓
+- DB column drop + data wipe → Task 3. ✓
+- Fail-soft / modal / magic-link unaffected → encoded in `tryUnlockFromWebAuthn` (Task 2) and onPasskey (Task 4); `unlockWithPasskey` standalone path preserved for magic-link/Google. ✓
+- Envelope/passphrase/recovery untouched → confirmed (no edits to those paths). ✓
+
+**Placeholder scan:** none — all steps carry concrete code/commands. The only non-literal is the generated migration filename (`00XX`), which is intrinsic to drizzle-kit and handled by Step 3.2–3.3.
+
+**Type consistency:** `PRF_SALT: Uint8Array`, `assertPrfForCredential(string)`, `assertPrfAny(string[])`, `unlockWithPrfOutput(string, Uint8Array)`, `tryUnlockFromWebAuthn(WebAuthnResult|undefined)`, `EnablePasskeyInput`/`PasskeyMaterial` without `prfSalt` — names/types match across Tasks 2 and 4.

--- a/docs/superpowers/specs/2026-06-28-passkey-single-tap-unlock-design.md
+++ b/docs/superpowers/specs/2026-06-28-passkey-single-tap-unlock-design.md
@@ -1,0 +1,129 @@
+# Single-tap passkey login + journal unlock
+
+**Date:** 2026-06-28
+**Branch:** `feat/passkey-single-tap-unlock`
+**Status:** Approved design — proceeding to implementation plan.
+
+## Problem
+
+A passkey user currently taps their authenticator twice: once to log in
+(`authClient.signIn.passkey()` in `features/auth/AuthForm.tsx`), and again to
+unlock their encrypted journal (`unlockWithPasskey` in
+`features/crypto/lib/passkeyFlow.ts`, surfaced on `UnlockScreen`). The two are
+cryptographically distinct outputs of the *same* credential — a signature for
+login, a PRF output for key derivation — but they are obtained in two separate
+WebAuthn ceremonies.
+
+A single `navigator.credentials.get()` can return both at once: pass the PRF
+`eval` salt into the assertion and read `getClientExtensionResults().prf.results.first`
+off the same response that authenticates the user. The blocker today is salt
+timing: the PRF salt is random per passkey and stored server-side
+(`cryptoPasskeyWrap.prfSalt`), fetched from `/api/crypto/material` which requires
+an authenticated session — so it cannot be known *before* the login ceremony.
+
+## Goal
+
+One biometric tap performs both login and journal unlock. Fall back cleanly to
+the existing passphrase / standalone-passkey unlock whenever PRF is unavailable.
+
+## Key decisions
+
+- **Fixed versioned PRF salt.** Replace the per-passkey random salt with a single
+  constant, `PRF_SALT = TextEncoder().encode('ledger-prf-v1')`, known at build
+  time. This is safe: the PRF output is already uniquely bound to (authenticator
+  hardware secret, rpId) by the authenticator; the salt is an application-chosen
+  input label, not entropy or a secret (it was already sent to the client in
+  plaintext). Domain separation is already handled by HKDF's fixed
+  `info: 'ledger-passkey-v1'` in `derivePrfKek`. The version in the name leaves a
+  rotation handle for the future.
+- **Drop the `prfSalt` column.** With a fixed salt the stored value is redundant.
+  Remove it from the table, the enroll schema, the material payload, and the
+  client flows. (Decided over keeping a constant-valued column.)
+- **No migration of existing wraps.** There are no real users on the server. The
+  salt change invalidates existing wraps, so they are deleted; users re-enroll
+  passkey unlock. Login passkey credentials themselves are untouched.
+- **Full single-tap merge now** (not a phased foundation-first).
+
+## Approach
+
+### 1. Fixed salt constant — `features/crypto/lib/clientCrypto.ts`
+Add `export const PRF_SALT = new TextEncoder().encode('ledger-prf-v1');`.
+`derivePrfKek` is unchanged (it already uses an empty HKDF salt + fixed info).
+
+### 2. WebAuthn assertions use the fixed salt — `features/crypto/lib/webauthn.ts`
+- `assertPrfForCredential(credentialId)` — drop the `salt` parameter; use
+  `eval: { first: PRF_SALT }`. Used at enrollment.
+- `assertPrfAny(credentialIds: string[])` — drop the per-credential `prfSalt`;
+  use a single `eval: { first: PRF_SALT }` for all listed credentials (still sets
+  `allowCredentials`). Used by the standalone unlock path.
+- `readPrf` unchanged.
+
+### 3. Shared unlock helper + login merge — `features/crypto/lib/passkeyFlow.ts`
+- New `unlockWithPrfOutput(credentialId: string, prfOutput: Uint8Array)`: fetch
+  material, find the wrap whose `credentialId` matches, `derivePrfKek` →
+  `unwrapDek` → `postDek`. Throws if no matching wrap. This is the shared core.
+- `unlockWithPasskey()` (standalone, used by `UnlockScreen` for users who logged
+  in via magic link / Google) refactors onto `assertPrfAny` + `unlockWithPrfOutput`.
+- `buildPasskeyWrap` / `enrollPasskeyForUnlock`: drop the generated salt and the
+  `prfSalt` field from `EnablePasskeyInput`; call `assertPrfForCredential(credentialId)`.
+
+### 4. Merge into login — `features/auth/AuthForm.tsx`
+`onPasskey` calls:
+```ts
+authClient.signIn.passkey({
+  extensions: { prf: { eval: { first: PRF_SALT } } },
+  returnWebAuthnResponse: true,
+})
+```
+On success the result is `{ webauthn: { response, clientExtensionResults }, data, error: null }`.
+After auth succeeds, **best-effort** unlock: read
+`webauthn.clientExtensionResults.prf?.results?.first` and `webauthn.response.id`;
+if both present, call `unlockWithPrfOutput(id, new Uint8Array(first))` wrapped in
+try/catch. Any failure (no encryption set up, passkey not enrolled for unlock,
+device returned no PRF) is swallowed — then redirect to the callback URL exactly
+as today. Net effect: enrolled users land unlocked; everyone else lands exactly
+where they do now.
+
+`runAttempt` is widened minimally so the passkey path can capture the full
+result (the webauthn object) — e.g. close over a local variable in `call` and
+read it in `onSuccess`, or have the passkey path bypass `runAttempt`'s
+result-discarding. Keep the existing `{ error }`-based state dispatch.
+
+### 5. Schema + data — `db/schema/cryptoPasskeyWrap.ts` + migration
+- Remove the `prfSalt` column and its comment.
+- `pnpm db:generate` to produce the drop-column migration; manually prepend
+  `DELETE FROM "cryptoPasskeyWrap";` so stale (now-undecryptable) wraps don't
+  linger.
+
+### 6. Server-side ripple (drop `prfSalt`)
+- `lib/crypto/passkeyWrapSchema.ts` — remove `prfSalt` from `enablePasskeyUnlockSchema`.
+- `lib/crypto/setupSchema.ts` — remove `prfSalt` from `PasskeyMaterial`.
+- `enablePasskeyUnlock` action + repository insert — stop writing `prfSalt`.
+- `/api/crypto/material` route — stop selecting/returning `prfSalt`.
+
+## Out of scope / untouched
+Envelope encryption (random DEK wrapped per authorizer), passphrase (Argon2id)
+and recovery-code unlock paths, the server-side zero-knowledge property (server
+still only stores opaque blobs and never unwraps).
+
+## Edge cases & fallbacks
+- **Device without PRF support** (e.g. Safari + YubiKey): login still succeeds;
+  PRF result absent → unlock skipped → user unlocks via passphrase on the unlock
+  screen. Never block login on PRF.
+- **Modal, not conditional UI.** Keep the passkey login as a modal prompt (the
+  current button), not autofill (`autoFill`), because PRF return during
+  conditional mediation is unreliable across platforms.
+- **Magic-link / Google login** users are unaffected; they unlock via the
+  standalone `UnlockScreen` passkey button or passphrase.
+
+## Testing (TDD)
+- `webauthn.test.ts` — assertions send `eval.first === PRF_SALT`; `assertPrfAny`
+  uses one shared salt across listed credentials.
+- `passkeyFlow.test.ts` — `unlockWithPrfOutput` finds the right wrap, unwraps,
+  posts the DEK; throws when the credential has no wrap. `unlockWithPasskey`
+  still unwraps + posts via the refactored path. Updated material shape (no
+  `prfSalt`).
+- `AuthForm` — `onPasskey` with mocked `signIn.passkey` returning PRF results
+  unlocks then redirects; with PRF absent (or unlock throwing) it still redirects
+  without surfacing an error.
+- Server: enroll action / material route tests updated for the dropped field.

--- a/features/auth/AuthForm.tsx
+++ b/features/auth/AuthForm.tsx
@@ -12,6 +12,11 @@ import {
   type Method,
 } from './authState';
 import { resolveCallbackUrl } from './callbackUrl';
+import { PRF_SALT } from '@/features/crypto/lib/clientCrypto';
+import {
+  tryUnlockFromWebAuthn,
+  type WebAuthnResult,
+} from '@/features/crypto/lib/passkeyFlow';
 import { authClient } from '@/lib/auth-client';
 import { useWebAuthnSupported } from '@naeemba/next-starter/client';
 import Link from 'next/link';
@@ -107,11 +112,25 @@ export function AuthForm({ mode }: AuthFormProps) {
   }
 
   function onPasskey() {
-    const passkey = authClient.signIn.passkey;
+    let webauthn: WebAuthnResult | undefined;
     return runAttempt(
       'passkey',
-      () => passkey(),
-      () => {
+      async () => {
+        const res = await authClient.signIn.passkey({
+          extensions: {
+            prf: { eval: { first: PRF_SALT as unknown as BufferSource } },
+          },
+          returnWebAuthnResponse: true,
+        } as Parameters<typeof authClient.signIn.passkey>[0]);
+        if (res && 'webauthn' in res && res.webauthn) {
+          webauthn = res.webauthn as unknown as WebAuthnResult;
+        }
+        return res;
+      },
+      async () => {
+        // Best-effort: unlock the journal from the same ceremony's PRF output.
+        // Never throws; falls through to passphrase unlock when unavailable.
+        await tryUnlockFromWebAuthn(webauthn);
         const callbackURL = resolveCallbackUrl('callbackUrl', CALLBACK_URL);
         window.location.assign(callbackURL);
       }

--- a/features/auth/AuthForm.tsx
+++ b/features/auth/AuthForm.tsx
@@ -12,11 +12,7 @@ import {
   type Method,
 } from './authState';
 import { resolveCallbackUrl } from './callbackUrl';
-import { PRF_SALT } from '@/features/crypto/lib/clientCrypto';
-import {
-  tryUnlockFromWebAuthn,
-  type WebAuthnResult,
-} from '@/features/crypto/lib/passkeyFlow';
+import { signInWithPasskey } from '@/features/crypto/lib/passkeyFlow';
 import { authClient } from '@/lib/auth-client';
 import { useWebAuthnSupported } from '@naeemba/next-starter/client';
 import Link from 'next/link';
@@ -112,29 +108,12 @@ export function AuthForm({ mode }: AuthFormProps) {
   }
 
   function onPasskey() {
-    let webauthn: WebAuthnResult | undefined;
-    return runAttempt(
-      'passkey',
-      async () => {
-        const res = await authClient.signIn.passkey({
-          extensions: {
-            prf: { eval: { first: PRF_SALT as unknown as BufferSource } },
-          },
-          returnWebAuthnResponse: true,
-        } as Parameters<typeof authClient.signIn.passkey>[0]);
-        if (res && 'webauthn' in res && res.webauthn) {
-          webauthn = res.webauthn as unknown as WebAuthnResult;
-        }
-        return res;
-      },
-      async () => {
-        // Best-effort: unlock the journal from the same ceremony's PRF output.
-        // Never throws; falls through to passphrase unlock when unavailable.
-        await tryUnlockFromWebAuthn(webauthn);
-        const callbackURL = resolveCallbackUrl('callbackUrl', CALLBACK_URL);
-        window.location.assign(callbackURL);
-      }
-    );
+    // signInWithPasskey runs the ceremony and a best-effort single-tap unlock
+    // (never throws on unlock failure); on success we redirect to the dashboard.
+    return runAttempt('passkey', signInWithPasskey, () => {
+      const callbackURL = resolveCallbackUrl('callbackUrl', CALLBACK_URL);
+      window.location.assign(callbackURL);
+    });
   }
 
   if (state.status.magicLink === 'sent') {

--- a/features/crypto/actions/enablePasskeyUnlock.ts
+++ b/features/crypto/actions/enablePasskeyUnlock.ts
@@ -25,7 +25,6 @@ export async function enablePasskeyUnlockAction(
     id: ulid(),
     userId: user.id,
     credentialId: parsed.data.credentialId,
-    prfSalt: parsed.data.prfSalt,
     wrap: parsed.data.wrap,
     label: parsed.data.label,
   });

--- a/features/crypto/actions/passkeyUnlock.test.ts
+++ b/features/crypto/actions/passkeyUnlock.test.ts
@@ -23,7 +23,6 @@ vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
 
 const validEnable = {
   credentialId: 'cred-A',
-  prfSalt: 'c2FsdA==',
   wrap: 'd3JhcA==',
   label: 'Laptop',
 };

--- a/features/crypto/lib/clientCrypto.test.ts
+++ b/features/crypto/lib/clientCrypto.test.ts
@@ -5,6 +5,7 @@ import {
   generateDek,
   generateRecoveryCode,
   parseRecoveryCode,
+  PRF_SALT,
   recoveryHkdfKey,
   unwrapDek,
   wrapDek,
@@ -80,5 +81,11 @@ describe('derivePrfKek', () => {
         await derivePrfKek(crypto.getRandomValues(new Uint8Array(32)))
       )
     ).rejects.toBeTruthy();
+  });
+});
+
+describe('PRF_SALT', () => {
+  it('is the fixed versioned salt bytes', () => {
+    expect(new TextDecoder().decode(PRF_SALT)).toBe('ledger-prf-v1');
   });
 });

--- a/features/crypto/lib/clientCrypto.test.ts
+++ b/features/crypto/lib/clientCrypto.test.ts
@@ -5,7 +5,7 @@ import {
   generateDek,
   generateRecoveryCode,
   parseRecoveryCode,
-  PRF_SALT,
+  prfSalt,
   recoveryHkdfKey,
   unwrapDek,
   wrapDek,
@@ -84,8 +84,15 @@ describe('derivePrfKek', () => {
   });
 });
 
-describe('PRF_SALT', () => {
+describe('prfSalt', () => {
   it('is the fixed versioned salt bytes', () => {
-    expect(new TextDecoder().decode(PRF_SALT)).toBe('ledger-prf-v1');
+    expect(new TextDecoder().decode(prfSalt())).toBe('ledger-prf-v1');
+  });
+  it('returns a fresh copy each call so the shared buffer stays immutable', () => {
+    const a = prfSalt();
+    const b = prfSalt();
+    expect(a).not.toBe(b);
+    a[0] = 0;
+    expect(new TextDecoder().decode(prfSalt())).toBe('ledger-prf-v1');
   });
 });

--- a/features/crypto/lib/clientCrypto.ts
+++ b/features/crypto/lib/clientCrypto.ts
@@ -3,14 +3,19 @@ import { argon2id } from 'hash-wasm';
 const GCM_NONCE = 12;
 const RECOVERY_INFO = new TextEncoder().encode('ledger-recovery-v1');
 const PASSKEY_INFO = new TextEncoder().encode('ledger-passkey-v1');
+const PRF_SALT_BYTES = new TextEncoder().encode('ledger-prf-v1');
+
 /**
  * Fixed PRF eval input for passkey-derived KEKs. Not a secret and not entropy:
  * the PRF output is already uniquely bound to (authenticator secret, rpId) by the
  * hardware, and domain separation is handled by derivePrfKek's HKDF info. A fixed
  * value lets the login ceremony request PRF without a pre-auth salt fetch. The
  * version suffix leaves a rotation handle.
+ *
+ * Returns a fresh copy on each call so the shared crypto-input buffer can never
+ * be mutated by a caller.
  */
-export const PRF_SALT: Uint8Array = new TextEncoder().encode('ledger-prf-v1');
+export const prfSalt = (): Uint8Array => new Uint8Array(PRF_SALT_BYTES);
 
 export const toBase64 = (b: Uint8Array): string =>
   btoa(String.fromCharCode(...b));

--- a/features/crypto/lib/clientCrypto.ts
+++ b/features/crypto/lib/clientCrypto.ts
@@ -3,6 +3,14 @@ import { argon2id } from 'hash-wasm';
 const GCM_NONCE = 12;
 const RECOVERY_INFO = new TextEncoder().encode('ledger-recovery-v1');
 const PASSKEY_INFO = new TextEncoder().encode('ledger-passkey-v1');
+/**
+ * Fixed PRF eval input for passkey-derived KEKs. Not a secret and not entropy:
+ * the PRF output is already uniquely bound to (authenticator secret, rpId) by the
+ * hardware, and domain separation is handled by derivePrfKek's HKDF info. A fixed
+ * value lets the login ceremony request PRF without a pre-auth salt fetch. The
+ * version suffix leaves a rotation handle.
+ */
+export const PRF_SALT: Uint8Array = new TextEncoder().encode('ledger-prf-v1');
 
 export const toBase64 = (b: Uint8Array): string =>
   btoa(String.fromCharCode(...b));

--- a/features/crypto/lib/passkeyFlow.test.ts
+++ b/features/crypto/lib/passkeyFlow.test.ts
@@ -8,6 +8,7 @@ import {
   tryUnlockFromWebAuthn,
   registerPasskey,
   enrollPasskeyForUnlock,
+  signInWithPasskey,
 } from './passkeyFlow';
 import { postDek } from './unlockFlow';
 import { assertPrfForCredential, assertPrfAny } from './webauthn';
@@ -18,7 +19,10 @@ vi.mock('./webauthn');
 vi.mock('./cryptoMaterial');
 vi.mock('./unlockFlow');
 vi.mock('@/lib/auth-client', () => ({
-  authClient: { passkey: { addPasskey: vi.fn() } },
+  authClient: {
+    passkey: { addPasskey: vi.fn() },
+    signIn: { passkey: vi.fn() },
+  },
 }));
 vi.mock('@/features/crypto/actions/enablePasskeyUnlock');
 
@@ -230,5 +234,91 @@ describe('enrollPasskeyForUnlock', () => {
     await expect(
       enrollPasskeyForUnlock(generateDek(), 'cred-A', 'L')
     ).rejects.toThrow('rate limited');
+  });
+});
+
+describe('signInWithPasskey', () => {
+  const signInPasskey = () =>
+    authClient.signIn.passkey as MockedFunction<
+      typeof authClient.signIn.passkey
+    >;
+
+  it('requests PRF with the fixed salt and unlocks from the assertion', async () => {
+    // Arrange: a passkey enrolled for unlock with a known PRF output.
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [{ credentialId: 'cred-B', wrap }],
+    });
+    signInPasskey().mockResolvedValue({
+      error: null,
+      webauthn: {
+        response: { id: 'cred-B' },
+        clientExtensionResults: { prf: { results: { first: prf.buffer } } },
+      },
+    } as never);
+
+    const res = await signInWithPasskey();
+
+    expect(res.error).toBeNull();
+    expect(postDek).toHaveBeenCalledTimes(1);
+    // PRF was requested with the fixed versioned salt.
+    const opts = signInPasskey().mock.calls[0][0] as {
+      extensions: { prf: { eval: { first: ArrayBufferView } } };
+    };
+    const sentSalt = new Uint8Array(
+      opts.extensions.prf.eval.first as unknown as ArrayBuffer
+    );
+    expect(new TextDecoder().decode(sentSalt)).toBe('ledger-prf-v1');
+  });
+
+  it('returns the better-auth error and never attempts unlock', async () => {
+    signInPasskey().mockResolvedValue({
+      error: { message: 'cancelled' },
+    } as never);
+
+    const res = await signInWithPasskey();
+
+    expect(res.error).toEqual({ message: 'cancelled' });
+    expect(postDek).not.toHaveBeenCalled();
+  });
+
+  it('resolves without error when no webauthn/PRF is returned (redirect still proceeds)', async () => {
+    signInPasskey().mockResolvedValue({ error: null } as never);
+
+    const res = await signInWithPasskey();
+
+    expect(res.error).toBeNull();
+    expect(postDek).not.toHaveBeenCalled();
+  });
+
+  it('swallows an unlock failure and still reports success', async () => {
+    // PRF present but the credential is not enrolled for unlock.
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [],
+    });
+    signInPasskey().mockResolvedValue({
+      error: null,
+      webauthn: {
+        response: { id: 'cred-Z' },
+        clientExtensionResults: {
+          prf: { results: { first: new Uint8Array(32).buffer } },
+        },
+      },
+    } as never);
+
+    const res = await signInWithPasskey();
+
+    expect(res.error).toBeNull();
+    expect(postDek).not.toHaveBeenCalled();
   });
 });

--- a/features/crypto/lib/passkeyFlow.test.ts
+++ b/features/crypto/lib/passkeyFlow.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi, MockedFunction } from 'vitest';
-import { generateDek, derivePrfKek, wrapDek, toBase64 } from './clientCrypto';
+import { generateDek, derivePrfKek, wrapDek } from './clientCrypto';
 import { getMaterial } from './cryptoMaterial';
 import {
   buildPasskeyWrap,
   unlockWithPasskey,
+  unlockWithPrfOutput,
+  tryUnlockFromWebAuthn,
   registerPasskey,
   enrollPasskeyForUnlock,
 } from './passkeyFlow';
@@ -27,16 +29,15 @@ describe('buildPasskeyWrap', () => {
     const prf = new Uint8Array(32).fill(3);
     (
       assertPrfForCredential as MockedFunction<typeof assertPrfForCredential>
-    ).mockResolvedValue({
-      credentialId: 'cred-A',
-      prfOutput: prf,
-    });
+    ).mockResolvedValue({ credentialId: 'cred-A', prfOutput: prf });
     const dek = generateDek();
     const out = await buildPasskeyWrap(dek, 'cred-A', 'Laptop');
-    expect(out.credentialId).toBe('cred-A');
-    expect(out.label).toBe('Laptop');
-    expect(out.prfSalt.length).toBeGreaterThan(0);
-    expect(out.wrap.length).toBeGreaterThan(0);
+    expect(out).toEqual({
+      credentialId: 'cred-A',
+      label: 'Laptop',
+      wrap: expect.any(String),
+    });
+    expect(assertPrfForCredential).toHaveBeenCalledWith('cred-A');
   });
 });
 
@@ -52,16 +53,8 @@ describe('unlockWithPasskey', () => {
       wrapPassphrase: 'pp',
       wrapRecovery: 'rec',
       passkeys: [
-        {
-          credentialId: 'cred-A',
-          prfSalt: toBase64(new Uint8Array(32).fill(1)),
-          wrap: 'x',
-        },
-        {
-          credentialId: 'cred-B',
-          prfSalt: toBase64(new Uint8Array(32).fill(2)),
-          wrap,
-        },
+        { credentialId: 'cred-A', wrap: 'x' },
+        { credentialId: 'cred-B', wrap },
       ],
     });
     (assertPrfAny as MockedFunction<typeof assertPrfAny>).mockResolvedValue({
@@ -86,6 +79,85 @@ describe('unlockWithPasskey', () => {
       passkeys: [],
     });
     await expect(unlockWithPasskey()).rejects.toThrow(/no passkey/i);
+  });
+});
+
+describe('unlockWithPrfOutput', () => {
+  it('unwraps the matching wrap and posts the DEK', async () => {
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [{ credentialId: 'cred-B', wrap }],
+    });
+    await unlockWithPrfOutput('cred-B', prf);
+    const posted = (postDek as MockedFunction<typeof postDek>).mock
+      .calls[0][0] as Uint8Array;
+    expect(Array.from(posted)).toEqual(Array.from(dek));
+  });
+
+  it('throws when the credential has no enrolled wrap', async () => {
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [],
+    });
+    await expect(
+      unlockWithPrfOutput('cred-X', new Uint8Array(32))
+    ).rejects.toThrow(/not enrolled/i);
+  });
+});
+
+describe('tryUnlockFromWebAuthn', () => {
+  it('unlocks when PRF output is present', async () => {
+    const prf = new Uint8Array(32).fill(5);
+    const dek = generateDek();
+    const wrap = await wrapDek(dek, await derivePrfKek(prf));
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [{ credentialId: 'cred-B', wrap }],
+    });
+    await tryUnlockFromWebAuthn({
+      response: { id: 'cred-B' },
+      clientExtensionResults: { prf: { results: { first: prf.buffer } } },
+    });
+    expect(postDek).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops when PRF output is absent', async () => {
+    await tryUnlockFromWebAuthn({
+      response: { id: 'cred-B' },
+      clientExtensionResults: {},
+    });
+    expect(postDek).not.toHaveBeenCalled();
+  });
+
+  it('swallows unlock errors (not enrolled) without throwing', async () => {
+    (getMaterial as MockedFunction<typeof getMaterial>).mockResolvedValue({
+      passSalt: 'salt',
+      argonParams: { m: 19, t: 2, p: 1 },
+      wrapPassphrase: 'pp',
+      wrapRecovery: 'rec',
+      passkeys: [],
+    });
+    await expect(
+      tryUnlockFromWebAuthn({
+        response: { id: 'cred-Z' },
+        clientExtensionResults: {
+          prf: { results: { first: new Uint8Array(32).buffer } },
+        },
+      })
+    ).resolves.toBeUndefined();
+    expect(postDek).not.toHaveBeenCalled();
   });
 });
 

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -1,4 +1,4 @@
-import { derivePrfKek, toBase64, unwrapDek, wrapDek } from './clientCrypto';
+import { derivePrfKek, unwrapDek, wrapDek } from './clientCrypto';
 import { getMaterial } from './cryptoMaterial';
 import { postDek } from './unlockFlow';
 import { assertPrfAny, assertPrfForCredential } from './webauthn';
@@ -7,7 +7,6 @@ import { authClient } from '@/lib/auth-client';
 
 export type EnablePasskeyInput = {
   credentialId: string;
-  prfSalt: string;
   wrap: string;
   label: string;
 };
@@ -36,19 +35,18 @@ export const fetchUserPasskeys = async (): Promise<AuthPasskey[] | null> => {
 
 /**
  * Build the wrap for a passkey. The caller must already hold the DEK (obtained
- * via obtainDek with a passphrase/recovery authorizer). Generates a fresh PRF
- * salt, asserts the passkey to read its PRF output, and wraps the DEK with the
- * derived KEK. The result is POSTed to enablePasskeyUnlockAction.
+ * via obtainDek with a passphrase/recovery authorizer). Asserts the passkey to
+ * read its PRF output using the fixed salt, then wraps the DEK with the derived
+ * KEK. The result is POSTed to enablePasskeyUnlockAction.
  */
 export const buildPasskeyWrap = async (
   dek: Uint8Array,
   credentialId: string,
   label: string
 ): Promise<EnablePasskeyInput> => {
-  const salt = crypto.getRandomValues(new Uint8Array(32));
-  const { prfOutput } = await assertPrfForCredential(credentialId, salt);
+  const { prfOutput } = await assertPrfForCredential(credentialId);
   const wrap = await wrapDek(dek, await derivePrfKek(prfOutput));
-  return { credentialId, prfSalt: toBase64(salt), wrap, label };
+  return { credentialId, wrap, label };
 };
 
 /**
@@ -88,16 +86,16 @@ export const enrollPasskeyForUnlock = async (
   if (!res.ok) throw new Error(res.message);
 };
 
-/** Unlock the session using any enrolled passkey. */
-export const unlockWithPasskey = async (): Promise<void> => {
+/**
+ * Unwrap the DEK using a PRF output already obtained from a ceremony and post it
+ * to the session. Shared by the standalone unlock and the single-tap login path.
+ * Throws if the responding credential has no enrolled wrap.
+ */
+export const unlockWithPrfOutput = async (
+  credentialId: string,
+  prfOutput: Uint8Array
+): Promise<void> => {
   const m = await getMaterial();
-  if (!m.passkeys.length) throw new Error('No passkey is set up for unlock.');
-  const { credentialId, prfOutput } = await assertPrfAny(
-    m.passkeys.map((p) => ({
-      credentialId: p.credentialId,
-      prfSalt: p.prfSalt,
-    }))
-  );
   const match = m.passkeys.find((p) => p.credentialId === credentialId);
   if (!match) throw new Error('Passkey is not enrolled for unlock.');
   const dek = await unwrapDek(match.wrap, await derivePrfKek(prfOutput)).catch(
@@ -106,4 +104,39 @@ export const unlockWithPasskey = async (): Promise<void> => {
     }
   );
   await postDek(dek);
+};
+
+/** Shape of better-auth's returned WebAuthn assertion (the bits we read). */
+export type WebAuthnResult = {
+  response: { id: string };
+  clientExtensionResults: { prf?: { results?: { first?: BufferSource } } };
+};
+
+/**
+ * Best-effort unlock from a login ceremony's PRF output. No-ops when PRF is
+ * absent (device unsupported / passkey not registered with PRF) and swallows
+ * unlock failures (passkey not enrolled for unlock, no encryption set up) so the
+ * caller can proceed to the normal passphrase unlock. Never throws.
+ */
+export const tryUnlockFromWebAuthn = async (
+  webauthn: WebAuthnResult | undefined
+): Promise<void> => {
+  const first = webauthn?.clientExtensionResults?.prf?.results?.first;
+  const credentialId = webauthn?.response?.id;
+  if (!first || !credentialId) return;
+  try {
+    await unlockWithPrfOutput(credentialId, new Uint8Array(first as ArrayBuffer));
+  } catch {
+    // Not enrolled for unlock / no encryption — fall through to passphrase unlock.
+  }
+};
+
+/** Unlock the session using any enrolled passkey (standalone unlock screen). */
+export const unlockWithPasskey = async (): Promise<void> => {
+  const m = await getMaterial();
+  if (!m.passkeys.length) throw new Error('No passkey is set up for unlock.');
+  const { credentialId, prfOutput } = await assertPrfAny(
+    m.passkeys.map((p) => p.credentialId)
+  );
+  await unlockWithPrfOutput(credentialId, prfOutput);
 };

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -1,4 +1,4 @@
-import { derivePrfKek, unwrapDek, wrapDek } from './clientCrypto';
+import { derivePrfKek, prfSalt, unwrapDek, wrapDek } from './clientCrypto';
 import { getMaterial } from './cryptoMaterial';
 import { postDek } from './unlockFlow';
 import { assertPrfAny, assertPrfForCredential } from './webauthn';
@@ -132,6 +132,33 @@ export const tryUnlockFromWebAuthn = async (
   } catch {
     // Not enrolled for unlock / no encryption — fall through to passphrase unlock.
   }
+};
+
+/**
+ * Drive the passkey login ceremony and the best-effort single-tap unlock from
+ * one assertion. Requests PRF with the fixed salt, surfaces any better-auth
+ * error to the caller (so the AuthForm can show it and skip the redirect), and
+ * otherwise attempts to unlock the journal from the ceremony's PRF output before
+ * the caller redirects. Unlock is best-effort and never blocks login: when PRF
+ * or an enrolled wrap is unavailable, the user falls through to passphrase
+ * unlock. Returns the better-auth result so callers can inspect `error`.
+ */
+export const signInWithPasskey = async (): Promise<{
+  error: { message?: string | null } | null | undefined;
+}> => {
+  const res = await authClient.signIn.passkey({
+    extensions: {
+      prf: { eval: { first: prfSalt() as unknown as BufferSource } },
+    },
+    returnWebAuthnResponse: true,
+  } as Parameters<typeof authClient.signIn.passkey>[0]);
+  if (res?.error) return { error: res.error };
+  let webauthn: WebAuthnResult | undefined;
+  if (res && 'webauthn' in res && res.webauthn) {
+    webauthn = res.webauthn as unknown as WebAuthnResult;
+  }
+  await tryUnlockFromWebAuthn(webauthn);
+  return { error: null };
 };
 
 /** Unlock the session using any enrolled passkey (standalone unlock screen). */

--- a/features/crypto/lib/passkeyFlow.ts
+++ b/features/crypto/lib/passkeyFlow.ts
@@ -125,7 +125,10 @@ export const tryUnlockFromWebAuthn = async (
   const credentialId = webauthn?.response?.id;
   if (!first || !credentialId) return;
   try {
-    await unlockWithPrfOutput(credentialId, new Uint8Array(first as ArrayBuffer));
+    await unlockWithPrfOutput(
+      credentialId,
+      new Uint8Array(first as ArrayBuffer)
+    );
   } catch {
     // Not enrolled for unlock / no encryption — fall through to passphrase unlock.
   }

--- a/features/crypto/lib/webauthn.test.ts
+++ b/features/crypto/lib/webauthn.test.ts
@@ -4,6 +4,7 @@ import {
   assertPrfForCredential,
   assertPrfAny,
 } from './webauthn';
+import { PRF_SALT } from './clientCrypto';
 
 // Minimal fake of a PublicKeyCredential carrying a PRF result.
 const fakeCred = (id: string, first: ArrayBuffer | undefined) => ({
@@ -29,26 +30,32 @@ describe('base64urlToBytes', () => {
 });
 
 describe('assertPrfForCredential', () => {
-  it('returns the PRF output for the credential', async () => {
+  it('returns the PRF output and sends the fixed salt', async () => {
     const out = new Uint8Array(32).fill(7).buffer;
-    stubGet(() => fakeCred('cred-A', out));
-    const res = await assertPrfForCredential('cred-A', new Uint8Array(32));
+    let opts: CredentialRequestOptions | undefined;
+    stubGet((o) => {
+      opts = o;
+      return fakeCred('cred-A', out);
+    });
+    const res = await assertPrfForCredential('cred-A');
     expect(res.credentialId).toBe('cred-A');
     expect(res.prfOutput).toHaveLength(32);
+    const first = new Uint8Array(
+      opts!.publicKey!.extensions!.prf!.eval!.first as ArrayBuffer
+    );
+    expect(Array.from(first)).toEqual(Array.from(PRF_SALT));
   });
 
   it('throws a clear error when PRF is unsupported', async () => {
     stubGet(() => fakeCred('cred-A', undefined));
-    await expect(
-      assertPrfForCredential('cred-A', new Uint8Array(32))
-    ).rejects.toThrow(/does not support/i);
+    await expect(assertPrfForCredential('cred-A')).rejects.toThrow(
+      /does not support/i
+    );
   });
 
   it('throws when the prompt is dismissed (null credential)', async () => {
     stubGet(() => null);
-    await expect(
-      assertPrfForCredential('cred-A', new Uint8Array(32))
-    ).rejects.toThrow(/dismissed/i);
+    await expect(assertPrfForCredential('cred-A')).rejects.toThrow(/dismissed/i);
   });
 });
 
@@ -56,10 +63,7 @@ describe('assertPrfAny', () => {
   it('identifies which credential answered and returns its PRF output', async () => {
     const out = new Uint8Array(32).fill(9).buffer;
     stubGet(() => fakeCred('cred-B', out));
-    const res = await assertPrfAny([
-      { credentialId: 'cred-A', prfSalt: 'c2FsdEE=' },
-      { credentialId: 'cred-B', prfSalt: 'c2FsdEI=' },
-    ]);
+    const res = await assertPrfAny(['cred-A', 'cred-B']);
     expect(res.credentialId).toBe('cred-B');
     expect(res.prfOutput).toHaveLength(32);
   });

--- a/features/crypto/lib/webauthn.test.ts
+++ b/features/crypto/lib/webauthn.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PRF_SALT } from './clientCrypto';
 import {
   base64urlToBytes,
   assertPrfForCredential,
   assertPrfAny,
 } from './webauthn';
-import { PRF_SALT } from './clientCrypto';
 
 // Minimal fake of a PublicKeyCredential carrying a PRF result.
 const fakeCred = (id: string, first: ArrayBuffer | undefined) => ({
@@ -55,7 +55,9 @@ describe('assertPrfForCredential', () => {
 
   it('throws when the prompt is dismissed (null credential)', async () => {
     stubGet(() => null);
-    await expect(assertPrfForCredential('cred-A')).rejects.toThrow(/dismissed/i);
+    await expect(assertPrfForCredential('cred-A')).rejects.toThrow(
+      /dismissed/i
+    );
   });
 });
 

--- a/features/crypto/lib/webauthn.test.ts
+++ b/features/crypto/lib/webauthn.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { PRF_SALT } from './clientCrypto';
+import { prfSalt } from './clientCrypto';
 import {
   base64urlToBytes,
   assertPrfForCredential,
@@ -43,7 +43,7 @@ describe('assertPrfForCredential', () => {
     const first = new Uint8Array(
       opts!.publicKey!.extensions!.prf!.eval!.first as ArrayBuffer
     );
-    expect(Array.from(first)).toEqual(Array.from(PRF_SALT));
+    expect(Array.from(first)).toEqual(Array.from(prfSalt()));
   });
 
   it('throws a clear error when PRF is unsupported', async () => {

--- a/features/crypto/lib/webauthn.ts
+++ b/features/crypto/lib/webauthn.ts
@@ -1,4 +1,4 @@
-import { PRF_SALT } from './clientCrypto';
+import { prfSalt } from './clientCrypto';
 
 export const base64urlToBytes = (s: string): Uint8Array<ArrayBuffer> => {
   const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
@@ -17,7 +17,7 @@ const readPrf = (cred: PublicKeyCredential): Uint8Array => {
 };
 
 const prfExtensions = () => ({
-  prf: { eval: { first: PRF_SALT as unknown as BufferSource } },
+  prf: { eval: { first: prfSalt() as unknown as BufferSource } },
 });
 
 /** Single-credential PRF assertion — used when enabling a specific passkey. */

--- a/features/crypto/lib/webauthn.ts
+++ b/features/crypto/lib/webauthn.ts
@@ -1,4 +1,4 @@
-import { fromBase64 } from './clientCrypto';
+import { PRF_SALT } from './clientCrypto';
 
 export const base64urlToBytes = (s: string): Uint8Array<ArrayBuffer> => {
   const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
@@ -16,10 +16,13 @@ const readPrf = (cred: PublicKeyCredential): Uint8Array => {
   return new Uint8Array(first as ArrayBuffer);
 };
 
+const prfExtensions = () => ({
+  prf: { eval: { first: PRF_SALT as unknown as BufferSource } },
+});
+
 /** Single-credential PRF assertion — used when enabling a specific passkey. */
 export const assertPrfForCredential = async (
-  credentialId: string,
-  salt: Uint8Array
+  credentialId: string
 ): Promise<PrfAssertion> => {
   const cred = (await navigator.credentials.get({
     publicKey: {
@@ -28,32 +31,26 @@ export const assertPrfForCredential = async (
         { id: base64urlToBytes(credentialId), type: 'public-key' },
       ],
       userVerification: 'required',
-      extensions: { prf: { eval: { first: salt as unknown as BufferSource } } },
+      extensions: prfExtensions(),
     },
   })) as PublicKeyCredential | null;
   if (!cred) throw new Error('Passkey prompt was dismissed.');
   return { credentialId, prfOutput: readPrf(cred) };
 };
 
-/** Multi-credential PRF assertion — used at unlock; the user picks any enrolled passkey. */
+/** Multi-credential PRF assertion — used by the standalone unlock screen. */
 export const assertPrfAny = async (
-  creds: { credentialId: string; prfSalt: string }[]
+  credentialIds: string[]
 ): Promise<PrfAssertion> => {
-  const evalByCredential: Record<string, { first: BufferSource }> = {};
-  for (const c of creds) {
-    evalByCredential[c.credentialId] = {
-      first: fromBase64(c.prfSalt) as unknown as BufferSource,
-    };
-  }
   const cred = (await navigator.credentials.get({
     publicKey: {
       challenge: crypto.getRandomValues(new Uint8Array(32)),
-      allowCredentials: creds.map((c) => ({
-        id: base64urlToBytes(c.credentialId),
+      allowCredentials: credentialIds.map((id) => ({
+        id: base64urlToBytes(id),
         type: 'public-key' as const,
       })),
       userVerification: 'required',
-      extensions: { prf: { evalByCredential } },
+      extensions: prfExtensions(),
     },
   })) as PublicKeyCredential | null;
   if (!cred) throw new Error('Passkey prompt was dismissed.');

--- a/lib/crypto/passkeyWrapRepository.test.ts
+++ b/lib/crypto/passkeyWrapRepository.test.ts
@@ -26,7 +26,6 @@ describe('PasskeyWrapRepository', () => {
     id: 'wrap-1',
     userId: 'alice',
     credentialId: 'cred-A',
-    prfSalt: 'c2FsdA==',
     wrap: 'd3JhcA==',
     label: 'Laptop',
     ...over,
@@ -58,13 +57,11 @@ describe('PasskeyWrapRepository', () => {
         id: 'wrap-2',
         credentialId: 'cred-A',
         wrap: 'new==',
-        prfSalt: 's2==',
       })
     );
     const all = await repo.listByUser('alice');
     expect(all).toHaveLength(1);
     expect(all[0].wrap).toBe('new==');
-    expect(all[0].prfSalt).toBe('s2==');
   });
 
   it('deleteByCredential removes only the matching row', async () => {

--- a/lib/crypto/passkeyWrapRepository.ts
+++ b/lib/crypto/passkeyWrapRepository.ts
@@ -23,7 +23,7 @@ export class PasskeyWrapRepository {
       .values(input)
       .onConflictDoUpdate({
         target: [cryptoPasskeyWrap.userId, cryptoPasskeyWrap.credentialId],
-        set: { prfSalt: input.prfSalt, wrap: input.wrap, label: input.label },
+        set: { wrap: input.wrap, label: input.label },
       });
   }
 

--- a/lib/crypto/passkeyWrapSchema.ts
+++ b/lib/crypto/passkeyWrapSchema.ts
@@ -19,7 +19,6 @@ const b64url = z
 
 export const enablePasskeyUnlockSchema = z.object({
   credentialId: b64url,
-  prfSalt: b64,
   wrap: b64,
   label: z.string().min(1).max(100),
 });

--- a/lib/crypto/setupSchema.ts
+++ b/lib/crypto/setupSchema.ts
@@ -24,7 +24,6 @@ export type SetupCryptoInput = z.infer<typeof setupCryptoSchema>;
 
 export type PasskeyMaterial = {
   credentialId: string;
-  prfSalt: string;
   wrap: string;
 };
 


### PR DESCRIPTION
## Summary

A passkey user previously tapped their authenticator twice — once to sign in, once to unlock the encrypted journal — because login (a WebAuthn signature) and decryption (a WebAuthn PRF output) were obtained in two separate ceremonies. This collapses them into a single tap.

The login ceremony now requests the PRF extension and feeds its output into the existing `derivePrfKek → unwrapDek → postDek` pipeline before redirecting, so an enrolled user lands on the dashboard already unlocked.

## How

- **Fixed PRF salt.** The per-passkey random `prfSalt` required a post-auth server round-trip, which made a single ceremony impossible (the salt must be known *before* the assertion). It's replaced by a fixed versioned constant `PRF_SALT = "ledger-prf-v1"`. This is safe: the PRF output's entropy comes from the authenticator's hardware secret bound to the rpId — the salt is a non-secret application label, and domain separation is already handled by HKDF's `info`.
- **Dropped `prfSalt`** from the schema, types, repository, enroll action, and `/api/crypto/material` response. Migration `0010` wipes stale wraps (made with random salts, now undecryptable) before dropping the column.
- **Single-tap wiring** in `AuthForm.onPasskey`: `signIn.passkey({ extensions: { prf: { eval: { first: PRF_SALT } } }, returnWebAuthnResponse: true })`, then a best-effort `tryUnlockFromWebAuthn` that **never blocks login** — if PRF is absent (unsupported device) or the passkey isn't enrolled for unlock, the user still lands logged in and falls back to the passphrase unlock screen.

## Properties preserved

- **Zero-knowledge:** the server still stores and returns only opaque blobs; the DEK and PRF output never newly cross the wire.
- **Modal prompt** (not conditional-UI autofill), since PRF return is unreliable under conditional mediation.
- Passphrase, recovery-code, and standalone-passkey unlock paths unchanged.

## Notes

- No real users exist on the server yet, so existing wraps are simply wiped rather than migrated; users re-enroll passkey unlock.
- Confirmed `@better-auth/passkey` 1.6.10 forwards `extensions` and returns `clientExtensionResults` — no library fork needed.

## Testing

- `pnpm type-check`, `pnpm lint` clean; `pnpm vitest run` → 633/633 across 125 files.
- New unit tests assert the fixed salt is sent, the correct wrap is selected, unlock no-ops when PRF is absent, and errors are swallowed without blocking login.

Spec: `docs/superpowers/specs/2026-06-28-passkey-single-tap-unlock-design.md`
Plan: `docs/superpowers/plans/2026-06-28-passkey-single-tap-unlock.md`
