### PR TITLE
fix(amounts): consistent comma thousands separators

### DIFF
--- a/features/transactions/AmountInput.test.ts
+++ b/features/transactions/AmountInput.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  cleanAmountInput,
+  groupAmountInput,
+  caretAfterFormat,
+} from './AmountInput';
+
+describe('cleanAmountInput', () => {
+  it('strips comma separators back to a raw number string', () => {
+    expect(cleanAmountInput('1,234,567.89')).toBe('1234567.89');
+  });
+
+  it('keeps a single leading minus and drops minus elsewhere', () => {
+    expect(cleanAmountInput('-1,234')).toBe('-1234');
+    expect(cleanAmountInput('1-2-3')).toBe('123');
+  });
+
+  it('collapses multiple dots to the first one', () => {
+    expect(cleanAmountInput('1.2.3')).toBe('1.23');
+  });
+
+  it('drops any other non-numeric characters', () => {
+    expect(cleanAmountInput('$1 234abc.5')).toBe('1234.5');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(cleanAmountInput('')).toBe('');
+  });
+});
+
+describe('groupAmountInput', () => {
+  it('groups the integer part with comma thousands separators', () => {
+    expect(groupAmountInput('1997.5')).toBe('1,997.5');
+    expect(groupAmountInput('20000.0')).toBe('20,000.0');
+    expect(groupAmountInput('1234567')).toBe('1,234,567');
+  });
+
+  it('preserves a negative sign', () => {
+    expect(groupAmountInput('-1234567.89')).toBe('-1,234,567.89');
+  });
+
+  it('preserves a trailing dot so decimals can still be typed', () => {
+    expect(groupAmountInput('1234.')).toBe('1,234.');
+  });
+
+  it('preserves a leading dot', () => {
+    expect(groupAmountInput('.5')).toBe('.5');
+  });
+
+  it('does not group amounts below one thousand', () => {
+    expect(groupAmountInput('42')).toBe('42');
+  });
+
+  it('is robust to already-grouped input', () => {
+    expect(groupAmountInput('1,234')).toBe('1,234');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(groupAmountInput('')).toBe('');
+  });
+});
+
+describe('caretAfterFormat', () => {
+  it('places the caret after the same number of significant chars', () => {
+    // caret after "12" of raw "1234" → after "2" in "1,234" (index 3)
+    expect(caretAfterFormat('1,234', 2)).toBe(3);
+  });
+
+  it('returns the start when no significant chars precede the caret', () => {
+    expect(caretAfterFormat('1,234', 0)).toBe(0);
+  });
+
+  it('returns the end when all significant chars precede the caret', () => {
+    expect(caretAfterFormat('1,234', 4)).toBe(5);
+  });
+
+  it('counts the minus sign as significant', () => {
+    // caret after "-1" of "-1234" → after "1" in "-1,234" (index 2)
+    expect(caretAfterFormat('-1,234', 2)).toBe(2);
+  });
+});

--- a/features/transactions/AmountInput.tsx
+++ b/features/transactions/AmountInput.tsx
@@ -1,65 +1,13 @@
 'use client';
 
 import * as React from 'react';
+import {
+  caretAfterFormat,
+  cleanAmountInput,
+  countSignificant,
+  groupAmountInput,
+} from './AmountInput.util';
 import { Input } from '@/components/ui/input';
-
-// Strips a free-text amount field back to a raw, parseable number string:
-// a single optional leading minus, the digits, and at most one decimal point.
-// This is the value that gets stored and submitted, so it must never contain
-// the grouping commas the user sees while typing.
-export const cleanAmountInput = (input: string): string => {
-  const digitsAndDots = input.replace(/[^0-9.]/g, '');
-  const firstDot = digitsAndDots.indexOf('.');
-  const single =
-    firstDot === -1
-      ? digitsAndDots
-      : digitsAndDots.slice(0, firstDot + 1) +
-        digitsAndDots.slice(firstDot + 1).replace(/\./g, '');
-  // A minus is only meaningful at the very start of the field.
-  const negative = input.trimStart().startsWith('-');
-  return (negative ? '-' : '') + single;
-};
-
-// Renders a raw number string with comma thousands separators for display in
-// the input. Preserves a trailing dot and the exact decimals the user typed so
-// editing stays lossless; tolerates already-grouped input defensively.
-export const groupAmountInput = (raw: string): string => {
-  const clean = cleanAmountInput(raw);
-  if (clean === '') return '';
-  const negative = clean.startsWith('-');
-  const body = negative ? clean.slice(1) : clean;
-  const dot = body.indexOf('.');
-  const intPart = dot === -1 ? body : body.slice(0, dot);
-  const decPart = dot === -1 ? undefined : body.slice(dot + 1);
-  const groupedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  const out = decPart === undefined ? groupedInt : `${groupedInt}.${decPart}`;
-  return (negative ? '-' : '') + out;
-};
-
-// Maps a caret position expressed as "after N significant characters" onto the
-// grouped string, where commas are the only non-significant characters. Keeps
-// the caret anchored to the digit the user was editing across reformatting.
-export const caretAfterFormat = (
-  formatted: string,
-  significantBefore: number
-): number => {
-  let seen = 0;
-  for (let i = 0; i < formatted.length; i++) {
-    if (seen >= significantBefore) return i;
-    if (formatted[i] !== ',') seen++;
-  }
-  return formatted.length;
-};
-
-const SIGNIFICANT = /[0-9.-]/;
-
-const countSignificant = (value: string, end: number): number => {
-  let n = 0;
-  for (let i = 0; i < end && i < value.length; i++) {
-    if (SIGNIFICANT.test(value[i])) n++;
-  }
-  return n;
-};
 
 type AmountInputProps = Omit<
   React.ComponentProps<typeof Input>,

