### PR TITLE
Fix server ledger version, import error reporting, and unlock prefetch storm

### DIFF
--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -27,12 +27,16 @@ export default function ImportPage() {
   const [file, setFile] = useState<File | null>(null);
   const [phase, setPhase] = useState<Phase>('idle');
   const [message, setMessage] = useState<string | null>(null);
+  // Verbatim ledger diagnostic (when the import lands but won't parse), shown in
+  // a distinct monospace block below the summary so the user can act on it.
+  const [detail, setDetail] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!file) return;
     setPhase('uploading');
     setMessage(null);
+    setDetail(null);
     try {
       const fd = new FormData();
       fd.append('file', file);
@@ -50,23 +54,27 @@ export default function ImportPage() {
           : `Imported ${(result.bytes ?? 0).toLocaleString()} bytes${tagged}. Reports refresh on next view.`;
       if (result.parseFailure) {
         // Files landed on disk but ledger can't parse them. Don't claim
-        // success — the user needs to know reports will be broken.
+        // success — the user needs to know reports will be broken — and show
+        // the actual ledger diagnostic so they can fix the offending entry.
         setPhase('error');
         setMessage(
-          `${description} Ledger rejected the resulting journal: ${result.parseFailure}`
+          `${description} Ledger could not parse the imported journal — reports will be broken until this is fixed:`
         );
+        setDetail(result.parseFailure);
         toast.error('Journal imported but not parseable', {
           description: result.parseFailure,
         });
       } else {
         setPhase('done');
         setMessage(description);
+        setDetail(null);
         toast.success('Journal imported', { description });
       }
       router.refresh();
     } catch (err) {
       setPhase('error');
       setMessage(err instanceof Error ? err.message : 'Upload failed');
+      setDetail(null);
     }
   };
 
@@ -115,7 +123,14 @@ export default function ImportPage() {
 
         {message && (
           <Alert variant={phase === 'error' ? 'destructive' : 'default'}>
-            <AlertDescription>{message}</AlertDescription>
+            <AlertDescription>
+              <span>{message}</span>
+              {detail && (
+                <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md bg-destructive/10 p-2 font-mono text-xs leading-relaxed">
+                  {detail}
+                </pre>
+              )}
+            </AlertDescription>
           </Alert>
         )}
       </form>

--- a/features/crypto/SetupWizard.tsx
+++ b/features/crypto/SetupWizard.tsx
@@ -78,6 +78,10 @@ function SetupBrandPanel() {
       {/* wordmark */}
       <Link
         href="/"
+        // Pre-unlock users get bounced /→/dashboard→/crypto/setup, so
+        // prefetching this wordmark replays that redirect chain on a loop in
+        // production. Home is one click away; skip the prefetch. (see UnlockScreen)
+        prefetch={false}
         className="au-rise relative z-10 flex items-center gap-2.5"
         style={{ ['--d' as string]: '0.05s' }}
         aria-label={`${APP_NAME} home`}
@@ -791,6 +795,7 @@ export function SetupWizard() {
           {/* compact wordmark — only visible on mobile */}
           <Link
             href="/"
+            prefetch={false}
             className="au-rise flex items-center gap-2.5 lg:invisible"
             style={{ ['--d' as string]: '0.05s' }}
             aria-label={`${APP_NAME} home`}

--- a/features/crypto/UnlockScreen.tsx
+++ b/features/crypto/UnlockScreen.tsx
@@ -41,6 +41,10 @@ function CryptoBrandPanel() {
       {/* wordmark */}
       <Link
         href="/"
+        // Locked users get bounced /→/dashboard→/crypto/unlock, so prefetching
+        // this wordmark replays that redirect chain on a loop in production
+        // (a storm of `unlock?_rsc` requests). Home is one click away; skip it.
+        prefetch={false}
         className="au-rise relative z-10 flex items-center gap-2.5"
         style={{ ['--d' as string]: '0.05s' }}
         aria-label={`${APP_NAME} home`}
@@ -312,6 +316,7 @@ export function UnlockScreen() {
           {/* compact wordmark — only visible on mobile (brand panel hidden) */}
           <Link
             href="/"
+            prefetch={false}
             className="au-rise flex items-center gap-2.5 lg:invisible"
             style={{ ['--d' as string]: '0.05s' }}
             aria-label={`${APP_NAME} home`}

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -189,7 +189,7 @@ export class JournalService {
           ok: false,
           reason: 'parse-failed',
           fieldErrors: {},
-          formError: `Ledger rejected the new transaction: ${verify.firstLine}`,
+          formError: `Ledger rejected the new transaction: ${verify.message}`,
         };
       }
       try {
@@ -275,7 +275,7 @@ export class JournalService {
       }
       return {
         uidsAdded: backfill.uidsAdded,
-        ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
+        ...(verify.ok ? {} : { parseFailure: verify.message }),
       };
     });
   }
@@ -363,7 +363,7 @@ export class JournalService {
         mainFile,
         fileCount: entries.length,
         uidsAdded: backfill.uidsAdded,
-        ...(verify.ok ? {} : { parseFailure: verify.firstLine }),
+        ...(verify.ok ? {} : { parseFailure: verify.message }),
       };
     });
   }
