### PR TITLE
fix(combobox): modal dialog on mobile so free-text entry survives

### DIFF
--- a/components/Combobox/Combobox.tsx
+++ b/components/Combobox/Combobox.tsx
@@ -12,10 +12,18 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -37,6 +45,7 @@ const Combobox = ({
   allowFreeText = true,
   triggerClassName,
 }: Props) => {
+  const isMobile = useIsMobile();
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
 
@@ -53,51 +62,77 @@ const Combobox = ({
   const trimmed = search.trim();
   const hasExactMatch = options.some((o) => o === trimmed);
 
+  const trigger = (
+    <Button
+      type="button"
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      className={cn(
+        'w-full justify-between font-normal',
+        !value && 'text-muted-foreground',
+        triggerClassName
+      )}
+    >
+      <span className="truncate">{value || placeholder}</span>
+      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+    </Button>
+  );
+
+  const list = (
+    <Command>
+      <CommandInput
+        placeholder={placeholder}
+        value={search}
+        onValueChange={setSearch}
+      />
+      <CommandList>
+        <CommandEmpty>{emptyMessage}</CommandEmpty>
+        {allowFreeText && trimmed && !hasExactMatch && (
+          <CommandGroup>
+            <CommandItem value={trimmed} onSelect={() => commit(trimmed)}>
+              Use &quot;{trimmed}&quot;
+            </CommandItem>
+          </CommandGroup>
+        )}
+        <CommandGroup>
+          {options.map((opt) => (
+            <CommandItem key={opt} value={opt} onSelect={commit}>
+              {opt}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+
+  // On touch screens a floating popover is fragile: the soft keyboard reflows
+  // the layout and Base UI's hardcoded "sloppy" touch dismissal closes the
+  // popup mid-tap, discarding the search. A modal dialog keeps the input and
+  // list anchored so the create-new affordance stays reachable.
+  if (isMobile) {
+    return (
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogTrigger render={trigger} />
+        <DialogContent
+          showCloseButton={false}
+          className="top-1/4 translate-y-0 gap-0 overflow-hidden p-0"
+        >
+          <DialogTitle className="sr-only">{placeholder}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {placeholder}
+          </DialogDescription>
+          {list}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger
-        render={
-          <Button
-            type="button"
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            className={cn(
-              'w-full justify-between font-normal',
-              !value && 'text-muted-foreground',
-              triggerClassName
-            )}
-          >
-            <span className="truncate">{value || placeholder}</span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </Button>
-        }
-      />
+      <PopoverTrigger render={trigger} />
       <PopoverContent className="w-(--anchor-width) min-w-56 p-0" align="start">
-        <Command>
-          <CommandInput
-            placeholder={placeholder}
-            value={search}
-            onValueChange={setSearch}
-          />
-          <CommandList>
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-            {allowFreeText && trimmed && !hasExactMatch && (
-              <CommandGroup>
-                <CommandItem value={trimmed} onSelect={() => commit(trimmed)}>
-                  Use &quot;{trimmed}&quot;
-                </CommandItem>
-              </CommandGroup>
-            )}
-            <CommandGroup>
-              {options.map((opt) => (
-                <CommandItem key={opt} value={opt} onSelect={commit}>
-                  {opt}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        {list}
       </PopoverContent>
     </Popover>
   );

--- a/components/Combobox/Combobox.tsx
+++ b/components/Combobox/Combobox.tsx
@@ -5,19 +5,13 @@ import * as React from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Command,
+  CommandDialog,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
 import {
   Popover,
   PopoverContent,
@@ -80,7 +74,7 @@ const Combobox = ({
   );
 
   const list = (
-    <Command>
+    <>
       <CommandInput
         placeholder={placeholder}
         value={search}
@@ -103,28 +97,28 @@ const Combobox = ({
           ))}
         </CommandGroup>
       </CommandList>
-    </Command>
+    </>
   );
 
   // On touch screens a floating popover is fragile: the soft keyboard reflows
   // the layout and Base UI's hardcoded "sloppy" touch dismissal closes the
   // popup mid-tap, discarding the search. A modal dialog keeps the input and
-  // list anchored so the create-new affordance stays reachable.
+  // list anchored so the create-new affordance stays reachable. CommandDialog
+  // supplies its own Command wrapper plus sr-only title/description, so the
+  // trigger stays a sibling driven by the existing open state.
   if (isMobile) {
     return (
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogTrigger render={trigger} />
-        <DialogContent
-          showCloseButton={false}
-          className="top-1/4 translate-y-0 gap-0 overflow-hidden p-0"
+      <>
+        {React.cloneElement(trigger, { onClick: () => setOpen(true) })}
+        <CommandDialog
+          open={open}
+          onOpenChange={handleOpenChange}
+          title={placeholder}
+          description="Search the list or type a new value"
         >
-          <DialogTitle className="sr-only">{placeholder}</DialogTitle>
-          <DialogDescription className="sr-only">
-            {placeholder}
-          </DialogDescription>
           {list}
-        </DialogContent>
-      </Dialog>
+        </CommandDialog>
+      </>
     );
   }
 
@@ -132,7 +126,7 @@ const Combobox = ({
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger render={trigger} />
       <PopoverContent className="w-(--anchor-width) min-w-56 p-0" align="start">
-        {list}
+        <Command>{list}</Command>
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
## Problem

On mobile, creating a new account/payee from the add-transaction autocomplete was impossible: after typing, scrolling/tapping toward the **Use "…"** option closed the dropdown and discarded the typed text — so a transaction with a brand-new item couldn't be added.

## Root cause

Two compounding causes:

1. **Base UI's `Popover` hardcodes touch dismissal to `'sloppy'`** (`@base-ui/react` `PopoverRoot.js`), with no public prop to tune it. A touch-drag, or the synthetic tap that lands "outside" once the **soft keyboard reflows the layout**, fires an `outsidePress` close before the tap registers as a selection.
2. **Every close wiped the search** — `handleOpenChange(false)` always ran `setSearch('')`, so any stray dismissal also threw away the typed text.

## Fix

Render the search-and-list inside a **modal `Dialog` on touch/small screens** (`useIsMobile()`, 768px breakpoint) while keeping the **`Popover` unchanged on desktop**. The trigger button and `Command` list are shared between both branches, so commit / free-text / filtering behaviour is identical — only the wrapper differs.

A modal dialog has a backdrop and an anchored, large list as the tap target, so keyboard reflow can't move content out from under the finger and touches inside never count as "outside." The **Use "…"** create option stays reachable and tappable.

This applies everywhere `Combobox` is used (add-transaction accounts/payees, filters, templates, prices, base-currency picker).

## Verification

- `pnpm type-check` — clean
- `eslint` — clean
- Component test suite (8 files / 27 tests) — green

No unit test added: the branch is gated on `matchMedia` + open state, and the component test harness runs in a `node`/SSR-string environment with no `matchMedia`, jsdom, or touch, so it cannot exercise the mobile path. Needs on-device / mobile-emulation verification.