--- a/features/transactions/AmountInput.tsx
+++ b/features/transactions/AmountInput.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import * as React from 'react';
+import { Input } from '@/components/ui/input';
+
+// Strips a free-text amount field back to a raw, parseable number string:
+// a single optional leading minus, the digits, and at most one decimal point.
+// This is the value that gets stored and submitted, so it must never contain
+// the grouping commas the user sees while typing.
+export const cleanAmountInput = (input: string): string => {
+  const digitsAndDots = input.replace(/[^0-9.]/g, '');
+  const firstDot = digitsAndDots.indexOf('.');
+  const single =
+    firstDot === -1
+      ? digitsAndDots
+      : digitsAndDots.slice(0, firstDot + 1) +
+        digitsAndDots.slice(firstDot + 1).replace(/\./g, '');
+  // A minus is only meaningful at the very start of the field.
+  const negative = input.trimStart().startsWith('-');
+  return (negative ? '-' : '') + single;
+};
+
+// Renders a raw number string with comma thousands separators for display in
+// the input. Preserves a trailing dot and the exact decimals the user typed so
+// editing stays lossless; tolerates already-grouped input defensively.
+export const groupAmountInput = (raw: string): string => {
+  const clean = cleanAmountInput(raw);
+  if (clean === '') return '';
+  const negative = clean.startsWith('-');
+  const body = negative ? clean.slice(1) : clean;
+  const dot = body.indexOf('.');
+  const intPart = dot === -1 ? body : body.slice(0, dot);
+  const decPart = dot === -1 ? undefined : body.slice(dot + 1);
+  const groupedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const out = decPart === undefined ? groupedInt : `${groupedInt}.${decPart}`;
+  return (negative ? '-' : '') + out;
+};
+
+// Maps a caret position expressed as "after N significant characters" onto the
+// grouped string, where commas are the only non-significant characters. Keeps
+// the caret anchored to the digit the user was editing across reformatting.
+export const caretAfterFormat = (
+  formatted: string,
+  significantBefore: number
+): number => {
+  let seen = 0;
+  for (let i = 0; i < formatted.length; i++) {
+    if (seen >= significantBefore) return i;
+    if (formatted[i] !== ',') seen++;
+  }
+  return formatted.length;
+};
+
+const SIGNIFICANT = /[0-9.-]/;
+
+const countSignificant = (value: string, end: number): number => {
+  let n = 0;
+  for (let i = 0; i < end && i < value.length; i++) {
+    if (SIGNIFICANT.test(value[i])) n++;
+  }
+  return n;
+};
+
+type AmountInputProps = Omit<
+  React.ComponentProps<typeof Input>,
+  'value' | 'onChange' | 'type'
+> & {
+  value: string;
+  onChange: (raw: string) => void;
+};
+
+// A controlled amount field that displays comma-grouped digits while emitting
+// the raw, un-grouped string to its parent — so balance maths and submission
+// keep working unchanged. Restores the caret after each reformat so inserting a
+// digit that shifts a comma doesn't jump the cursor to the end.
+const AmountInput = ({ value, onChange, ...props }: AmountInputProps) => {
+  const ref = React.useRef<HTMLInputElement>(null);
+  const caretRef = React.useRef<number | null>(null);
+
+  React.useLayoutEffect(() => {
+    if (caretRef.current !== null && ref.current) {
+      ref.current.setSelectionRange(caretRef.current, caretRef.current);
+      caretRef.current = null;
+    }
+  });
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const typed = event.target.value;
+    const selectionStart = event.target.selectionStart ?? typed.length;
+    const significantBefore = countSignificant(typed, selectionStart);
+    const raw = cleanAmountInput(typed);
+    caretRef.current = caretAfterFormat(
+      groupAmountInput(raw),
+      significantBefore
+    );
+    onChange(raw);
+  };
+
+  return (
+    <Input
+      ref={ref}
+      type="text"
+      inputMode="decimal"
+      value={groupAmountInput(value)}
+      onChange={handleChange}
+      {...props}
+    />
+  );
+};
+
+export default AmountInput;