@@ -449,7 +449,7 @@ export class JournalService {
       return {
         ok: false,
         reason: 'parse-failed',
-        message: `Ledger rejected the edit: ${verify.firstLine}`,
+        message: `Ledger rejected the edit: ${verify.message}`,
       };
     }
     try {
@@ -532,7 +532,7 @@ export class JournalService {
       return {
         ok: false,
         reason: 'parse-failed',
-        message: `Ledger rejected the delete: ${verify.firstLine}`,
+        message: `Ledger rejected the delete: ${verify.message}`,
       };
     }
     try {

--- a/lib/journal/verify.test.ts
+++ b/lib/journal/verify.test.ts
@@ -53,7 +53,9 @@ describe('verifyJournalParseable', () => {
     const result = await verifyJournalParseable(file);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.firstLine.length).toBeGreaterThan(0);
+      // Surface ledger's actual diagnostic, not just the (often useless) first
+      // "In file included from"/"While parsing" context line.
+      expect(result.message).toMatch(/Error: Transaction does not balance/);
     }
   });
 
@@ -69,8 +71,29 @@ describe('verifyJournalParseable', () => {
     const result = await verifyJournalParseable(file);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.firstLine).not.toContain(tmp);
-      expect(result.firstLine).not.toMatch(/\/[A-Za-z]+\/[A-Za-z]/);
+      expect(result.message).not.toContain(tmp);
+      expect(result.message).not.toMatch(/\/[A-Za-z]+\/[A-Za-z]/);
+    }
+  });
+
+  it('surfaces the real error, not the "In file included from" context, for an included file', async () => {
+    // Reproduces the reported bug: an unbalanced transaction lives in an
+    // included file, so ledger's FIRST stderr line is the unhelpful
+    // "In file included from ... line N:". The message must carry the actual
+    // diagnostic instead.
+    const main = path.join(tmp, 'main.ledger');
+    const sub = path.join(tmp, 'sub.ledger');
+    await fs.writeFile(main, 'include ./sub.ledger\n');
+    await fs.writeFile(
+      sub,
+      '2024-09-01 oops\n    Expenses:Food  USD 10\n    Assets:Cash  USD -7\n'
+    );
+    const result = await verifyJournalParseable(main);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/Error: Transaction does not balance/);
+      expect(result.message).not.toMatch(/^In file included from/);
+      expect(result.message).not.toContain(tmp);
     }
   });
 

--- a/lib/journal/verify.ts
+++ b/lib/journal/verify.ts
@@ -3,17 +3,49 @@ import { promisify } from 'util';
 
 const execFileP = promisify(execFile);
 
-export type VerifyResult = { ok: true } | { ok: false; firstLine: string };
+export type VerifyResult = { ok: true } | { ok: false; message: string };
 
 // Strip absolute paths from ledger's error messages so we don't leak server
-// filesystem layout to the client. ledger error lines look like
-// "path/to/file:LINE: error message".
-const PATH_REDACT = /\/[^:\s]+/g;
-const FIRST_LINE_MAX = 200;
+// filesystem layout to the client. ledger references files as
+// `"path/to/file"` (quoted) or `path/to/file:LINE`, so we redact any run of a
+// slash-led path up to the next quote/comma/colon/whitespace.
+const PATH_REDACT = /\/[^:\s",]+/g;
+const MAX_LEN = 500;
 
+const redact = (line: string): string => line.replace(PATH_REDACT, '<journal>');
+
+/**
+ * Turn ledger's multi-line stderr into one safe, *useful* message.
+ *
+ * ledger reports a parse error as a block: location context first
+ * (`In file included from ...`, `While parsing file ...`, `While balancing
+ * transaction from ...`), then the offending source lines (prefixed `>`),
+ * then the real diagnostic on an `Error: ...` line. The bare first line is
+ * almost always just include context ("In file included from ... line 2:") and
+ * tells the user nothing, so we pair each `Error:` with its nearest location
+ * line instead. Falls back to the first non-empty line when there is no
+ * `Error:` marker.
+ */
 const sanitize = (stderr: string): string => {
-  const firstLine = stderr.split('\n').find((l) => l.trim()) ?? '';
-  return firstLine.replace(PATH_REDACT, '<journal>').slice(0, FIRST_LINE_MAX);
+  const lines = stderr.split('\n').map(redact);
+  const nonEmpty = lines.filter((l) => l.trim());
+  if (nonEmpty.length === 0) return 'unknown error';
+
+  const isError = (l: string) => /^\s*Error:/.test(l);
+  const isLocation = (l: string) => /^\s*(While |In file included)/.test(l);
+
+  const diagnostics: string[] = [];
+  lines.forEach((line, i) => {
+    if (!isError(line)) return;
+    const context = lines.slice(0, i).reverse().find(isLocation);
+    diagnostics.push(
+      context ? `${line.trim()} (${context.trim()})` : line.trim()
+    );
+  });
+
+  const message =
+    diagnostics.length > 0 ? diagnostics.join('; ') : nonEmpty[0].trim();
+  return message.slice(0, MAX_LEN);
 };
 
 /**
@@ -22,7 +54,7 @@ const sanitize = (stderr: string): string => {
  * diverges from ledger's grammar, we catch it before the user has to find
  * out via a broken report page.
  *
- * On failure, returns the first non-empty stderr line with absolute paths
+ * On failure, returns the actual ledger diagnostic with absolute paths
  * redacted so the message is safe to surface to the client.
  */
 export const verifyJournalParseable = async (
@@ -35,7 +67,7 @@ export const verifyJournalParseable = async (
     const err = e as { stderr?: string; message?: string };
     return {
       ok: false,
-      firstLine: sanitize(err.stderr ?? err.message ?? 'unknown error'),
+      message: sanitize(err.stderr ?? err.message ?? 'unknown error'),
     };
   }
 };

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,6 +1,17 @@
 # The app shells out to the `ledger` CLI (ledger-cli 3.x) to compute
 # balances/stats from journal files (see lib/journal/*). Nixpacks installs
-# Node deps but not system binaries, so install `ledger` via apt here or the
+# Node deps but not system binaries, so `ledger` must be provided here or the
 # production container fails at runtime with `spawn ledger ENOENT`.
+#
+# We pull ledger from nixpkgs (pinned) rather than apt. Debian/Ubuntu apt ships
+# ledger 3.3.2, whose transaction balancing is stricter about sub-precision
+# rounding than the 3.4.1 most journals are authored against locally — so a
+# journal that parses on a dev machine can be REJECTED on the server (e.g. a BTC
+# transfer that's off by a rounding remainder). Pinning nixpkgs to a commit that
+# packages ledger 3.4.1 keeps server-side parsing identical to local `ledger`.
+#
+# nixpkgsArchive is the nixpkgs revision used for this phase; the pinned commit
+# below packages ledger 3.4.1 (verify: pkgs/by-name/le/ledger/package.nix).
 [phases.setup]
-aptPkgs = ["ledger"]
+nixPkgs = ["ledger"]
+nixpkgsArchive = "e73de5be04e0eff4190a1432b946d469c794e7b4"


### PR DESCRIPTION
Four related robustness fixes uncovered while debugging a journal that parsed locally but was rejected on the server.

## 1. Pin server ledger to 3.4.1 (was apt 3.3.2)
`nixpacks.toml` installed ledger via apt, which on Debian/Ubuntu is **3.3.2**. That version balances transactions more strictly than the **3.4.1** most journals are authored against locally, so a journal that parses on a dev machine can be rejected server-side over a sub-precision rounding remainder (e.g. a BTC transfer off by ~0.004 BTC) — breaking every report. Now pulls ledger from a pinned nixpkgs revision that packages 3.4.1 so server parsing matches local.

> ⚠️ Verification note: nixpkgs at the pinned commit `e73de5b` is confirmed to package ledger 3.4.1, but I couldn't run a nixpacks build locally (not installed). Please confirm ledger reports 3.4.1 on the first deploy. If the build regresses, reverting this file to `aptPkgs = ["ledger"]` restores the prior behavior.

## 2. Surface ledger's real parse error on import
`verify.ts` kept only the **first** stderr line. For an error inside an `include`d file, ledger's first line is the useless `In file included from … line N:` context, while the actual `Error: Transaction does not balance` was on a later line that got discarded — so import failures were uninformative. Now each `Error:` line is paired with its nearest location context (file + line range), paths redacted, multiple errors supported. Field renamed `firstLine` → `message`.

## 3. Better error display on the import page
The ledger diagnostic now renders in a distinct, scrollable monospace block below the summary so the offending entry is easy to locate and fix.

## 4. Stop the unlock/setup prefetch storm
The unlock and setup screens render a `<Link href="/">` wordmark. In production Next auto-prefetches in-viewport links; for a signed-in user who is locked or pre-setup, prefetching `/` replays the redirect chain `/ → /dashboard → /crypto/unlock` (the RSC client follows each hop with a cache-busting param), and since `/` never yields a stable cache entry it is re-prefetched on every re-render — producing the observed flood of `unlock?_rsc` requests and a blank first paint. `prefetch={false}` keeps the link clickable without prefetching the redirecting route.

> Root cause for #4 confirmed against the Next.js docs (prefetch is production-only; RSC prefetch follows redirects with cache-busting). The flood is prod-only and needs a locked crypto session, so it couldn't be reproduced in local dev — please confirm on deploy.

## Testing
- `pnpm test` — 657 passed (126 files), incl. new `verify.test.ts` cases asserting the real error is surfaced and paths stay redacted for the include scenario
- `pnpm type-check` and `pnpm lint` clean
- Reproduced the original rejection in an apt-ledger-3.3.2 container and confirmed local 3.4.1 accepts the same journal