--- a/features/transactions/AmountInput.util.test.ts
+++ b/features/transactions/AmountInput.util.test.ts
@@ -3,7 +3,7 @@ import {
   cleanAmountInput,
   groupAmountInput,
   caretAfterFormat,
-} from './AmountInput';
+} from './AmountInput.util';
 
 describe('cleanAmountInput', () => {
   it('strips comma separators back to a raw number string', () => {

--- a/features/transactions/AmountInput.util.ts
+++ b/features/transactions/AmountInput.util.ts
@@ -1,0 +1,61 @@
+import { groupThousands } from '@/utils/formatAmount';
+
+// Strips a free-text amount field back to a raw, parseable number string:
+// a single optional leading minus, the digits, and at most one decimal point.
+// This is the value that gets stored and submitted, so it must never contain
+// the grouping commas the user sees while typing.
+export const cleanAmountInput = (input: string): string => {
+  const digitsAndDots = input.replace(/[^0-9.]/g, '');
+  const firstDot = digitsAndDots.indexOf('.');
+  const single =
+    firstDot === -1
+      ? digitsAndDots
+      : digitsAndDots.slice(0, firstDot + 1) +
+        digitsAndDots.slice(firstDot + 1).replace(/\./g, '');
+  // A minus is only meaningful at the very start of the field.
+  const negative = input.trimStart().startsWith('-');
+  return (negative ? '-' : '') + single;
+};
+
+// Renders a raw number string with comma thousands separators for display in
+// the input. Preserves a trailing dot and the exact decimals the user typed so
+// editing stays lossless; tolerates already-grouped input defensively. The
+// grouping rule itself is shared with `groupThousands` so display and input
+// never drift.
+export const groupAmountInput = (raw: string): string => {
+  const clean = cleanAmountInput(raw);
+  if (clean === '') return '';
+  const negative = clean.startsWith('-');
+  const body = negative ? clean.slice(1) : clean;
+  const dot = body.indexOf('.');
+  const intPart = dot === -1 ? body : body.slice(0, dot);
+  const decPart = dot === -1 ? undefined : body.slice(dot + 1);
+  const groupedInt = groupThousands(intPart);
+  const out = decPart === undefined ? groupedInt : `${groupedInt}.${decPart}`;
+  return (negative ? '-' : '') + out;
+};
+
+// Maps a caret position expressed as "after N significant characters" onto the
+// grouped string, where commas are the only non-significant characters. Keeps
+// the caret anchored to the digit the user was editing across reformatting.
+export const caretAfterFormat = (
+  formatted: string,
+  significantBefore: number
+): number => {
+  let seen = 0;
+  for (let i = 0; i < formatted.length; i++) {
+    if (seen >= significantBefore) return i;
+    if (formatted[i] !== ',') seen++;
+  }
+  return formatted.length;
+};
+
+const SIGNIFICANT = /[0-9.-]/;
+
+export const countSignificant = (value: string, end: number): number => {
+  let n = 0;
+  for (let i = 0; i < end && i < value.length; i++) {
+    if (SIGNIFICANT.test(value[i])) n++;
+  }
+  return n;
+};

--- a/features/transactions/TransactionForm.tsx
+++ b/features/transactions/TransactionForm.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
+import AmountInput from './AmountInput';
 import type { TransactionActionState } from './actions';
 import Combobox from '@/components/Combobox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -428,11 +429,9 @@ const PostingRow = ({
       placeholder="Account (e.g. Expenses:Food)"
     />
     <div className="flex items-center gap-2 sm:contents">
-      <Input
-        type="text"
-        inputMode="decimal"
+      <AmountInput
         value={posting.amount}
-        onChange={(e) => onChange({ amount: e.target.value })}
+        onChange={(amount) => onChange({ amount })}
         placeholder="Amount"
         className="flex-1 text-right tabular-nums sm:flex-none"
       />

--- a/utils/formatAmount.test.tsx
+++ b/utils/formatAmount.test.tsx
@@ -21,7 +21,18 @@ describe('formatAmount', () => {
   it('formats a negative unit-less amount with the negative color class and parens', () => {
     const out = html(formatAmount('-42', true));
     expect(out).toContain('text-negative');
-    expect(out).toMatch(/\(42\.000\)/);
+    expect(out).toMatch(/\(42\)/);
+  });
+
+  it('groups positive amounts with comma thousands separators', () => {
+    const out = html(formatAmount('1997.5', true));
+    expect(out).toContain('text-positive');
+    expect(out).toMatch(/1,997\.5/);
+  });
+
+  it('preserves the original decimal precision on both signs', () => {
+    expect(html(formatAmount('20000.0', true))).toMatch(/20,000\.0/);
+    expect(html(formatAmount('-20000.0', true))).toMatch(/\(20,000\.0\)/);
   });
 
   it('renders unit prefix when withUnit is true and stdout has a unit', () => {
@@ -39,6 +50,6 @@ describe('formatAmount', () => {
   it('formats a negative amount with comma thousands', () => {
     const out = html(formatAmount('USD -1234567.89', true));
     expect(out).toContain('text-negative');
-    expect(out).toMatch(/1,234,567\.890/);
+    expect(out).toMatch(/1,234,567\.89/);
   });
 });

--- a/utils/formatAmount.tsx
+++ b/utils/formatAmount.tsx
@@ -2,7 +2,7 @@
 // while preserving its original decimal places. Operates on the string (not a
 // parsed Number) so ledger's display precision — including trailing zeros — is
 // kept intact.
-const groupThousands = (absNumStr: string): string => {
+export const groupThousands = (absNumStr: string): string => {
   const [intPart, decPart] = absNumStr.split('.');
   const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   return decPart !== undefined ? `${grouped}.${decPart}` : grouped;

--- a/utils/formatAmount.tsx
+++ b/utils/formatAmount.tsx
@@ -1,19 +1,26 @@
+// Adds comma thousands separators to the integer part of a numeric string
+// while preserving its original decimal places. Operates on the string (not a
+// parsed Number) so ledger's display precision — including trailing zeros — is
+// kept intact.
+const groupThousands = (absNumStr: string): string => {
+  const [intPart, decPart] = absNumStr.split('.');
+  const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return decPart !== undefined ? `${grouped}.${decPart}` : grouped;
+};
+
 const formatAmountWithoutUnit = (str: string, unit?: string) => {
   const fixedStr = str.replaceAll(',', '');
+  const grouped = groupThousands(fixedStr.replace(/^-/, ''));
   if (Number(fixedStr) < 0) {
     return (
       <span className="font-medium text-negative tabular-nums">
-        {unit}&nbsp;(
-        {Math.abs(Number(fixedStr))
-          .toFixed(3)
-          .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-        )
+        {unit}&nbsp;({grouped})
       </span>
     );
   } else {
     return (
       <span className="font-medium text-positive tabular-nums">
-        {unit}&nbsp;{str}
+        {unit}&nbsp;{grouped}
       </span>
     );
   }


### PR DESCRIPTION
## Problem

Amount formatting was inconsistent between signs: positive amounts rendered raw with no thousands separators, while negative amounts were force-formatted to three decimals with commas — producing mismatches like `Kirt 1997.5` vs `Kirt (1,997.500)`. Amount input fields had no grouping at all, making large numbers easy to mistype.

## Changes

- **`utils/formatAmount.tsx`** — positive and negative amounts now both get comma thousands separators and both preserve ledger's original decimal precision (no more forced `.000` on negatives).
- **`features/transactions/AmountInput.tsx`** (new) — a controlled amount field for the transaction form's posting rows. It **displays** comma-grouped digits but **emits the raw, un-grouped string** to the form, so `Number(...)` balance maths and the submitted draft are untouched. The caret is restored after each reformat, so inserting a digit that shifts a comma doesn't jump the cursor to the end.

The cleaning, grouping, and caret-mapping logic is extracted into pure exported functions, covered by unit tests (the project's vitest runs in a `node` environment with no DOM).

## Testing

- `pnpm exec vitest run features/transactions utils` — 68 tests pass (16 new in `AmountInput.test.ts`, plus updated `formatAmount.test.tsx`).
- `tsc --noEmit` and eslint clean (enforced by pre-commit hooks).

> [!NOTE]
> The live DOM caret restoration (`setSelectionRange` via a ref forwarded through the base-ui `Input`) is not exercised by the node tests — the caret math is tested, but the ref plumbing isn't. Worst case if that ref didn't forward: typing still yields correct values, the caret would just jump to the end. Worth a quick manual check in the new-transaction form.