### PR TITLE
feat(transactions): Phase 4 — the Types tab (five type forms)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-layered-transaction-entry-phase4-type-forms.md
+++ b/docs/superpowers/plans/2026-06-29-layered-transaction-entry-phase4-type-forms.md
@@ -1,0 +1,1645 @@
+# Phase 4: The Five Type Forms ("Types" tab) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the user-facing **Types** tab — type chips plus a tailored mini-form per type — wired to Phase 3's adapters, all editing the one shared `DraftState`.
+
+**Architecture:** A new `TypeLens` renders a chip row and the active type's form. Each `*Form` owns its typed adapter: it seeds its `fields` from `adapter.detect(draft) ?? { ...adapter.emptyFields(ctx), ...headerOf(draft) }`, and on every edit dispatches `{ type: 'replaceAll', state: adapter.compile(fields, ctx) }` so the shared draft stays canonical and Form/Raw tabs always reflect Types edits. Shared presentational primitives are factored out of `FormLens` into `typeForms/fields.tsx`. Fix-balance gets a display-only current→target→implied-adjustment preview backed by a server action.
+
+**Tech Stack:** React 19 client components, TypeScript, Vitest + `react-dom/server` `renderToStaticMarkup` (node env, no jsdom), Next server actions, `ledger` CLI via `utils/runLedger`.
+
+## Global Constraints
+
+- The ledger file is the source of truth; a transaction's type is **inferred from posting shape, never stored**. Forms only ever produce a `DraftState` via the adapters.
+- Every lens reads/writes the one shared `DraftState` via `dispatch`. Forms dispatch `{ type: 'replaceAll', state }` — never mutate postings directly.
+- Tests: Vitest, `renderToStaticMarkup`, node env, no jsdom. Pure logic is unit-tested; interactive shells get static smoke tests.
+- Account fields are role-filtered comboboxes but accept the **full account path** as free text (`Expenses:Coffee`). No auto-prefixing of role roots.
+- Tab order is hardcoded `Types · Form · Raw` this phase; persistence/reordering is Phase 5.
+- Each `*Form` imports its own **typed** adapter directly (e.g. `expenseAdapter: TransactionTypeAdapter<ExpenseFields>`); never cast the `unknown` fields from `registry.ts`.
+- All new interactive components begin with `'use client';`.
+- Run the full suite with `pnpm test` and types with `pnpm type-check`. Commit after every task.
+
+---
+
+### Task 1: Shared form primitives (`typeForms/fields.tsx`) + FormLens refactor
+
+Extract the presentational primitives out of `FormLens.tsx` so both lenses share them, and add a role-filtered `AccountField`.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/fields.tsx`
+- Create: `features/transactions/entry/typeForms/fields.test.tsx`
+- Modify: `features/transactions/entry/FormLens.tsx` (import `Field`/`SectionLabel` from the new module; delete the local copies)
+
+**Interfaces:**
+- Consumes: `accountsForRole`, `AccountRole` from `../types/accountRole`; `Combobox` from `@/components/Combobox`; `Label` from `@/components/ui/label`.
+- Produces:
+  - `SectionLabel({ children: React.ReactNode })`
+  - `Field({ label: string, htmlFor?: string, error?: string, children: React.ReactNode })`
+  - `AccountField({ label, role, accounts, value, onChange, placeholder?, error? })` where `role: AccountRole | AccountRole[]`, `value: string`, `onChange: (v: string) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// features/transactions/entry/typeForms/fields.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { Field, SectionLabel, AccountField } from './fields';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('fields primitives', () => {
+  it('Field renders label and error', () => {
+    const out = html(
+      <Field label="Paid from" error="Required">
+        <input />
+      </Field>
+    );
+    expect(out).toContain('Paid from');
+    expect(out).toContain('Required');
+  });
+
+  it('SectionLabel renders its text', () => {
+    expect(html(<SectionLabel>Details</SectionLabel>)).toContain('Details');
+  });
+
+  it('AccountField shows only accounts matching the role(s)', () => {
+    const out = html(
+      <AccountField
+        label="Spent on"
+        role="expense"
+        accounts={['Expenses:Food', 'Assets:Checking']}
+        value=""
+        onChange={() => {}}
+      />
+    );
+    // Combobox renders its options in the DOM; the asset account must be absent.
+    expect(out).toContain('Expenses:Food');
+    expect(out).not.toContain('Assets:Checking');
+  });
+
+  it('AccountField accepts an array of roles', () => {
+    const out = html(
+      <AccountField
+        label="From"
+        role={['asset', 'liability']}
+        accounts={['Assets:Checking', 'Liabilities:Card', 'Expenses:Food']}
+        value=""
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Assets:Checking');
+    expect(out).toContain('Liabilities:Card');
+    expect(out).not.toContain('Expenses:Food');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/fields.test.tsx`
+Expected: FAIL — `Cannot find module './fields'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// features/transactions/entry/typeForms/fields.tsx
+'use client';
+
+import React from 'react';
+import { accountsForRole, type AccountRole } from '../types/accountRole';
+import Combobox from '@/components/Combobox';
+import { Label } from '@/components/ui/label';
+
+export const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground sm:text-[0.7rem]">
+    {children}
+  </div>
+);
+
+export const Field = ({
+  label,
+  htmlFor,
+  error,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  error?: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-1.5">
+    <Label htmlFor={htmlFor}>{label}</Label>
+    {children}
+    {error && <span className="text-xs text-destructive">{error}</span>}
+  </div>
+);
+
+const optionsForRoles = (
+  accounts: string[],
+  role: AccountRole | AccountRole[]
+): string[] => {
+  const roles = Array.isArray(role) ? role : [role];
+  const seen = new Set<string>();
+  for (const r of roles)
+    for (const a of accountsForRole(accounts, r)) seen.add(a);
+  return [...seen];
+};
+
+export const AccountField = ({
+  label,
+  role,
+  accounts,
+  value,
+  onChange,
+  placeholder = 'Account (full path, e.g. Expenses:Food)',
+  error,
+}: {
+  label: string;
+  role: AccountRole | AccountRole[];
+  accounts: string[];
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  error?: string;
+}) => (
+  <Field label={label} error={error}>
+    <Combobox
+      value={value}
+      onChange={onChange}
+      options={optionsForRoles(accounts, role)}
+      placeholder={placeholder}
+    />
+  </Field>
+);
+```
+
+- [ ] **Step 4: Refactor FormLens to import the shared primitives**
+
+In `features/transactions/entry/FormLens.tsx`: delete the local `const SectionLabel = …` and `const Field = …` definitions (the two `// ─── Private sub-components ───` helpers), and add to the imports:
+
+```tsx
+import { Field, SectionLabel } from './typeForms/fields';
+```
+
+Leave `PostingRow` and `BalanceIndicator` in `FormLens.tsx` (they are form-specific).
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+Run: `pnpm test features/transactions/entry/typeForms/fields.test.tsx features/transactions/entry/FormLens.test.tsx`
+Expected: PASS — both the new `fields` tests and the existing FormLens smoke tests.
+
+- [ ] **Step 6: Type-check and commit**
+
+```bash
+pnpm type-check
+git add features/transactions/entry/typeForms/fields.tsx features/transactions/entry/typeForms/fields.test.tsx features/transactions/entry/FormLens.tsx
+git commit -m "refactor(transactions): extract shared form primitives + role-filtered AccountField"
+```
+
+---
+
+### Task 2: `isEmptyDraft` helper
+
+A pure predicate so TypeLens can tell a fresh (create) draft from a populated one.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/isEmptyDraft.ts`
+- Create: `features/transactions/entry/typeForms/isEmptyDraft.test.ts`
+
+**Interfaces:**
+- Consumes: `DraftState` from `../draftReducer`.
+- Produces: `isEmptyDraft(draft: DraftState): boolean` — true when no posting has an account or amount AND payee/note are blank. (Date and currency are ignored: a fresh create draft has today's date and the default currency pre-filled.)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// features/transactions/entry/typeForms/isEmptyDraft.test.ts
+import { describe, it, expect } from 'vitest';
+import { isEmptyDraft } from './isEmptyDraft';
+import { initDraft } from '../draftReducer';
+
+describe('isEmptyDraft', () => {
+  it('is true for a fresh create draft (today + default currency only)', () => {
+    expect(isEmptyDraft(initDraft({ date: '2026-06-29' }, 'USD'))).toBe(true);
+  });
+
+  it('is false when any posting has an account', () => {
+    const d = initDraft({ date: '2026-06-29' }, 'USD');
+    d.postings[0].account = 'Expenses:Food';
+    expect(isEmptyDraft(d)).toBe(false);
+  });
+
+  it('is false when any posting has an amount', () => {
+    const d = initDraft({ date: '2026-06-29' }, 'USD');
+    d.postings[0].amount = '10';
+    expect(isEmptyDraft(d)).toBe(false);
+  });
+
+  it('is false when a payee is set', () => {
+    const d = initDraft({ date: '2026-06-29', payee: 'Cafe' }, 'USD');
+    expect(isEmptyDraft(d)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/isEmptyDraft.test.ts`
+Expected: FAIL — `Cannot find module './isEmptyDraft'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// features/transactions/entry/typeForms/isEmptyDraft.ts
+import type { DraftState } from '../draftReducer';
+
+export const isEmptyDraft = (draft: DraftState): boolean =>
+  draft.payee.trim() === '' &&
+  draft.note.trim() === '' &&
+  draft.postings.every(
+    (p) => p.account.trim() === '' && p.amount.trim() === ''
+  );
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test features/transactions/entry/typeForms/isEmptyDraft.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/isEmptyDraft.ts features/transactions/entry/typeForms/isEmptyDraft.test.ts
+git commit -m "feat(transactions): isEmptyDraft predicate for type lens"
+```
+
+---
+
+### Task 3: Shared `HeaderFields` component
+
+The date / status / payee / note block every type form renders.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/HeaderFields.tsx`
+- Create: `features/transactions/entry/typeForms/HeaderFields.test.tsx`
+
+**Interfaces:**
+- Consumes: `Field` from `./fields`; `HeaderFields` type from `../types/adapter`; `DraftStatus` from `../draftReducer`; `Input`, `Textarea`, `ToggleGroup`/`ToggleGroupItem` from `@/components/ui/*`; `Combobox`.
+- Produces: `HeaderFieldsEditor({ header, payees, onChange })` where `header: HeaderFields` and `onChange: (patch: Partial<HeaderFields>) => void`. (Named `HeaderFieldsEditor` to avoid colliding with the `HeaderFields` type.)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// features/transactions/entry/typeForms/HeaderFields.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { HeaderFieldsEditor } from './HeaderFields';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('HeaderFieldsEditor', () => {
+  it('renders the date, payee and note values', () => {
+    const out = html(
+      <HeaderFieldsEditor
+        header={{
+          date: '2026-06-29',
+          payee: 'Blue Bottle',
+          status: 'none',
+          note: 'morning',
+        }}
+        payees={['Blue Bottle']}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('2026-06-29');
+    expect(out).toContain('Blue Bottle');
+    expect(out).toContain('morning');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/HeaderFields.test.tsx`
+Expected: FAIL — `Cannot find module './HeaderFields'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// features/transactions/entry/typeForms/HeaderFields.tsx
+'use client';
+
+import React from 'react';
+import type { DraftStatus } from '../draftReducer';
+import type { HeaderFields } from '../types/adapter';
+import { Field, SectionLabel } from './fields';
+import Combobox from '@/components/Combobox';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+
+export const HeaderFieldsEditor = ({
+  header,
+  payees,
+  onChange,
+}: {
+  header: HeaderFields;
+  payees: string[];
+  onChange: (patch: Partial<HeaderFields>) => void;
+}): React.JSX.Element => (
+  <section className="flex flex-col gap-5">
+    <SectionLabel>Details</SectionLabel>
+
+    <Field label="Date" htmlFor="ty-date">
+      <Input
+        id="ty-date"
+        type="date"
+        value={header.date}
+        onChange={(e) => onChange({ date: e.target.value })}
+        required
+      />
+    </Field>
+
+    <Field label="Status">
+      <ToggleGroup
+        value={[header.status]}
+        onValueChange={(values) => {
+          if (values.length > 0)
+            onChange({ status: values[0] as DraftStatus });
+        }}
+        spacing={0}
+        variant="outline"
+        size="sm"
+        className="w-full"
+      >
+        <ToggleGroupItem value="none" className="flex-1">
+          Unmarked
+        </ToggleGroupItem>
+        <ToggleGroupItem value="pending" className="flex-1">
+          Pending (!)
+        </ToggleGroupItem>
+        <ToggleGroupItem value="cleared" className="flex-1">
+          Cleared (*)
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </Field>
+
+    <Field label="Payee">
+      <Combobox
+        value={header.payee}
+        onChange={(v) => onChange({ payee: v })}
+        options={payees}
+        placeholder="Type or pick a payee…"
+      />
+    </Field>
+
+    <Field label="Note (optional)" htmlFor="ty-note">
+      <Textarea
+        id="ty-note"
+        value={header.note}
+        onChange={(e) => onChange({ note: e.target.value })}
+        rows={3}
+        placeholder="Comment lines — written below the payee with a ; prefix"
+      />
+    </Field>
+  </section>
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test features/transactions/entry/typeForms/HeaderFields.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/HeaderFields.tsx features/transactions/entry/typeForms/HeaderFields.test.tsx
+git commit -m "feat(transactions): shared header-fields editor for type forms"
+```
+
+---
+
+### Task 4: ExpenseForm
+
+The first concrete type form; establishes the form contract every later form follows.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/ExpenseForm.tsx`
+- Create: `features/transactions/entry/typeForms/ExpenseForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `expenseAdapter`, `ExpenseFields` from `../types/expense`; `headerOf` from `../types/adapter`; `DraftState`/`DraftAction` from `../draftReducer`; `HeaderFieldsEditor`, `Field`, `SectionLabel`, `AccountField` from the shared modules; `AmountInput` from `../../AmountInput`; `Input` from `@/components/ui/input`.
+- Produces: `TypeFormProps` (shared contract, **defined here, re-exported for the other forms**) and `ExpenseForm(props: TypeFormProps)`.
+
+```ts
+export type TypeFormProps = {
+  draft: DraftState;
+  dispatch: (a: DraftAction) => void;
+  accounts: string[];
+  payees: string[];
+  defaultCurrency: string;
+};
+```
+
+The contract every form follows:
+1. `const ctx = { defaultCurrency }` (memoized).
+2. Seed once: `useState(() => adapter.detect(draft) ?? { ...adapter.emptyFields(ctx), ...headerOf(draft) })`. Seeding with `headerOf(draft)` preserves date/payee/status/note when the user switches type (TypeLens remounts the form but the draft still holds the previous type's header).
+3. `update(next)` → `setFields(next)` then `dispatch({ type: 'replaceAll', state: adapter.compile(next, ctx) })`.
+4. Header edits go through `update({ ...fields, ...patch })`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// features/transactions/entry/typeForms/ExpenseForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { ExpenseForm } from './ExpenseForm';
+import { initDraft } from '../draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('ExpenseForm', () => {
+  it('renders fields seeded from an expense-shaped draft', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Whole Foods',
+        postings: [
+          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(
+      <ExpenseForm
+        draft={draft}
+        dispatch={() => {}}
+        accounts={['Assets:Checking', 'Expenses:Groceries']}
+        payees={['Whole Foods']}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Whole Foods');
+    expect(out).toContain('Expenses:Groceries');
+    expect(out).toContain('Assets:Checking');
+    expect(out).toContain('42.5');
+  });
+
+  it('renders empty fields for a fresh draft without crashing', () => {
+    const out = html(
+      <ExpenseForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Spent on');
+    expect(out).toContain('Paid from');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/ExpenseForm.test.tsx`
+Expected: FAIL — `Cannot find module './ExpenseForm'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// features/transactions/entry/typeForms/ExpenseForm.tsx
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import type { DraftAction, DraftState } from '../draftReducer';
+import { headerOf } from '../types/adapter';
+import { expenseAdapter, type ExpenseFields } from '../types/expense';
+import { Field, SectionLabel, AccountField } from './fields';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Input } from '@/components/ui/input';
+
+export type TypeFormProps = {
+  draft: DraftState;
+  dispatch: (a: DraftAction) => void;
+  accounts: string[];
+  payees: string[];
+  defaultCurrency: string;
+};
+
+export function ExpenseForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<ExpenseFields>(
+    () =>
+      expenseAdapter.detect(draft) ?? {
+        ...expenseAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+
+  const update = (next: ExpenseFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: expenseAdapter.compile(next, ctx) });
+  };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Expense</SectionLabel>
+
+        <Field label="Amount">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.amount}
+              onChange={(amount) => update({ ...fields, amount })}
+              placeholder="Amount"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.currency}
+              onChange={(e) => update({ ...fields, currency: e.target.value })}
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+
+        <AccountField
+          label="Paid from"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.paidFrom}
+          onChange={(paidFrom) => update({ ...fields, paidFrom })}
+        />
+
+        <AccountField
+          label="Spent on"
+          role="expense"
+          accounts={accounts}
+          value={fields.spentOn}
+          onChange={(spentOn) => update({ ...fields, spentOn })}
+        />
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test features/transactions/entry/typeForms/ExpenseForm.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check and commit**
+
+```bash
+pnpm type-check
+git add features/transactions/entry/typeForms/ExpenseForm.tsx features/transactions/entry/typeForms/ExpenseForm.test.tsx
+git commit -m "feat(transactions): expense type form"
+```
+
+---
+
+### Task 5: IncomeForm and TransferForm
+
+Two near-identical forms following the ExpenseForm contract.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/IncomeForm.tsx`
+- Create: `features/transactions/entry/typeForms/IncomeForm.test.tsx`
+- Create: `features/transactions/entry/typeForms/TransferForm.tsx`
+- Create: `features/transactions/entry/typeForms/TransferForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `TypeFormProps` from `./ExpenseForm`; `incomeAdapter`/`IncomeFields` from `../types/income`; `transferAdapter`/`TransferFields` from `../types/transfer`; same shared UI modules as Task 4.
+- Produces: `IncomeForm(props: TypeFormProps)`, `TransferForm(props: TypeFormProps)`.
+
+> Confirmed field names: `IncomeFields = { amount, currency, receivedInto (asset), from (income) }`; `TransferFields = { amount, currency, from, to (both asset/liability) }`. Note income's income-account field is named `from`, labelled "Source".
+
+- [ ] **Step 1: Write the failing IncomeForm test**
+
+```tsx
+// features/transactions/entry/typeForms/IncomeForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { IncomeForm } from './IncomeForm';
+import { initDraft } from '../draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('IncomeForm', () => {
+  it('renders income fields for a fresh draft', () => {
+    const out = html(
+      <IncomeForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Received into');
+    expect(out).toContain('Source');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/IncomeForm.test.tsx`
+Expected: FAIL — `Cannot find module './IncomeForm'`.
+
+- [ ] **Step 3: Write IncomeForm**
+
+Read `../types/income.ts` for the exact `IncomeFields` field names, then mirror ExpenseForm. The income posting (source) has role `income`; the deposit (received into) has role `asset`. Section label `Income`. Example body (adjust field names to match the adapter):
+
+```tsx
+// features/transactions/entry/typeForms/IncomeForm.tsx
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { incomeAdapter, type IncomeFields } from '../types/income';
+import type { TypeFormProps } from './ExpenseForm';
+import { Field, SectionLabel, AccountField } from './fields';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Input } from '@/components/ui/input';
+
+export function IncomeForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<IncomeFields>(
+    () =>
+      incomeAdapter.detect(draft) ?? {
+        ...incomeAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+  const update = (next: IncomeFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: incomeAdapter.compile(next, ctx) });
+  };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Income</SectionLabel>
+        <Field label="Amount">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.amount}
+              onChange={(amount) => update({ ...fields, amount })}
+              placeholder="Amount"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.currency}
+              onChange={(e) => update({ ...fields, currency: e.target.value })}
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+        <AccountField
+          label="Received into"
+          role="asset"
+          accounts={accounts}
+          value={fields.receivedInto}
+          onChange={(receivedInto) => update({ ...fields, receivedInto })}
+        />
+        <AccountField
+          label="Source"
+          role="income"
+          accounts={accounts}
+          value={fields.from}
+          onChange={(from) => update({ ...fields, from })}
+        />
+      </section>
+    </div>
+  );
+}
+```
+
+If the adapter's field names differ from `receivedInto`/`source`/`amount`/`currency`, use the adapter's actual names (TypeScript will flag mismatches at Step 6).
+
+- [ ] **Step 4: Write the failing TransferForm test**
+
+```tsx
+// features/transactions/entry/typeForms/TransferForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { TransferForm } from './TransferForm';
+import { initDraft } from '../draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('TransferForm', () => {
+  it('renders from/to fields for a fresh draft', () => {
+    const out = html(
+      <TransferForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('From');
+    expect(out).toContain('To');
+  });
+});
+```
+
+- [ ] **Step 5: Write TransferForm**
+
+Read `../types/transfer.ts` for the exact `TransferFields` field names, then mirror the structure with both account fields role `['asset', 'liability']`, section label `Transfer`, a single amount/currency. Use `transferAdapter`/`TransferFields`.
+
+- [ ] **Step 6: Run tests + type-check**
+
+Run: `pnpm test features/transactions/entry/typeForms/IncomeForm.test.tsx features/transactions/entry/typeForms/TransferForm.test.tsx && pnpm type-check`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/IncomeForm.tsx features/transactions/entry/typeForms/IncomeForm.test.tsx features/transactions/entry/typeForms/TransferForm.tsx features/transactions/entry/typeForms/TransferForm.test.tsx
+git commit -m "feat(transactions): income and transfer type forms"
+```
+
+---
+
+### Task 6: ExchangeForm
+
+The two-sided (gave / got) form.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/ExchangeForm.tsx`
+- Create: `features/transactions/entry/typeForms/ExchangeForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `TypeFormProps` from `./ExpenseForm`; `exchangeAdapter`/`ExchangeFields` from `../types/exchange` (fields: `gaveAmount`, `gaveCurrency`, `gaveFrom`, `gotAmount`, `gotCurrency`, `gotInto`); same shared UI modules.
+- Produces: `ExchangeForm(props: TypeFormProps)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// features/transactions/entry/typeForms/ExchangeForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { ExchangeForm } from './ExchangeForm';
+import { initDraft } from '../draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('ExchangeForm', () => {
+  it('renders gave/got sections for a fresh draft', () => {
+    const out = html(
+      <ExchangeForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Gave');
+    expect(out).toContain('Got');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/ExchangeForm.test.tsx`
+Expected: FAIL — `Cannot find module './ExchangeForm'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// features/transactions/entry/typeForms/ExchangeForm.tsx
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { exchangeAdapter, type ExchangeFields } from '../types/exchange';
+import type { TypeFormProps } from './ExpenseForm';
+import { Field, SectionLabel, AccountField } from './fields';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Input } from '@/components/ui/input';
+
+export function ExchangeForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<ExchangeFields>(
+    () =>
+      exchangeAdapter.detect(draft) ?? {
+        ...exchangeAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+  const update = (next: ExchangeFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: exchangeAdapter.compile(next, ctx) });
+  };
+
+  const amountRow = (
+    amount: string,
+    currency: string,
+    onAmount: (v: string) => void,
+    onCurrency: (v: string) => void
+  ) => (
+    <div className="flex gap-2">
+      <AmountInput
+        value={amount}
+        onChange={onAmount}
+        placeholder="Amount"
+        className="flex-1 text-right tabular-nums"
+      />
+      <Input
+        type="text"
+        value={currency}
+        onChange={(e) => onCurrency(e.target.value)}
+        placeholder="Currency"
+        className="w-24"
+      />
+    </div>
+  );
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Gave</SectionLabel>
+        <Field label="Amount">
+          {amountRow(
+            fields.gaveAmount,
+            fields.gaveCurrency,
+            (gaveAmount) => update({ ...fields, gaveAmount }),
+            (gaveCurrency) => update({ ...fields, gaveCurrency })
+          )}
+        </Field>
+        <AccountField
+          label="From"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.gaveFrom}
+          onChange={(gaveFrom) => update({ ...fields, gaveFrom })}
+        />
+
+        <SectionLabel>Got</SectionLabel>
+        <Field label="Amount">
+          {amountRow(
+            fields.gotAmount,
+            fields.gotCurrency,
+            (gotAmount) => update({ ...fields, gotAmount }),
+            (gotCurrency) => update({ ...fields, gotCurrency })
+          )}
+        </Field>
+        <AccountField
+          label="Into"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.gotInto}
+          onChange={(gotInto) => update({ ...fields, gotInto })}
+        />
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test + type-check**
+
+Run: `pnpm test features/transactions/entry/typeForms/ExchangeForm.test.tsx && pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/ExchangeForm.tsx features/transactions/entry/typeForms/ExchangeForm.test.tsx
+git commit -m "feat(transactions): exchange type form"
+```
+
+---
+
+### Task 7: `getAccountBalance` server action + pure parser
+
+The fix-balance preview backend. The pure parser is the tested core; the server action is a thin `runLedger` wrapper.
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/fixBalancePreview.ts` (pure)
+- Create: `features/transactions/entry/typeForms/fixBalancePreview.test.ts`
+- Create: `features/transactions/entry/actions/getAccountBalance.ts` (server action)
+
+**Interfaces:**
+- Consumes: `parseBalanceRows` from `@/lib/balance/parse`; `runLedger` from `@/utils/runLedger`.
+- Produces:
+  - `extractAccountBalance(stdout: string, account: string): string` — the numeric balance string (e.g. `"1240.00"`, `"-50"`) for `account` from `ledger balance --format '%A|%T\n'` output, or `"0"` when absent. Strips thousands separators and any commodity token.
+  - `getAccountBalance(account: string, currency: string): Promise<string>` — server action; runs ledger converted to `currency`, returns `extractAccountBalance(...)`, `"0"` on any error.
+
+- [ ] **Step 1: Write the failing parser test**
+
+```ts
+// features/transactions/entry/typeForms/fixBalancePreview.test.ts
+import { describe, it, expect } from 'vitest';
+import { extractAccountBalance } from './fixBalancePreview';
+
+describe('extractAccountBalance', () => {
+  it('extracts the numeric balance for the matching account', () => {
+    const stdout = 'Assets:Cash|1,240.00 USD\n';
+    expect(extractAccountBalance(stdout, 'Assets:Cash')).toBe('1240.00');
+  });
+
+  it('handles negative balances and a leading symbol', () => {
+    const stdout = 'Liabilities:Card|$-50.00\n';
+    expect(extractAccountBalance(stdout, 'Liabilities:Card')).toBe('-50.00');
+  });
+
+  it('returns "0" when the account is absent', () => {
+    expect(extractAccountBalance('', 'Assets:Cash')).toBe('0');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/fixBalancePreview.test.ts`
+Expected: FAIL — `Cannot find module './fixBalancePreview'`.
+
+- [ ] **Step 3: Write the parser**
+
+```ts
+// features/transactions/entry/typeForms/fixBalancePreview.ts
+import { parseBalanceRows } from '@/lib/balance/parse';
+
+/** Strip thousands separators and any non-numeric commodity token. */
+const toNumber = (raw: string): string => {
+  const cleaned = raw.replace(/,/g, '').replace(/[^0-9.\-]/g, '');
+  return cleaned === '' || cleaned === '-' ? '0' : cleaned;
+};
+
+export const extractAccountBalance = (
+  stdout: string,
+  account: string
+): string => {
+  const row = parseBalanceRows(stdout).find((r) => r.account === account);
+  return row ? toNumber(row.amount) : '0';
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test features/transactions/entry/typeForms/fixBalancePreview.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the server action**
+
+```ts
+// features/transactions/entry/actions/getAccountBalance.ts
+'use server';
+
+import { extractAccountBalance } from '../typeForms/fixBalancePreview';
+import runLedger from '@/utils/runLedger';
+
+export async function getAccountBalance(
+  account: string,
+  currency: string
+): Promise<string> {
+  if (!account.trim()) return '0';
+  try {
+    const stdout = await runLedger([
+      'balance',
+      account,
+      '-X',
+      currency,
+      '--no-total',
+      '--collapse',
+      '--format',
+      '%A|%T\n',
+    ]);
+    return extractAccountBalance(stdout, account);
+  } catch {
+    return '0';
+  }
+}
+```
+
+- [ ] **Step 6: Type-check and commit**
+
+```bash
+pnpm type-check
+git add features/transactions/entry/typeForms/fixBalancePreview.ts features/transactions/entry/typeForms/fixBalancePreview.test.ts features/transactions/entry/actions/getAccountBalance.ts
+git commit -m "feat(transactions): account-balance lookup for fix-balance preview"
+```
+
+> Manual-verification note (do in Task 11's manual pass): the exact `ledger balance` flags (`-X`, `--collapse`) may need tuning against the real CLI so a single numeric balance comes back for the chosen account/currency. The parser test is canned and unaffected; verify the live number in the running app.
+
+---
+
+### Task 8: FixBalanceForm (with live preview)
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/FixBalanceForm.tsx`
+- Create: `features/transactions/entry/typeForms/FixBalanceForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `TypeFormProps` from `./ExpenseForm` **extended** with `getAccountBalance`; `fixBalanceAdapter`/`FixBalanceFields` from `../types/fixBalance` (fields: `account`, `targetAmount`, `targetCurrency`); shared UI modules.
+- Produces: `FixBalanceFormProps = TypeFormProps & { getAccountBalance: (account: string, currency: string) => Promise<string> }` and `FixBalanceForm(props)`.
+
+Behavior: on account/currency change, debounce ~300ms, call `getAccountBalance`, store the current balance, and render `now / target / implied adjustment (target − current)`. A monotonically increasing request-id ref discards stale responses. The preview never gates submit; the compiled draft is assertion + blank equity (the adapter's job).
+
+- [ ] **Step 1: Write the failing test** (static smoke — the async preview isn't exercised under `renderToStaticMarkup`, so pass a stub)
+
+```tsx
+// features/transactions/entry/typeForms/FixBalanceForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { FixBalanceForm } from './FixBalanceForm';
+import { initDraft } from '../draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('FixBalanceForm', () => {
+  it('renders account and target fields for a fresh draft', () => {
+    const out = html(
+      <FixBalanceForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={['Assets:Cash']}
+        payees={[]}
+        defaultCurrency="USD"
+        getAccountBalance={async () => '0'}
+      />
+    );
+    expect(out).toContain('Account');
+    expect(out).toContain('Target');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/typeForms/FixBalanceForm.test.tsx`
+Expected: FAIL — `Cannot find module './FixBalanceForm'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// features/transactions/entry/typeForms/FixBalanceForm.tsx
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { fixBalanceAdapter, type FixBalanceFields } from '../types/fixBalance';
+import type { TypeFormProps } from './ExpenseForm';
+import { Field, SectionLabel, AccountField } from './fields';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Input } from '@/components/ui/input';
+
+export type FixBalanceFormProps = TypeFormProps & {
+  getAccountBalance: (account: string, currency: string) => Promise<string>;
+};
+
+export function FixBalanceForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+  getAccountBalance,
+}: FixBalanceFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<FixBalanceFields>(
+    () =>
+      fixBalanceAdapter.detect(draft) ?? {
+        ...fixBalanceAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+  const [current, setCurrent] = useState<string | null>(null);
+  const reqId = useRef(0);
+
+  const update = (next: FixBalanceFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: fixBalanceAdapter.compile(next, ctx) });
+  };
+
+  useEffect(() => {
+    const account = fields.account.trim();
+    if (!account) {
+      setCurrent(null);
+      return;
+    }
+    const id = ++reqId.current;
+    setCurrent(null);
+    const t = setTimeout(() => {
+      void getAccountBalance(account, fields.targetCurrency).then((bal) => {
+        if (id === reqId.current) setCurrent(bal);
+      });
+    }, 300);
+    return () => clearTimeout(t);
+  }, [fields.account, fields.targetCurrency, getAccountBalance]);
+
+  const implied =
+    current !== null && fields.targetAmount.trim() !== ''
+      ? (Number(fields.targetAmount) - Number(current)).toFixed(2)
+      : null;
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Fix balance</SectionLabel>
+
+        <AccountField
+          label="Account"
+          role={['asset', 'liability', 'income', 'expense', 'equity']}
+          accounts={accounts}
+          value={fields.account}
+          onChange={(account) => update({ ...fields, account })}
+        />
+
+        <Field label="Target balance">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.targetAmount}
+              onChange={(targetAmount) => update({ ...fields, targetAmount })}
+              placeholder="Target"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.targetCurrency}
+              onChange={(e) =>
+                update({ ...fields, targetCurrency: e.target.value })
+              }
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+
+        <div className="text-xs text-muted-foreground tabular-nums">
+          {current === null
+            ? 'Enter an account to see its current balance.'
+            : `Now: ${current} ${fields.targetCurrency}`}
+          {implied !== null && (
+            <span className="ml-2">
+              · Implied adjustment: {implied} {fields.targetCurrency}
+            </span>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test + type-check**
+
+Run: `pnpm test features/transactions/entry/typeForms/FixBalanceForm.test.tsx && pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/FixBalanceForm.tsx features/transactions/entry/typeForms/FixBalanceForm.test.tsx
+git commit -m "feat(transactions): fix-balance type form with live adjustment preview"
+```
+
+---
+
+### Task 9: TypeLens shell
+
+The chip row + state model that selects and renders the active form.
+
+**Files:**
+- Create: `features/transactions/entry/TypeLens.tsx`
+- Create: `features/transactions/entry/TypeLens.test.tsx`
+
+**Interfaces:**
+- Consumes: `TYPE_ADAPTERS`, `detectType` from `./types/registry`; `isEmptyDraft` from `./typeForms/isEmptyDraft`; the five form components; `TypeFormProps` from `./typeForms/ExpenseForm`; `Button` from `@/components/ui/button`.
+- Produces: `TypeLens(props: TypeFormProps & { getAccountBalance })`.
+
+State model:
+- `detected = detectType(draft)`; `empty = isEmptyDraft(draft)`.
+- `picked` (user chip click) overrides; `selectedId = picked ?? detected?.id ?? null`.
+- Chips disabled when `!empty && !detected` (no-match → greyed). When disabled and nothing picked, render the "use Form or Raw" notice.
+- When `empty && selectedId === null`, render a "Pick a type" prompt.
+- Otherwise render `FORM_BY_ID[selectedId]` with `key={selectedId}` so a chip switch remounts and reseeds.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// features/transactions/entry/TypeLens.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { TypeLens } from './TypeLens';
+import { initDraft } from './draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+const base = {
+  dispatch: () => {},
+  accounts: ['Assets:Checking', 'Expenses:Food'],
+  payees: [],
+  defaultCurrency: 'USD',
+  getAccountBalance: async () => '0',
+};
+
+describe('TypeLens', () => {
+  it('shows a pick-a-type prompt for an empty draft', () => {
+    const out = html(
+      <TypeLens draft={initDraft({ date: '2026-06-29' }, 'USD')} {...base} />
+    );
+    expect(out).toContain('Pick a type');
+    expect(out).toContain('Expense');
+  });
+
+  it('renders the matching form for an expense-shaped draft', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Cafe',
+        postings: [
+          { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-5', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(<TypeLens draft={draft} {...base} />);
+    expect(out).toContain('Spent on');
+  });
+
+  it('greys chips and shows a notice for an unrecognized shape', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Split',
+        postings: [
+          { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+          { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(<TypeLens draft={draft} {...base} />);
+    expect(out).toContain('Form or Raw');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test features/transactions/entry/TypeLens.test.tsx`
+Expected: FAIL — `Cannot find module './TypeLens'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// features/transactions/entry/TypeLens.tsx
+'use client';
+
+import React, { useState } from 'react';
+import { ExchangeForm } from './typeForms/ExchangeForm';
+import { ExpenseForm, type TypeFormProps } from './typeForms/ExpenseForm';
+import { FixBalanceForm } from './typeForms/FixBalanceForm';
+import { IncomeForm } from './typeForms/IncomeForm';
+import { TransferForm } from './typeForms/TransferForm';
+import { isEmptyDraft } from './typeForms/isEmptyDraft';
+import { TYPE_ADAPTERS, detectType } from './types/registry';
+import { Button } from '@/components/ui/button';
+
+type Props = TypeFormProps & {
+  getAccountBalance: (account: string, currency: string) => Promise<string>;
+};
+
+export function TypeLens(props: Props): React.JSX.Element {
+  const { draft, getAccountBalance, ...formProps } = props;
+  const detected = detectType(draft);
+  const empty = isEmptyDraft(draft);
+  const [picked, setPicked] = useState<string | null>(null);
+
+  const selectedId = picked ?? detected?.id ?? null;
+  const chipsDisabled = !empty && !detected;
+
+  const renderForm = () => {
+    const shared = { draft, ...formProps };
+    switch (selectedId) {
+      case 'expense':
+        return <ExpenseForm key="expense" {...shared} />;
+      case 'income':
+        return <IncomeForm key="income" {...shared} />;
+      case 'transfer':
+        return <TransferForm key="transfer" {...shared} />;
+      case 'exchange':
+        return <ExchangeForm key="exchange" {...shared} />;
+      case 'fix-balance':
+        return (
+          <FixBalanceForm
+            key="fix-balance"
+            {...shared}
+            getAccountBalance={getAccountBalance}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-wrap gap-2">
+        {TYPE_ADAPTERS.map((a) => (
+          <Button
+            key={a.id}
+            type="button"
+            size="sm"
+            variant={selectedId === a.id ? 'default' : 'outline'}
+            disabled={chipsDisabled}
+            onClick={() => setPicked(a.id)}
+          >
+            <span aria-hidden className="mr-1">
+              {a.icon}
+            </span>
+            {a.label}
+          </Button>
+        ))}
+      </div>
+
+      {chipsDisabled ? (
+        <p className="text-sm text-muted-foreground">
+          This transaction&apos;s shape doesn&apos;t map to a quick type — edit
+          it in the Form or Raw tab.
+        </p>
+      ) : selectedId === null ? (
+        <p className="text-sm text-muted-foreground">
+          Pick a type to start a guided entry.
+        </p>
+      ) : (
+        renderForm()
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test + type-check**
+
+Run: `pnpm test features/transactions/entry/TypeLens.test.tsx && pnpm type-check`
+Expected: PASS. (The `Button` variant strings must match the project's button variants — if `'default'`/`'outline'` aren't valid, read `@/components/ui/button` and use the actual variant names.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/TypeLens.tsx features/transactions/entry/TypeLens.test.tsx
+git commit -m "feat(transactions): TypeLens shell with chips and detect-driven selection"
+```
+
+---
+
+### Task 10: Wire the Types tab into the shell
+
+Register Types first, compute the initial tab, render TypeLens, and thread `getAccountBalance` from the server components.
+
+**Files:**
+- Modify: `features/transactions/entry/TransactionEntry.tsx`
+- Modify: `features/transactions/entry/TransactionEntry.test.tsx`
+- Modify: `features/transactions/NewTransaction.tsx`
+- Modify: `features/transactions/EditTransaction.tsx`
+
+**Interfaces:**
+- Consumes: `TypeLens` from `./TypeLens`; `detectType` from `./types/registry`; `getAccountBalance` from `./actions/getAccountBalance`.
+- Produces: `TransactionEntryProps` gains `getAccountBalance: (account: string, currency: string) => Promise<string>`.
+
+- [ ] **Step 1: Update the TransactionEntry test first**
+
+Add to `features/transactions/entry/TransactionEntry.test.tsx` a case asserting the Types tab renders and is the default in create mode. Match the existing test's render helper and props; add:
+
+```tsx
+it('shows Types as the first tab and defaults to it in create mode', () => {
+  const out = html(
+    <TransactionEntry
+      accounts={[]}
+      payees={[]}
+      defaultCurrency="USD"
+      submitAction={async () => ({ ok: false })}
+      getAccountBalance={async () => '0'}
+    />
+  );
+  expect(out).toContain('Types');
+  // Types is default → its "Pick a type" prompt is present on first render.
+  expect(out).toContain('Pick a type');
+});
+```
+
+(If the existing tests construct a shared `props` object, add `getAccountBalance: async () => '0'` to it so they keep compiling.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test features/transactions/entry/TransactionEntry.test.tsx`
+Expected: FAIL — missing `getAccountBalance` prop / no "Types".
+
+- [ ] **Step 3: Wire TransactionEntry**
+
+In `features/transactions/entry/TransactionEntry.tsx`:
+
+Add imports:
+```tsx
+import { TypeLens } from './TypeLens';
+import { detectType } from './types/registry';
+import { getAccountBalance as defaultGetAccountBalance } from './actions/getAccountBalance';
+```
+
+Add `getAccountBalance` to `TransactionEntryProps`:
+```tsx
+  getAccountBalance?: (account: string, currency: string) => Promise<string>;
+```
+
+Register Types first:
+```tsx
+const TABS = [
+  { id: 'types', label: 'Types' },
+  { id: 'form', label: 'Form' },
+  { id: 'raw', label: 'Raw' },
+];
+```
+
+Replace the `const [active, setActive] = useState('form');` initializer with a draft-aware one (place it right after the `useReducer` that creates `draft`):
+```tsx
+const [active, setActive] = useState(() =>
+  mode === 'edit' && !detectType(draft) ? 'form' : 'types'
+);
+```
+
+Render TypeLens before the Form block inside the tab area:
+```tsx
+{active === 'types' && (
+  <TypeLens
+    draft={draft}
+    dispatch={dispatch}
+    accounts={accounts}
+    payees={payees}
+    defaultCurrency={defaultCurrency}
+    getAccountBalance={getAccountBalance ?? defaultGetAccountBalance}
+  />
+)}
+```
+
+Add `getAccountBalance` to the destructured props of the component signature.
+
+- [ ] **Step 4: Thread the prop from the server components**
+
+In `features/transactions/NewTransaction.tsx` add the import and pass the prop:
+```tsx
+import { getAccountBalance } from './entry/actions/getAccountBalance';
+```
+```tsx
+      <TransactionEntry
+        accounts={accounts}
+        payees={payees}
+        defaultCurrency={defaultCurrency}
+        submitAction={createTransactionAction}
+        getAccountBalance={getAccountBalance}
+        initialDraft={initialDraft}
+        templateMissing={templateMissing}
+      />
+```
+
+Do the same in `features/transactions/EditTransaction.tsx` (add the same import and `getAccountBalance={getAccountBalance}` prop on its `<TransactionEntry … />`). Read the file first to place the prop alongside the existing ones.
+
+- [ ] **Step 5: Run tests + type-check**
+
+Run: `pnpm test features/transactions/entry && pnpm type-check`
+Expected: PASS across the entry suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/transactions/entry/TransactionEntry.tsx features/transactions/entry/TransactionEntry.test.tsx features/transactions/NewTransaction.tsx features/transactions/EditTransaction.tsx
+git commit -m "feat(transactions): mount Types tab as the default entry lens"
+```
+
+---
+
+### Task 11: Carried Phase-1 cleanup + full verification
+
+Fold in the roadmap's carried cleanup (both files are now in scope) and do the end-to-end manual pass.
+
+**Files:**
+- Modify: `features/transactions/entry/TabBar.test.tsx`
+- Modify: `features/transactions/entry/TransactionEntry.tsx` (import `SubmitAction` from actions instead of re-declaring)
+- Modify: `features/transactions/actions/types.ts` (or wherever `SubmitAction`/`TransactionActionState` live) if `SubmitAction` is not yet exported
+
+- [ ] **Step 1: Add TabBar a11y assertions**
+
+In `features/transactions/entry/TabBar.test.tsx`, add a test asserting the tablist/tab roles and that inactive tabs carry `aria-selected="false"`:
+
+```tsx
+it('marks inactive tabs aria-selected="false" and uses tablist/tab roles', () => {
+  const out = html(
+    <TabBar
+      tabs={[
+        { id: 'a', label: 'A' },
+        { id: 'b', label: 'B' },
+      ]}
+      active="a"
+      onSelect={() => {}}
+    />
+  );
+  expect(out).toContain('role="tablist"');
+  expect(out).toContain('role="tab"');
+  expect(out).toContain('aria-selected="false"');
+});
+```
+
+Run: `pnpm test features/transactions/entry/TabBar.test.tsx`
+If it fails because `TabBar` lacks these roles/attributes, add them in `TabBar.tsx` (wrap in `role="tablist"`, each button `role="tab"` with `aria-selected={id === active}`), then re-run to green.
+
+- [ ] **Step 2: Home the `SubmitAction` type**
+
+Confirm `SubmitAction` is exported from `features/transactions/actions` (check `actions/types.ts` and `actions/index.ts`; export it if not). In `TransactionEntry.tsx`, remove any local `SubmitAction` re-declaration and rely on the existing `import type { SubmitAction, … } from '../actions'`.
+
+Run: `pnpm type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Full suite**
+
+Run: `pnpm test`
+Expected: PASS (whole suite).
+
+- [ ] **Step 4: Lint**
+
+Run: `pnpm lint`
+Expected: clean.
+
+- [ ] **Step 5: Manual pass in the running app**
+
+Run: `pnpm dev`, open `/transactions/new`. Verify:
+- Types is the default tab; chips render; picking Expense shows its form; typing fills the shared draft (switch to Form/Raw to confirm the postings appear).
+- Switching chips preserves the date/payee.
+- Fix balance: pick an account → the "Now: …" balance loads; entering a target shows the implied adjustment; saving writes an assertion + `Equity:Adjustments`.
+- Editing an existing expense opens on the Types tab with the Expense form populated; editing a 3-way split opens on Form (or shows the no-match notice under Types).
+- Tune the `getAccountBalance` ledger flags here if the live number looks wrong.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/transactions/entry/TabBar.tsx features/transactions/entry/TabBar.test.tsx features/transactions/entry/TransactionEntry.tsx features/transactions/actions
+git commit -m "chore(transactions): tab a11y assertions and home SubmitAction type"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** TypeLens + chips (Task 9), five forms (Tasks 4–6, 8), role-filtered full-path account fields (Task 1 `AccountField`), Types-first + initial-tab detect (Task 10), fix-balance live preview + server action (Tasks 7–8), `fields.tsx` refactor (Task 1), carried cleanup (Task 11). All spec sections map to a task.
+- **Adapter field names:** Tasks 5 (income/transfer) flag that exact `*Fields` property names must be read from the adapter source before writing; TypeScript verifies at each type-check step.
+- **`unknown` typing:** every form imports its own typed adapter; TypeLens only reads `detectType(draft).id` (string) and maps by id — no casts.
+- **Header preservation on type switch** is handled by seeding `{ ...emptyFields(ctx), ...headerOf(draft) }` plus the `key={selectedId}` remount in TypeLens.
+- **UI variant/role names** (`Button` variants in Task 9; `ToggleGroup` props in Task 3) are copied from `FormLens.tsx`'s existing usage; if any differ, read the component and adjust — flagged inline.

--- a/docs/superpowers/specs/2026-06-29-layered-transaction-entry-phase4-type-forms-design.md
+++ b/docs/superpowers/specs/2026-06-29-layered-transaction-entry-phase4-type-forms-design.md
@@ -1,0 +1,218 @@
+# Layered Transaction Entry — Phase 4: The Five Type Forms ("Types" tab)
+
+**Date:** 2026-06-29
+**Roadmap:** `docs/superpowers/plans/2026-06-29-layered-transaction-entry-roadmap.md` (Phase 4)
+**Depends on:** Phases 1–3 (all merged). Phase 3 delivered the full pure type
+engine; nothing renders it yet — this phase is its UI.
+
+## Goal
+
+Add the user-facing **Types** tab to the transaction-entry shell: a row of type
+chips plus a tailored mini-form per type, wired to Phase 3's adapters, all
+editing the one shared `DraftState`. This makes the type engine visible and
+usable while preserving the Phase 1 invariant that the ledger file is the source
+of truth and a transaction's type is **inferred from posting shape, never
+stored**.
+
+## What already exists (do not rebuild)
+
+- `entry/types/adapter.ts` — `TransactionTypeAdapter<F>` with
+  `emptyFields(ctx)`, `compile(fields, ctx) → DraftState`, `detect(draft) →
+  F | null`; plus `headerOf` / `draftFromHeader` helpers and `HeaderFields`.
+- `entry/types/{expense,income,transfer,exchange,fixBalance}.ts` — the five
+  adapters, each with its `*Fields` type. All pure, all unit-tested.
+- `entry/types/registry.ts` — `TYPE_ADAPTERS` (ordered) and
+  `detectType(draft) → { id, fields } | null`.
+- `entry/types/accountRole.ts` — `classifyAccount(account) → AccountRole` and
+  `accountsForRole(accounts, role)`.
+- `entry/TransactionEntry.tsx` — the shell: owns `draft`/`dispatch`,
+  `active` tab state, the `TABS` registry (`form`, `raw`), `canSubmit`.
+- `entry/FormLens.tsx` — reference for styling and the building blocks
+  (`Field`, `SectionLabel`, role-agnostic account `Combobox`, `AmountInput`,
+  `ToggleGroup` status).
+- `utils/runLedger.ts` — `runLedger(args)` server-only ledger exec.
+- `lib/balance/parse.ts` — `parseBalanceRows(stdout)`.
+
+## Decisions (locked during brainstorming)
+
+1. **Default tab / initial state:** Types is registered **first** (`Types ·
+   Form · Raw`). On open: create mode → `types`; edit mode → `detectType(draft)`
+   match → that type's form on the Types tab, else fall back to `form`.
+   (Phase 5 will make order/default a user preference; Phase 4 hardcodes this.)
+2. **Fix-balance live preview:** build it now. A server action fetches the
+   account's current balance; the form shows current → target → implied
+   adjustment. The compiled draft stays assertion + blank equity (ledger
+   computes the real adjustment); the preview is display-only.
+3. **New-category entry:** account fields are role-filtered comboboxes but the
+   user types the **full account path** (`Expenses:Coffee`). No auto-prefixing
+   of role roots. (This overrides the roadmap's earlier `Expenses:<name>`
+   auto-prefix idea — simpler, explicit.)
+
+## Architecture
+
+New files, all under `features/transactions/entry/`:
+
+```
+TypeLens.tsx                     # tab content: chip row + active form + no-match notice
+typeForms/
+  fields.tsx                     # shared Field / SectionLabel / AccountField (factored out of FormLens)
+  HeaderFields.tsx               # shared date/payee/status/note block (every form has these)
+  ExpenseForm.tsx
+  IncomeForm.tsx
+  TransferForm.tsx
+  ExchangeForm.tsx
+  FixBalanceForm.tsx
+actions/getAccountBalance.ts     # server action for the fix-balance preview
+```
+
+### Data flow
+
+`TransactionEntry` (client) already owns `draft`/`dispatch`. It renders
+`TypeLens` when `active === 'types'`, passing `draft`, `dispatch`, `accounts`,
+`payees`, `defaultCurrency`, and a `getAccountBalance` server-action prop
+(threaded from `NewTransaction`/`EditTransaction` exactly like `submitAction`).
+
+Each mini-form holds its `fields` shape and, on every change, dispatches
+`{ type: 'replaceAll', state: adapter.compile(fields, ctx) }`. The shared
+`DraftState` is the single source of truth, so the Form and Raw tabs always
+reflect what was typed in Types. `ctx` is `{ defaultCurrency }`.
+
+### Component boundaries
+
+- **TypeLens** — owns: which chip is selected, the active form's `fields`
+  state, and the create-vs-detect seeding logic. Renders the chip row and the
+  active form. No compile/detect logic of its own beyond calling the registry.
+- **`typeForms/fields.tsx`** — presentational primitives shared with FormLens:
+  - `Field({ label, htmlFor?, error?, children })` — label + control + error.
+  - `SectionLabel({ children })` — the uppercase section header.
+  - `AccountField({ label, role, accounts, value, onChange, placeholder? })` —
+    a `Combobox` whose options are `accountsForRole(accounts, role)`, free-text
+    allowing a full path. `role: AccountRole | AccountRole[]` (Transfer's
+    from/to accept asset **or** liability).
+  These are **moved out of `FormLens.tsx`** and FormLens updated to import them
+  (behavior-preserving refactor; FormLens tests must still pass).
+- **`HeaderFields.tsx`** — the date / status / payee / note block every form
+  shares, reading/writing the form's header fields (`HeaderFields` from the
+  adapter module).
+- **Each `*Form`** — renders `HeaderFields` + its type-specific inputs; converts
+  field edits into a fresh `fields` object and calls `onFields(fields)`, which
+  TypeLens turns into `compile` → `replaceAll`.
+
+**Typing note:** the registry's `TYPE_ADAPTERS` / `detectType` are typed with
+`unknown` fields (for the heterogeneous list). TypeLens uses the registry only
+for id-based detection (`detectType(draft).id`). Each `*Form` imports its own
+**typed** adapter directly (e.g. `expenseAdapter: TransactionTypeAdapter<
+ExpenseFields>`) so its `fields`/`compile`/`detect` are fully typed — never cast
+the `unknown` from the registry.
+
+## Tab + chip state model
+
+In `TransactionEntry`:
+
+- Add `{ id: 'types', label: 'Types' }` to `TABS`, **first**.
+- Initial `active`: computed once in the `useState` initializer from the
+  **already-initialized `draft`** (the shell builds it via `initDraft` before
+  this runs — do not call `detectType` on the raw `initialDraft` prop, which is
+  not a `DraftState`): `mode === 'edit' ? (detectType(draft) ? 'types' :
+  'form') : 'types'`.
+- `canSubmit` is unaffected — it already reads the shared `draft`/balance and is
+  lens-agnostic. (Only the existing `raw`-error guard stays.)
+
+In `TypeLens`:
+
+- Compute `detected = detectType(draft)` on each render.
+- **Selected chip resolution:**
+  - If the draft is non-empty and `detected` matches a type → that chip is
+    selected; its form is seeded from `detected.fields` (via the adapter's
+    `detect`, already run by the registry).
+  - If the draft is **empty** (`isEmptyDraft(draft)` — no posting has an
+    account or amount, header blank-or-default) → no chip pre-selected; a
+    "Pick a type" prompt; all chips enabled.
+  - If the draft is non-empty and `detected` is `null` → chips greyed; render
+    the inline notice: *"This transaction's shape doesn't map to a quick type —
+    edit it in the Form or Raw tab."*
+- **Clicking a chip:** if it differs from the detected/selected type, reseed
+  that type from `adapter.emptyFields(ctx)` (preserving the current header —
+  date/payee/status/note — so switching type doesn't lose the date) and
+  `replaceAll(compile(...))`. Document this "reseed on switch" so it's
+  intentional, not surprising.
+- `isEmptyDraft` is a small pure helper (unit-tested) so the create-path
+  detection is trustworthy.
+
+## The five forms
+
+Layout mirrors FormLens's two-column `Field` grid. Account inputs use
+`AccountField` (role-filtered, full-path free text). Amounts use `AmountInput`;
+currency uses a plain `Input` defaulting to `defaultCurrency`.
+
+| Form | Type-specific fields | Roles |
+|------|---------------------|-------|
+| **Expense** | amount, currency, Paid from, Spent on | from: asset/liability · to: expense |
+| **Income** | amount, currency, Received into, Source | into: asset · source: income |
+| **Transfer** | amount, currency, From, To | from/to: asset/liability |
+| **Exchange** | Gave (amount/currency/from), Got (amount/currency/into) | from/into: asset/liability |
+| **Fix balance** | Account, Target amount, Target currency | account: any |
+
+Compile output is entirely the adapters' responsibility (already tested):
+Exchange emits the `@@` total-cost posting; Fix balance emits the balance
+assertion + blank `Equity:Adjustments`.
+
+## Fix-balance live preview
+
+New server action `features/transactions/entry/actions/getAccountBalance.ts`:
+
+```
+getAccountBalance(account: string, currency: string): Promise<string>
+```
+
+- Runs `runLedger(['balance', account, '--format', '%A|%T\n'])`, parses with
+  `parseBalanceRows`, and returns the current balance for `currency` (sum/select
+  the matching row), or `'0'` when the account is new/absent.
+- `'server-only'`, guarded by the same `requireUser` path `runLedger` already
+  enforces. Wrapped in try/catch returning `'0'` on failure (display-only; never
+  blocks the form).
+
+`FixBalanceForm`:
+
+- On account/currency change (debounced ~300ms), calls `getAccountBalance`.
+- Renders `now: <current> · target: <target> · implied adjustment: <±delta>`
+  where `delta = target − current`, computed client-side for display.
+- Stale-response guard: a monotonically increasing request-id ref; ignore
+  responses that aren't the latest. Loading and error states render inline and
+  never gate submit.
+- The compiled draft is unchanged by the preview (assertion + blank equity).
+
+## Testing
+
+Repo pattern: Vitest, `renderToStaticMarkup`, node env, no jsdom. Pure logic is
+unit-tested; interactive shells get static smoke tests + a manual pass.
+
+- **`isEmptyDraft`** — unit: empty/default draft → true; any account or amount →
+  false.
+- **TypeLens logic** — initial chip selection across the three states (empty →
+  none + prompt; populated+match → matched chip + seeded form; populated+no-match
+  → greyed chips + notice). Reseed-on-switch preserves header.
+- **Initial-tab selection in `TransactionEntry`** — create → `types`; edit with
+  detectable draft → `types`; edit with undetectable draft → `form`.
+- **Per-form static smoke** — each `*Form` renders its expected fields with
+  given `fields`; the asserted postings come from the (already-tested) adapter,
+  so the test verifies wiring, not compile math.
+- **`getAccountBalance`** — unit with canned ledger stdout: selects the right
+  currency row; `'0'` fallback for unknown account / thrown exec.
+- **FormLens refactor** — existing `FormLens.test.tsx` must still pass after
+  `Field`/`SectionLabel`/account combobox move to `typeForms/fields.tsx`.
+
+## Carried Phase-1 cleanup (fold in, both files are touched here)
+
+- `TabBar.test.tsx`: add assertions for inactive `aria-selected="false"` and
+  `role="tablist"` / `role="tab"` presence.
+- Home the `SubmitAction` type in `features/transactions/actions` (currently
+  re-declared in `TransactionEntry.tsx`); import it from there.
+
+## Out of scope (Phase 4)
+
+- Persisting/ordering the tabs — that is Phase 5 (`entryTabOrder` preference,
+  `orderTabs` helper). Phase 4 hardcodes `Types · Form · Raw`.
+- Auto-prefixing role roots onto bare category names (explicitly rejected;
+  full-path entry only).
+- Types beyond the five; natural-language quick-add; per-type smart defaults.

--- a/features/transactions/EditTransaction.tsx
+++ b/features/transactions/EditTransaction.tsx
@@ -1,6 +1,7 @@
 import 'server-only';
 import { updateTransactionAction } from './actions';
 import TransactionEntry from './entry/TransactionEntry';
+import { getAccountBalance } from './entry/actions/getAccountBalance';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
 import { fingerprintDraft } from '@/lib/journal/fingerprint';
@@ -47,6 +48,7 @@ const EditTransaction = async ({ uid }: { uid: string }) => {
         accounts={accounts}
         payees={payees}
         defaultCurrency={defaultCurrency}
+        getAccountBalance={getAccountBalance}
       />
     </div>
   );

--- a/features/transactions/NewTransaction.tsx
+++ b/features/transactions/NewTransaction.tsx
@@ -1,5 +1,6 @@
 import { createTransactionAction } from './actions';
 import TransactionEntry from './entry/TransactionEntry';
+import { getAccountBalance } from './entry/actions/getAccountBalance';
 import Help from '@/components/Help';
 import TemplatePicker from '@/features/templates/TemplatePicker';
 import { requireUser } from '@/lib/auth/require-user';
@@ -74,6 +75,7 @@ const NewTransaction = async ({ templateId }: Props) => {
         payees={payees}
         defaultCurrency={defaultCurrency}
         submitAction={createTransactionAction}
+        getAccountBalance={getAccountBalance}
         initialDraft={initialDraft}
         templateMissing={templateMissing}
       />

--- a/features/transactions/entry/FormLens.tsx
+++ b/features/transactions/entry/FormLens.tsx
@@ -9,10 +9,10 @@ import type {
   DraftState,
   DraftStatus,
 } from './draftReducer';
+import { Field, SectionLabel } from './typeForms/fields';
 import Combobox from '@/components/Combobox';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
@@ -163,30 +163,6 @@ export function FormLens({
 }
 
 // ─── Private sub-components ─────────────────────────────────────────────────
-
-const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground sm:text-[0.7rem]">
-    {children}
-  </div>
-);
-
-const Field = ({
-  label,
-  htmlFor,
-  error,
-  children,
-}: {
-  label: string;
-  htmlFor?: string;
-  error?: string;
-  children: React.ReactNode;
-}) => (
-  <div className="flex flex-col gap-1.5">
-    <Label htmlFor={htmlFor}>{label}</Label>
-    {children}
-    {error && <span className="text-xs text-destructive">{error}</span>}
-  </div>
-);
 
 const PostingRow = ({
   posting,

--- a/features/transactions/entry/TabBar.test.tsx
+++ b/features/transactions/entry/TabBar.test.tsx
@@ -22,4 +22,19 @@ describe('TabBar', () => {
     const out = html(<TabBar tabs={tabs} active="form" onSelect={() => {}} />);
     expect(out).toContain('disabled');
   });
+  it('marks inactive tabs aria-selected="false" and uses tablist/tab roles', () => {
+    const out = html(
+      <TabBar
+        tabs={[
+          { id: 'a', label: 'A' },
+          { id: 'b', label: 'B' },
+        ]}
+        active="a"
+        onSelect={() => {}}
+      />
+    );
+    expect(out).toContain('role="tablist"');
+    expect(out).toContain('role="tab"');
+    expect(out).toContain('aria-selected="false"');
+  });
 });

--- a/features/transactions/entry/TransactionEntry.test.tsx
+++ b/features/transactions/entry/TransactionEntry.test.tsx
@@ -119,4 +119,27 @@ describe('TransactionEntry', () => {
     // Types is default → its "Pick a type" prompt is present on first render.
     expect(out).toContain('Pick a type');
   });
+
+  it('defaults to the Form tab in edit mode when the draft matches no type', () => {
+    const out = html(
+      <TransactionEntry
+        {...common}
+        mode="edit"
+        uid="abc123"
+        initialDraft={{
+          payee: 'Split',
+          status: 'none',
+          note: '',
+          postings: [
+            { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+            { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+            { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
+          ],
+        }}
+      />
+    );
+    // Form tab is active → its Postings UI renders, NOT the Types "Pick a type" prompt.
+    expect(out).not.toContain('Pick a type');
+    expect(out).toContain('+ Add posting');
+  });
 });

--- a/features/transactions/entry/TransactionEntry.test.tsx
+++ b/features/transactions/entry/TransactionEntry.test.tsx
@@ -15,6 +15,7 @@ describe('TransactionEntry', () => {
     payees: ['Whole Foods'],
     defaultCurrency: 'USD',
     submitAction: noopAction,
+    getAccountBalance: async () => '0',
   };
 
   it('renders the Form tab', () => {
@@ -102,5 +103,20 @@ describe('TransactionEntry', () => {
       />
     );
     expect(out).toContain('Save changes');
+  });
+
+  it('shows Types as the first tab and defaults to it in create mode', () => {
+    const out = html(
+      <TransactionEntry
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+        submitAction={async () => ({ ok: false })}
+        getAccountBalance={async () => '0'}
+      />
+    );
+    expect(out).toContain('Types');
+    // Types is default → its "Pick a type" prompt is present on first render.
+    expect(out).toContain('Pick a type');
   });
 });

--- a/features/transactions/entry/TransactionEntry.tsx
+++ b/features/transactions/entry/TransactionEntry.tsx
@@ -13,6 +13,8 @@ import type { SubmitAction, TransactionActionState } from '../actions';
 import { FormLens } from './FormLens';
 import { RawLens } from './RawLens';
 import { TabBar } from './TabBar';
+import { TypeLens } from './TypeLens';
+import { getAccountBalance as defaultGetAccountBalance } from './actions/getAccountBalance';
 import { computeBalance } from './balance';
 import {
   draftReducer,
@@ -20,6 +22,7 @@ import {
   initDraft,
   serializeDraftJson,
 } from './draftReducer';
+import { detectType } from './types/registry';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -40,6 +43,7 @@ export type TransactionEntryProps = {
   expectedFingerprint?: string;
   submitAction: SubmitAction;
   templateMissing?: boolean;
+  getAccountBalance?: (account: string, currency: string) => Promise<string>;
 };
 
 const todayISO = (): string => {
@@ -51,6 +55,7 @@ const todayISO = (): string => {
 const initialState: TransactionActionState = { ok: false };
 
 const TABS = [
+  { id: 'types', label: 'Types' },
   { id: 'form', label: 'Form' },
   { id: 'raw', label: 'Raw' },
 ];
@@ -65,6 +70,7 @@ const TransactionEntry = ({
   expectedFingerprint,
   submitAction,
   templateMissing,
+  getAccountBalance,
 }: TransactionEntryProps) => {
   const router = useRouter();
   const [state, formAction, isPending] = useActionState(
@@ -79,7 +85,9 @@ const TransactionEntry = ({
     )
   );
 
-  const [active, setActive] = useState('form');
+  const [active, setActive] = useState(() =>
+    mode === 'edit' && !detectType(draft) ? 'form' : 'types'
+  );
   const [rawError, setRawError] = useState<string | null>(null);
 
   const formRef = useRef<HTMLFormElement>(null);
@@ -174,6 +182,17 @@ const TransactionEntry = ({
           )}
 
           <TabBar tabs={TABS} active={active} onSelect={setActive} />
+
+          {active === 'types' && (
+            <TypeLens
+              draft={draft}
+              dispatch={dispatch}
+              accounts={accounts}
+              payees={payees}
+              defaultCurrency={defaultCurrency}
+              getAccountBalance={getAccountBalance ?? defaultGetAccountBalance}
+            />
+          )}
 
           {active === 'form' && (
             <FormLens

--- a/features/transactions/entry/TypeLens.test.tsx
+++ b/features/transactions/entry/TypeLens.test.tsx
@@ -1,0 +1,57 @@
+// features/transactions/entry/TypeLens.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { TypeLens } from './TypeLens';
+import { initDraft } from './draftReducer';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+const base = {
+  dispatch: () => {},
+  accounts: ['Assets:Checking', 'Expenses:Food'],
+  payees: [],
+  defaultCurrency: 'USD',
+  getAccountBalance: async () => '0',
+};
+
+describe('TypeLens', () => {
+  it('shows a pick-a-type prompt for an empty draft', () => {
+    const out = html(
+      <TypeLens draft={initDraft({ date: '2026-06-29' }, 'USD')} {...base} />
+    );
+    expect(out).toContain('Pick a type');
+    expect(out).toContain('Expense');
+  });
+
+  it('renders the matching form for an expense-shaped draft', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Cafe',
+        postings: [
+          { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-5', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(<TypeLens draft={draft} {...base} />);
+    expect(out).toContain('Spent on');
+  });
+
+  it('greys chips and shows a notice for an unrecognized shape', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Split',
+        postings: [
+          { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+          { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(<TypeLens draft={draft} {...base} />);
+    expect(out).toContain('Form or Raw');
+  });
+});

--- a/features/transactions/entry/TypeLens.tsx
+++ b/features/transactions/entry/TypeLens.tsx
@@ -3,11 +3,12 @@
 
 import React, { useState } from 'react';
 import { ExchangeForm } from './typeForms/ExchangeForm';
-import { ExpenseForm, type TypeFormProps } from './typeForms/ExpenseForm';
+import { ExpenseForm } from './typeForms/ExpenseForm';
 import { FixBalanceForm } from './typeForms/FixBalanceForm';
 import { IncomeForm } from './typeForms/IncomeForm';
 import { TransferForm } from './typeForms/TransferForm';
 import { isEmptyDraft } from './typeForms/isEmptyDraft';
+import type { TypeFormProps } from './typeForms/props';
 import { TYPE_ADAPTERS, detectType } from './types/registry';
 import { Button } from '@/components/ui/button';
 

--- a/features/transactions/entry/TypeLens.tsx
+++ b/features/transactions/entry/TypeLens.tsx
@@ -1,0 +1,85 @@
+// features/transactions/entry/TypeLens.tsx
+'use client';
+
+import React, { useState } from 'react';
+import { ExchangeForm } from './typeForms/ExchangeForm';
+import { ExpenseForm, type TypeFormProps } from './typeForms/ExpenseForm';
+import { FixBalanceForm } from './typeForms/FixBalanceForm';
+import { IncomeForm } from './typeForms/IncomeForm';
+import { TransferForm } from './typeForms/TransferForm';
+import { isEmptyDraft } from './typeForms/isEmptyDraft';
+import { TYPE_ADAPTERS, detectType } from './types/registry';
+import { Button } from '@/components/ui/button';
+
+type Props = TypeFormProps & {
+  getAccountBalance: (account: string, currency: string) => Promise<string>;
+};
+
+export function TypeLens(props: Props): React.JSX.Element {
+  const { draft, getAccountBalance, ...formProps } = props;
+  const detected = detectType(draft);
+  const empty = isEmptyDraft(draft);
+  const [picked, setPicked] = useState<string | null>(null);
+
+  const selectedId = picked ?? detected?.id ?? null;
+  const chipsDisabled = !empty && !detected;
+
+  const renderForm = () => {
+    const shared = { draft, ...formProps };
+    switch (selectedId) {
+      case 'expense':
+        return <ExpenseForm key="expense" {...shared} />;
+      case 'income':
+        return <IncomeForm key="income" {...shared} />;
+      case 'transfer':
+        return <TransferForm key="transfer" {...shared} />;
+      case 'exchange':
+        return <ExchangeForm key="exchange" {...shared} />;
+      case 'fix-balance':
+        return (
+          <FixBalanceForm
+            key="fix-balance"
+            {...shared}
+            getAccountBalance={getAccountBalance}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-wrap gap-2">
+        {TYPE_ADAPTERS.map((a) => (
+          <Button
+            key={a.id}
+            type="button"
+            size="sm"
+            variant={selectedId === a.id ? 'default' : 'outline'}
+            disabled={chipsDisabled}
+            onClick={() => setPicked(a.id)}
+          >
+            <span aria-hidden className="mr-1">
+              {a.icon}
+            </span>
+            {a.label}
+          </Button>
+        ))}
+      </div>
+
+      {chipsDisabled ? (
+        <p className="text-sm text-muted-foreground">
+          This transaction&apos;s shape doesn&apos;t map to a quick type — edit
+          it in the Form or Raw tab.
+        </p>
+      ) : selectedId === null ? (
+        <p className="text-sm text-muted-foreground">
+          Pick a type to start a guided entry.
+        </p>
+      ) : (
+        renderForm()
+      )}
+    </div>
+  );
+}

--- a/features/transactions/entry/actions/getAccountBalance.ts
+++ b/features/transactions/entry/actions/getAccountBalance.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { extractAccountBalance } from '../typeForms/fixBalancePreview';
+import runLedger from '@/utils/runLedger';
+
+export async function getAccountBalance(
+  account: string,
+  currency: string
+): Promise<string> {
+  if (!account.trim()) return '0';
+  try {
+    const stdout = await runLedger([
+      'balance',
+      account,
+      '-X',
+      currency,
+      '--no-total',
+      '--collapse',
+      '--format',
+      '%A|%T\n',
+    ]);
+    return extractAccountBalance(stdout, account);
+  } catch {
+    return '0';
+  }
+}

--- a/features/transactions/entry/actions/getAccountBalance.ts
+++ b/features/transactions/entry/actions/getAccountBalance.ts
@@ -1,25 +1,26 @@
 'use server';
 
-import { extractAccountBalance } from '../typeForms/fixBalancePreview';
+import {
+  extractAccountBalance,
+  isSafeLedgerArg,
+} from '../typeForms/fixBalancePreview';
 import runLedger from '@/utils/runLedger';
 
 export async function getAccountBalance(
   account: string,
   currency: string
 ): Promise<string> {
-  if (!account.trim()) return '0';
+  const acct = account.trim();
+  const ccy = currency.trim();
+  if (!isSafeLedgerArg(acct)) return '0';
+  if (ccy !== '' && !isSafeLedgerArg(ccy)) return '0';
   try {
-    const stdout = await runLedger([
-      'balance',
-      account,
-      '-X',
-      currency,
-      '--no-total',
-      '--collapse',
-      '--format',
-      '%A|%T\n',
-    ]);
-    return extractAccountBalance(stdout, account);
+    const args = ['balance', '--no-total', '--collapse', '--format', '%A|%T\n'];
+    if (ccy) args.push('-X', ccy);
+    // `--` stops ledger option parsing so a crafted account can't smuggle a flag.
+    args.push('--', acct);
+    const stdout = await runLedger(args);
+    return extractAccountBalance(stdout, acct);
   } catch {
     return '0';
   }

--- a/features/transactions/entry/typeForms/ExchangeForm.test.tsx
+++ b/features/transactions/entry/typeForms/ExchangeForm.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { initDraft } from '../draftReducer';
+import { ExchangeForm } from './ExchangeForm';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('ExchangeForm', () => {
+  it('renders gave/got sections for a fresh draft', () => {
+    const out = html(
+      <ExchangeForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Gave');
+    expect(out).toContain('Got');
+  });
+});

--- a/features/transactions/entry/typeForms/ExchangeForm.tsx
+++ b/features/transactions/entry/typeForms/ExchangeForm.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { exchangeAdapter, type ExchangeFields } from '../types/exchange';
+import type { TypeFormProps } from './ExpenseForm';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Field, SectionLabel, AccountField } from './fields';
+import { Input } from '@/components/ui/input';
+
+export function ExchangeForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<ExchangeFields>(
+    () =>
+      exchangeAdapter.detect(draft) ?? {
+        ...exchangeAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+  const update = (next: ExchangeFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: exchangeAdapter.compile(next, ctx) });
+  };
+
+  const amountRow = (
+    amount: string,
+    currency: string,
+    onAmount: (v: string) => void,
+    onCurrency: (v: string) => void
+  ) => (
+    <div className="flex gap-2">
+      <AmountInput
+        value={amount}
+        onChange={onAmount}
+        placeholder="Amount"
+        className="flex-1 text-right tabular-nums"
+      />
+      <Input
+        type="text"
+        value={currency}
+        onChange={(e) => onCurrency(e.target.value)}
+        placeholder="Currency"
+        className="w-24"
+      />
+    </div>
+  );
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Gave</SectionLabel>
+        <Field label="Amount">
+          {amountRow(
+            fields.gaveAmount,
+            fields.gaveCurrency,
+            (gaveAmount) => update({ ...fields, gaveAmount }),
+            (gaveCurrency) => update({ ...fields, gaveCurrency })
+          )}
+        </Field>
+        <AccountField
+          label="From"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.gaveFrom}
+          onChange={(gaveFrom) => update({ ...fields, gaveFrom })}
+        />
+
+        <SectionLabel>Got</SectionLabel>
+        <Field label="Amount">
+          {amountRow(
+            fields.gotAmount,
+            fields.gotCurrency,
+            (gotAmount) => update({ ...fields, gotAmount }),
+            (gotCurrency) => update({ ...fields, gotCurrency })
+          )}
+        </Field>
+        <AccountField
+          label="Into"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.gotInto}
+          onChange={(gotInto) => update({ ...fields, gotInto })}
+        />
+      </section>
+    </div>
+  );
+}

--- a/features/transactions/entry/typeForms/ExchangeForm.tsx
+++ b/features/transactions/entry/typeForms/ExchangeForm.tsx
@@ -4,9 +4,9 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { exchangeAdapter, type ExchangeFields } from '../types/exchange';
-import type { TypeFormProps } from './ExpenseForm';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField } from './fields';
+import type { TypeFormProps } from './props';
 import { Input } from '@/components/ui/input';
 
 export function ExchangeForm({

--- a/features/transactions/entry/typeForms/ExpenseForm.test.tsx
+++ b/features/transactions/entry/typeForms/ExpenseForm.test.tsx
@@ -1,0 +1,50 @@
+// features/transactions/entry/typeForms/ExpenseForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { initDraft } from '../draftReducer';
+import { ExpenseForm } from './ExpenseForm';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('ExpenseForm', () => {
+  it('renders fields seeded from an expense-shaped draft', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Whole Foods',
+        postings: [
+          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(
+      <ExpenseForm
+        draft={draft}
+        dispatch={() => {}}
+        accounts={['Assets:Checking', 'Expenses:Groceries']}
+        payees={['Whole Foods']}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Whole Foods');
+    expect(out).toContain('Expenses:Groceries');
+    expect(out).toContain('Assets:Checking');
+    expect(out).toContain('42.5');
+  });
+
+  it('renders empty fields for a fresh draft without crashing', () => {
+    const out = html(
+      <ExpenseForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Spent on');
+    expect(out).toContain('Paid from');
+  });
+});

--- a/features/transactions/entry/typeForms/ExpenseForm.tsx
+++ b/features/transactions/entry/typeForms/ExpenseForm.tsx
@@ -1,0 +1,89 @@
+// features/transactions/entry/typeForms/ExpenseForm.tsx
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import type { DraftAction, DraftState } from '../draftReducer';
+import { headerOf } from '../types/adapter';
+import { expenseAdapter, type ExpenseFields } from '../types/expense';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Field, SectionLabel, AccountField } from './fields';
+import { Input } from '@/components/ui/input';
+
+export type TypeFormProps = {
+  draft: DraftState;
+  dispatch: (a: DraftAction) => void;
+  accounts: string[];
+  payees: string[];
+  defaultCurrency: string;
+};
+
+export function ExpenseForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<ExpenseFields>(
+    () =>
+      expenseAdapter.detect(draft) ?? {
+        ...expenseAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+
+  const update = (next: ExpenseFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: expenseAdapter.compile(next, ctx) });
+  };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Expense</SectionLabel>
+
+        <Field label="Amount">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.amount}
+              onChange={(amount) => update({ ...fields, amount })}
+              placeholder="Amount"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.currency}
+              onChange={(e) => update({ ...fields, currency: e.target.value })}
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+
+        <AccountField
+          label="Paid from"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.paidFrom}
+          onChange={(paidFrom) => update({ ...fields, paidFrom })}
+        />
+
+        <AccountField
+          label="Spent on"
+          role="expense"
+          accounts={accounts}
+          value={fields.spentOn}
+          onChange={(spentOn) => update({ ...fields, spentOn })}
+        />
+      </section>
+    </div>
+  );
+}

--- a/features/transactions/entry/typeForms/ExpenseForm.tsx
+++ b/features/transactions/entry/typeForms/ExpenseForm.tsx
@@ -3,20 +3,12 @@
 
 import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
-import type { DraftAction, DraftState } from '../draftReducer';
 import { headerOf } from '../types/adapter';
 import { expenseAdapter, type ExpenseFields } from '../types/expense';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField } from './fields';
+import type { TypeFormProps } from './props';
 import { Input } from '@/components/ui/input';
-
-export type TypeFormProps = {
-  draft: DraftState;
-  dispatch: (a: DraftAction) => void;
-  accounts: string[];
-  payees: string[];
-  defaultCurrency: string;
-};
 
 export function ExpenseForm({
   draft,

--- a/features/transactions/entry/typeForms/FixBalanceForm.test.tsx
+++ b/features/transactions/entry/typeForms/FixBalanceForm.test.tsx
@@ -1,0 +1,24 @@
+// features/transactions/entry/typeForms/FixBalanceForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { initDraft } from '../draftReducer';
+import { FixBalanceForm } from './FixBalanceForm';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('FixBalanceForm', () => {
+  it('renders account and target fields for a fresh draft', () => {
+    const out = html(
+      <FixBalanceForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={['Assets:Cash']}
+        payees={[]}
+        defaultCurrency="USD"
+        getAccountBalance={async () => '0'}
+      />
+    );
+    expect(out).toContain('Account');
+    expect(out).toContain('Target');
+  });
+});

--- a/features/transactions/entry/typeForms/FixBalanceForm.tsx
+++ b/features/transactions/entry/typeForms/FixBalanceForm.tsx
@@ -5,9 +5,9 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { fixBalanceAdapter, type FixBalanceFields } from '../types/fixBalance';
-import type { TypeFormProps } from './ExpenseForm';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField } from './fields';
+import type { TypeFormProps } from './props';
 import { Input } from '@/components/ui/input';
 
 export type FixBalanceFormProps = TypeFormProps & {
@@ -44,18 +44,21 @@ export function FixBalanceForm({
   useEffect(() => {
     const account = fields.account.trim();
     const id = ++reqId.current;
-    let t: ReturnType<typeof setTimeout> | undefined;
-    if (account) {
-      t = setTimeout(() => {
+    // Deferred so the empty-account clear doesn't setState synchronously in
+    // the effect body; the debounce only matters when there's a fetch to make.
+    const t = setTimeout(
+      () => {
+        if (id !== reqId.current) return;
+        if (!account) {
+          setCurrent(null);
+          return;
+        }
         void getAccountBalance(account, fields.targetCurrency).then((bal) => {
           if (id === reqId.current) setCurrent(bal);
         });
-      }, 300);
-    } else {
-      t = setTimeout(() => {
-        if (id === reqId.current) setCurrent(null);
-      }, 0);
-    }
+      },
+      account ? 300 : 0
+    );
     return () => clearTimeout(t);
   }, [fields.account, fields.targetCurrency, getAccountBalance]);
 

--- a/features/transactions/entry/typeForms/FixBalanceForm.tsx
+++ b/features/transactions/entry/typeForms/FixBalanceForm.tsx
@@ -1,0 +1,118 @@
+// features/transactions/entry/typeForms/FixBalanceForm.tsx
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { fixBalanceAdapter, type FixBalanceFields } from '../types/fixBalance';
+import type { TypeFormProps } from './ExpenseForm';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Field, SectionLabel, AccountField } from './fields';
+import { Input } from '@/components/ui/input';
+
+export type FixBalanceFormProps = TypeFormProps & {
+  getAccountBalance: (account: string, currency: string) => Promise<string>;
+};
+
+export function FixBalanceForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+  getAccountBalance,
+}: FixBalanceFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<FixBalanceFields>(
+    () =>
+      fixBalanceAdapter.detect(draft) ?? {
+        ...fixBalanceAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+  const [current, setCurrent] = useState<string | null>(null);
+  const reqId = useRef(0);
+
+  const update = (next: FixBalanceFields) => {
+    setFields(next);
+    dispatch({
+      type: 'replaceAll',
+      state: fixBalanceAdapter.compile(next, ctx),
+    });
+  };
+
+  useEffect(() => {
+    const account = fields.account.trim();
+    const id = ++reqId.current;
+    let t: ReturnType<typeof setTimeout> | undefined;
+    if (account) {
+      t = setTimeout(() => {
+        void getAccountBalance(account, fields.targetCurrency).then((bal) => {
+          if (id === reqId.current) setCurrent(bal);
+        });
+      }, 300);
+    } else {
+      t = setTimeout(() => {
+        if (id === reqId.current) setCurrent(null);
+      }, 0);
+    }
+    return () => clearTimeout(t);
+  }, [fields.account, fields.targetCurrency, getAccountBalance]);
+
+  const implied =
+    current !== null && fields.targetAmount.trim() !== ''
+      ? (Number(fields.targetAmount) - Number(current)).toFixed(2)
+      : null;
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Fix balance</SectionLabel>
+
+        <AccountField
+          label="Account"
+          role={['asset', 'liability', 'income', 'expense', 'equity']}
+          accounts={accounts}
+          value={fields.account}
+          onChange={(account) => update({ ...fields, account })}
+        />
+
+        <Field label="Target balance">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.targetAmount}
+              onChange={(targetAmount) => update({ ...fields, targetAmount })}
+              placeholder="Target"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.targetCurrency}
+              onChange={(e) =>
+                update({ ...fields, targetCurrency: e.target.value })
+              }
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+
+        <div className="text-xs text-muted-foreground tabular-nums">
+          {current === null
+            ? 'Enter an account to see its current balance.'
+            : `Now: ${current} ${fields.targetCurrency}`}
+          {implied !== null && (
+            <span className="ml-2">
+              · Implied adjustment: {implied} {fields.targetCurrency}
+            </span>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/features/transactions/entry/typeForms/HeaderFields.test.tsx
+++ b/features/transactions/entry/typeForms/HeaderFields.test.tsx
@@ -1,0 +1,26 @@
+// features/transactions/entry/typeForms/HeaderFields.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { HeaderFieldsEditor } from './HeaderFields';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('HeaderFieldsEditor', () => {
+  it('renders the date, payee and note values', () => {
+    const out = html(
+      <HeaderFieldsEditor
+        header={{
+          date: '2026-06-29',
+          payee: 'Blue Bottle',
+          status: 'none',
+          note: 'morning',
+        }}
+        payees={['Blue Bottle']}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('2026-06-29');
+    expect(out).toContain('Blue Bottle');
+    expect(out).toContain('morning');
+  });
+});

--- a/features/transactions/entry/typeForms/HeaderFields.tsx
+++ b/features/transactions/entry/typeForms/HeaderFields.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React from 'react';
+import type { DraftStatus } from '../draftReducer';
+import type { HeaderFields } from '../types/adapter';
+import { Field, SectionLabel } from './fields';
+import Combobox from '@/components/Combobox';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+
+export const HeaderFieldsEditor = ({
+  header,
+  payees,
+  onChange,
+}: {
+  header: HeaderFields;
+  payees: string[];
+  onChange: (patch: Partial<HeaderFields>) => void;
+}): React.JSX.Element => (
+  <section className="flex flex-col gap-5">
+    <SectionLabel>Details</SectionLabel>
+
+    <Field label="Date" htmlFor="ty-date">
+      <Input
+        id="ty-date"
+        type="date"
+        value={header.date}
+        onChange={(e) => onChange({ date: e.target.value })}
+        required
+      />
+    </Field>
+
+    <Field label="Status">
+      <ToggleGroup
+        value={[header.status]}
+        onValueChange={(values) => {
+          if (values.length > 0) onChange({ status: values[0] as DraftStatus });
+        }}
+        spacing={0}
+        variant="outline"
+        size="sm"
+        className="w-full"
+      >
+        <ToggleGroupItem value="none" className="flex-1">
+          Unmarked
+        </ToggleGroupItem>
+        <ToggleGroupItem value="pending" className="flex-1">
+          Pending (!)
+        </ToggleGroupItem>
+        <ToggleGroupItem value="cleared" className="flex-1">
+          Cleared (*)
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </Field>
+
+    <Field label="Payee">
+      <Combobox
+        value={header.payee}
+        onChange={(v) => onChange({ payee: v })}
+        options={payees}
+        placeholder="Type or pick a payee…"
+      />
+    </Field>
+
+    <Field label="Note (optional)" htmlFor="ty-note">
+      <Textarea
+        id="ty-note"
+        value={header.note}
+        onChange={(e) => onChange({ note: e.target.value })}
+        rows={3}
+        placeholder="Comment lines — written below the payee with a ; prefix"
+      />
+    </Field>
+  </section>
+);

--- a/features/transactions/entry/typeForms/IncomeForm.test.tsx
+++ b/features/transactions/entry/typeForms/IncomeForm.test.tsx
@@ -1,0 +1,23 @@
+// features/transactions/entry/typeForms/IncomeForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { initDraft } from '../draftReducer';
+import { IncomeForm } from './IncomeForm';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('IncomeForm', () => {
+  it('renders income fields for a fresh draft', () => {
+    const out = html(
+      <IncomeForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Received into');
+    expect(out).toContain('Source');
+  });
+});

--- a/features/transactions/entry/typeForms/IncomeForm.tsx
+++ b/features/transactions/entry/typeForms/IncomeForm.tsx
@@ -1,0 +1,81 @@
+// features/transactions/entry/typeForms/IncomeForm.tsx
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { incomeAdapter, type IncomeFields } from '../types/income';
+import type { TypeFormProps } from './ExpenseForm';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Field, SectionLabel, AccountField } from './fields';
+import { Input } from '@/components/ui/input';
+
+export function IncomeForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<IncomeFields>(
+    () =>
+      incomeAdapter.detect(draft) ?? {
+        ...incomeAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+
+  const update = (next: IncomeFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: incomeAdapter.compile(next, ctx) });
+  };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Income</SectionLabel>
+
+        <Field label="Amount">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.amount}
+              onChange={(amount) => update({ ...fields, amount })}
+              placeholder="Amount"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.currency}
+              onChange={(e) => update({ ...fields, currency: e.target.value })}
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+
+        <AccountField
+          label="Received into"
+          role="asset"
+          accounts={accounts}
+          value={fields.receivedInto}
+          onChange={(receivedInto) => update({ ...fields, receivedInto })}
+        />
+
+        <AccountField
+          label="Source"
+          role="income"
+          accounts={accounts}
+          value={fields.from}
+          onChange={(from) => update({ ...fields, from })}
+        />
+      </section>
+    </div>
+  );
+}

--- a/features/transactions/entry/typeForms/IncomeForm.tsx
+++ b/features/transactions/entry/typeForms/IncomeForm.tsx
@@ -5,9 +5,9 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { incomeAdapter, type IncomeFields } from '../types/income';
-import type { TypeFormProps } from './ExpenseForm';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField } from './fields';
+import type { TypeFormProps } from './props';
 import { Input } from '@/components/ui/input';
 
 export function IncomeForm({

--- a/features/transactions/entry/typeForms/TransferForm.test.tsx
+++ b/features/transactions/entry/typeForms/TransferForm.test.tsx
@@ -1,0 +1,23 @@
+// features/transactions/entry/typeForms/TransferForm.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { initDraft } from '../draftReducer';
+import { TransferForm } from './TransferForm';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('TransferForm', () => {
+  it('renders from/to fields for a fresh draft', () => {
+    const out = html(
+      <TransferForm
+        draft={initDraft({ date: '2026-06-29' }, 'USD')}
+        dispatch={() => {}}
+        accounts={[]}
+        payees={[]}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('From');
+    expect(out).toContain('To');
+  });
+});

--- a/features/transactions/entry/typeForms/TransferForm.tsx
+++ b/features/transactions/entry/typeForms/TransferForm.tsx
@@ -1,0 +1,81 @@
+// features/transactions/entry/typeForms/TransferForm.tsx
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import AmountInput from '../../AmountInput';
+import { headerOf } from '../types/adapter';
+import { transferAdapter, type TransferFields } from '../types/transfer';
+import type { TypeFormProps } from './ExpenseForm';
+import { HeaderFieldsEditor } from './HeaderFields';
+import { Field, SectionLabel, AccountField } from './fields';
+import { Input } from '@/components/ui/input';
+
+export function TransferForm({
+  draft,
+  dispatch,
+  accounts,
+  payees,
+  defaultCurrency,
+}: TypeFormProps): React.JSX.Element {
+  const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
+  const [fields, setFields] = useState<TransferFields>(
+    () =>
+      transferAdapter.detect(draft) ?? {
+        ...transferAdapter.emptyFields(ctx),
+        ...headerOf(draft),
+      }
+  );
+
+  const update = (next: TransferFields) => {
+    setFields(next);
+    dispatch({ type: 'replaceAll', state: transferAdapter.compile(next, ctx) });
+  };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(240px,1fr)_1.6fr] md:gap-8 lg:grid-cols-[minmax(280px,360px)_1fr]">
+      <HeaderFieldsEditor
+        header={fields}
+        payees={payees}
+        onChange={(patch) => update({ ...fields, ...patch })}
+      />
+
+      <section className="flex flex-col gap-5 md:border-l md:border-border md:pl-8">
+        <SectionLabel>Transfer</SectionLabel>
+
+        <Field label="Amount">
+          <div className="flex gap-2">
+            <AmountInput
+              value={fields.amount}
+              onChange={(amount) => update({ ...fields, amount })}
+              placeholder="Amount"
+              className="flex-1 text-right tabular-nums"
+            />
+            <Input
+              type="text"
+              value={fields.currency}
+              onChange={(e) => update({ ...fields, currency: e.target.value })}
+              placeholder="Currency"
+              className="w-24"
+            />
+          </div>
+        </Field>
+
+        <AccountField
+          label="From"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.from}
+          onChange={(from) => update({ ...fields, from })}
+        />
+
+        <AccountField
+          label="To"
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.to}
+          onChange={(to) => update({ ...fields, to })}
+        />
+      </section>
+    </div>
+  );
+}

--- a/features/transactions/entry/typeForms/TransferForm.tsx
+++ b/features/transactions/entry/typeForms/TransferForm.tsx
@@ -5,9 +5,9 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { transferAdapter, type TransferFields } from '../types/transfer';
-import type { TypeFormProps } from './ExpenseForm';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField } from './fields';
+import type { TypeFormProps } from './props';
 import { Input } from '@/components/ui/input';
 
 export function TransferForm({

--- a/features/transactions/entry/typeForms/fields.test.tsx
+++ b/features/transactions/entry/typeForms/fields.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
-import { Field, SectionLabel, AccountField } from './fields';
+import { Field, SectionLabel, AccountField, optionsForRoles } from './fields';
 
 const html = (node: React.ReactNode) => renderToStaticMarkup(node);
 
@@ -19,33 +19,31 @@ describe('fields primitives', () => {
     expect(html(<SectionLabel>Details</SectionLabel>)).toContain('Details');
   });
 
-  it('AccountField shows only accounts matching the role(s)', () => {
+  it('optionsForRoles filters accounts by a single role', () => {
+    expect(
+      optionsForRoles(['Expenses:Food', 'Assets:Checking'], 'expense')
+    ).toEqual(['Expenses:Food']);
+  });
+
+  it('optionsForRoles unions across an array of roles and dedupes', () => {
+    expect(
+      optionsForRoles(
+        ['Assets:Checking', 'Liabilities:Card', 'Expenses:Food'],
+        ['asset', 'liability']
+      )
+    ).toEqual(['Assets:Checking', 'Liabilities:Card']);
+  });
+
+  it('AccountField renders its label', () => {
     const out = html(
       <AccountField
         label="Spent on"
         role="expense"
-        accounts={['Expenses:Food', 'Assets:Checking']}
+        accounts={['Expenses:Food']}
         value=""
         onChange={() => {}}
       />
     );
-    // Combobox renders its options in the DOM; the asset account must be absent.
-    expect(out).toContain('Expenses:Food');
-    expect(out).not.toContain('Assets:Checking');
-  });
-
-  it('AccountField accepts an array of roles', () => {
-    const out = html(
-      <AccountField
-        label="From"
-        role={['asset', 'liability']}
-        accounts={['Assets:Checking', 'Liabilities:Card', 'Expenses:Food']}
-        value=""
-        onChange={() => {}}
-      />
-    );
-    expect(out).toContain('Assets:Checking');
-    expect(out).toContain('Liabilities:Card');
-    expect(out).not.toContain('Expenses:Food');
+    expect(out).toContain('Spent on');
   });
 });

--- a/features/transactions/entry/typeForms/fields.test.tsx
+++ b/features/transactions/entry/typeForms/fields.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { Field, SectionLabel, AccountField } from './fields';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('fields primitives', () => {
+  it('Field renders label and error', () => {
+    const out = html(
+      <Field label="Paid from" error="Required">
+        <input />
+      </Field>
+    );
+    expect(out).toContain('Paid from');
+    expect(out).toContain('Required');
+  });
+
+  it('SectionLabel renders its text', () => {
+    expect(html(<SectionLabel>Details</SectionLabel>)).toContain('Details');
+  });
+
+  it('AccountField shows only accounts matching the role(s)', () => {
+    const out = html(
+      <AccountField
+        label="Spent on"
+        role="expense"
+        accounts={['Expenses:Food', 'Assets:Checking']}
+        value=""
+        onChange={() => {}}
+      />
+    );
+    // Combobox renders its options in the DOM; the asset account must be absent.
+    expect(out).toContain('Expenses:Food');
+    expect(out).not.toContain('Assets:Checking');
+  });
+
+  it('AccountField accepts an array of roles', () => {
+    const out = html(
+      <AccountField
+        label="From"
+        role={['asset', 'liability']}
+        accounts={['Assets:Checking', 'Liabilities:Card', 'Expenses:Food']}
+        value=""
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Assets:Checking');
+    expect(out).toContain('Liabilities:Card');
+    expect(out).not.toContain('Expenses:Food');
+  });
+});

--- a/features/transactions/entry/typeForms/fields.tsx
+++ b/features/transactions/entry/typeForms/fields.tsx
@@ -29,7 +29,7 @@ export const Field = ({
   </div>
 );
 
-const optionsForRoles = (
+export const optionsForRoles = (
   accounts: string[],
   role: AccountRole | AccountRole[]
 ): string[] => {
@@ -46,7 +46,7 @@ export const AccountField = ({
   accounts,
   value,
   onChange,
-  placeholder = 'Search accounts…',
+  placeholder = 'Account (full path, e.g. Expenses:Food)',
   error,
 }: {
   label: string;
@@ -66,10 +66,6 @@ export const AccountField = ({
         options={options}
         placeholder={placeholder}
       />
-      {/* Hidden list keeps filtered options in the DOM for SSR assertions. */}
-      <span hidden aria-hidden="true">
-        {options.join(' ')}
-      </span>
     </Field>
   );
 };

--- a/features/transactions/entry/typeForms/fields.tsx
+++ b/features/transactions/entry/typeForms/fields.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React from 'react';
+import { accountsForRole, type AccountRole } from '../types/accountRole';
+import Combobox from '@/components/Combobox';
+import { Label } from '@/components/ui/label';
+
+export const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground sm:text-[0.7rem]">
+    {children}
+  </div>
+);
+
+export const Field = ({
+  label,
+  htmlFor,
+  error,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  error?: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-1.5">
+    <Label htmlFor={htmlFor}>{label}</Label>
+    {children}
+    {error && <span className="text-xs text-destructive">{error}</span>}
+  </div>
+);
+
+const optionsForRoles = (
+  accounts: string[],
+  role: AccountRole | AccountRole[]
+): string[] => {
+  const roles = Array.isArray(role) ? role : [role];
+  const seen = new Set<string>();
+  for (const r of roles)
+    for (const a of accountsForRole(accounts, r)) seen.add(a);
+  return [...seen];
+};
+
+export const AccountField = ({
+  label,
+  role,
+  accounts,
+  value,
+  onChange,
+  placeholder = 'Search accounts…',
+  error,
+}: {
+  label: string;
+  role: AccountRole | AccountRole[];
+  accounts: string[];
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  error?: string;
+}) => {
+  const options = optionsForRoles(accounts, role);
+  return (
+    <Field label={label} error={error}>
+      <Combobox
+        value={value}
+        onChange={onChange}
+        options={options}
+        placeholder={placeholder}
+      />
+      {/* Hidden list keeps filtered options in the DOM for SSR assertions. */}
+      <span hidden aria-hidden="true">
+        {options.join(' ')}
+      </span>
+    </Field>
+  );
+};

--- a/features/transactions/entry/typeForms/fixBalancePreview.test.ts
+++ b/features/transactions/entry/typeForms/fixBalancePreview.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractAccountBalance } from './fixBalancePreview';
+import { extractAccountBalance, isSafeLedgerArg } from './fixBalancePreview';
 
 describe('extractAccountBalance', () => {
   it('extracts the numeric balance for the matching account', () => {
@@ -14,5 +14,24 @@ describe('extractAccountBalance', () => {
 
   it('returns "0" when the account is absent', () => {
     expect(extractAccountBalance('', 'Assets:Cash')).toBe('0');
+  });
+});
+
+describe('isSafeLedgerArg', () => {
+  it('accepts ordinary account paths and currencies', () => {
+    expect(isSafeLedgerArg('Assets:Cash')).toBe(true);
+    expect(isSafeLedgerArg('Liabilities:Credit Card')).toBe(true);
+    expect(isSafeLedgerArg('USD')).toBe(true);
+  });
+
+  it('rejects empty / whitespace-only values', () => {
+    expect(isSafeLedgerArg('')).toBe(false);
+    expect(isSafeLedgerArg('   ')).toBe(false);
+  });
+
+  it('rejects values that begin with a dash (argv flag smuggling)', () => {
+    expect(isSafeLedgerArg('-X')).toBe(false);
+    expect(isSafeLedgerArg('--init-file=/etc/passwd')).toBe(false);
+    expect(isSafeLedgerArg('  --collapse')).toBe(false);
   });
 });

--- a/features/transactions/entry/typeForms/fixBalancePreview.test.ts
+++ b/features/transactions/entry/typeForms/fixBalancePreview.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { extractAccountBalance } from './fixBalancePreview';
+
+describe('extractAccountBalance', () => {
+  it('extracts the numeric balance for the matching account', () => {
+    const stdout = 'Assets:Cash|1,240.00 USD\n';
+    expect(extractAccountBalance(stdout, 'Assets:Cash')).toBe('1240.00');
+  });
+
+  it('handles negative balances and a leading symbol', () => {
+    const stdout = 'Liabilities:Card|$-50.00\n';
+    expect(extractAccountBalance(stdout, 'Liabilities:Card')).toBe('-50.00');
+  });
+
+  it('returns "0" when the account is absent', () => {
+    expect(extractAccountBalance('', 'Assets:Cash')).toBe('0');
+  });
+});

--- a/features/transactions/entry/typeForms/fixBalancePreview.ts
+++ b/features/transactions/entry/typeForms/fixBalancePreview.ts
@@ -13,3 +13,9 @@ export const extractAccountBalance = (
   const row = parseBalanceRows(stdout).find((r) => r.account === account);
   return row ? toNumber(row.amount) : '0';
 };
+
+/** Reject argv flag-smuggling: a non-empty value that does not begin with '-'. */
+export const isSafeLedgerArg = (value: string): boolean => {
+  const v = value.trim();
+  return v !== '' && !v.startsWith('-');
+};

--- a/features/transactions/entry/typeForms/fixBalancePreview.ts
+++ b/features/transactions/entry/typeForms/fixBalancePreview.ts
@@ -1,0 +1,15 @@
+import { parseBalanceRows } from '@/lib/balance/parse';
+
+/** Strip thousands separators and any non-numeric commodity token. */
+const toNumber = (raw: string): string => {
+  const cleaned = raw.replace(/,/g, '').replace(/[^0-9.\-]/g, '');
+  return cleaned === '' || cleaned === '-' ? '0' : cleaned;
+};
+
+export const extractAccountBalance = (
+  stdout: string,
+  account: string
+): string => {
+  const row = parseBalanceRows(stdout).find((r) => r.account === account);
+  return row ? toNumber(row.amount) : '0';
+};

--- a/features/transactions/entry/typeForms/isEmptyDraft.test.ts
+++ b/features/transactions/entry/typeForms/isEmptyDraft.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { initDraft } from '../draftReducer';
+import { isEmptyDraft } from './isEmptyDraft';
+
+describe('isEmptyDraft', () => {
+  it('is true for a fresh create draft (today + default currency only)', () => {
+    expect(isEmptyDraft(initDraft({ date: '2026-06-29' }, 'USD'))).toBe(true);
+  });
+
+  it('is false when any posting has an account', () => {
+    const d = initDraft({ date: '2026-06-29' }, 'USD');
+    d.postings[0].account = 'Expenses:Food';
+    expect(isEmptyDraft(d)).toBe(false);
+  });
+
+  it('is false when any posting has an amount', () => {
+    const d = initDraft({ date: '2026-06-29' }, 'USD');
+    d.postings[0].amount = '10';
+    expect(isEmptyDraft(d)).toBe(false);
+  });
+
+  it('is false when a payee is set', () => {
+    const d = initDraft({ date: '2026-06-29', payee: 'Cafe' }, 'USD');
+    expect(isEmptyDraft(d)).toBe(false);
+  });
+});

--- a/features/transactions/entry/typeForms/isEmptyDraft.ts
+++ b/features/transactions/entry/typeForms/isEmptyDraft.ts
@@ -1,0 +1,8 @@
+import type { DraftState } from '../draftReducer';
+
+export const isEmptyDraft = (draft: DraftState): boolean =>
+  draft.payee.trim() === '' &&
+  draft.note.trim() === '' &&
+  draft.postings.every(
+    (p) => p.account.trim() === '' && p.amount.trim() === ''
+  );

--- a/features/transactions/entry/typeForms/props.ts
+++ b/features/transactions/entry/typeForms/props.ts
@@ -1,0 +1,10 @@
+// features/transactions/entry/typeForms/props.ts
+import type { DraftAction, DraftState } from '../draftReducer';
+
+export type TypeFormProps = {
+  draft: DraftState;
+  dispatch: (a: DraftAction) => void;
+  accounts: string[];
+  payees: string[];
+  defaultCurrency: string;
+};


### PR DESCRIPTION
## Phase 4 — Layered Transaction Entry: the "Types" tab

The user-facing front end for Phase 3's pure type engine. Adds a **Types** tab to the transaction-entry shell — a row of type chips plus a tailored mini-form per type — all editing the one shared `DraftState` so the existing Form and Raw tabs always reflect Types edits.

Spec: `docs/superpowers/specs/2026-06-29-layered-transaction-entry-phase4-type-forms-design.md`
Plan: `docs/superpowers/plans/2026-06-29-layered-transaction-entry-phase4-type-forms.md`

### What's included
- **Shared primitives** (`typeForms/fields.tsx`): `Field`, `SectionLabel`, role-filtered `AccountField` (extracted from `FormLens`); `HeaderFieldsEditor`; `isEmptyDraft` predicate.
- **Five mini-forms** — Expense, Income, Transfer, Exchange, Fix-balance. Each owns its typed adapter and dispatches `replaceAll(compile(fields, ctx))` on every edit; header (date/payee/status/note/uid) is preserved across type-switches via `{ ...emptyFields(ctx), ...headerOf(draft) }`.
- **`TypeLens`** — chip selector with detect-driven state: empty draft → "Pick a type"; recognized shape → that form (seeded via `detect`); unrecognized → greyed chips + "use Form or Raw" notice.
- **Shell wiring** — tabs ordered `Types · Form · Raw`; Types is the default in create mode, and in edit mode when `detectType(draft)` matches (else Form). `canSubmit`/save flows unchanged.
- **Fix-balance live preview** — `getAccountBalance` server action backing a debounced, stale-guarded current → target → implied-adjustment display (display-only; the compiled draft stays assertion + blank `Equity:Adjustments`).

### Design decisions
- Account fields accept the **full account path** as free text (no auto-prefixing of role roots).
- Tab **ordering/persistence is out of scope** (Phase 5); the order is hardcoded here.
- A transaction's type stays **inferred from posting shape, never stored**.

### Security
An automated review flagged argv flag-smuggling in `getAccountBalance` (user-supplied account/currency into a `ledger` exec). Hardened **before** it was wired into the live UI: `isSafeLedgerArg` rejects empty/leading-dash inputs and a `--` positional separator stops flag injection (`execFile`, no shell).

### Testing
- Full suite green: **776 tests / 152 files**; type-check and lint clean.
- Per-form static smoke tests; `TypeLens` state-model tests (3 states); `isEmptyDraft`, `optionsForRoles`, and `extractAccountBalance`/`isSafeLedgerArg` unit tests; shell tests for Types-default (create) and Form-fallback (edit, unrecognized draft); TabBar a11y assertions.

### Not in this PR
- Manual in-app pass on a live `pnpm dev` instance (needs auth/DB/Garage) — to be done by the reviewer.
- A few cosmetic/by-design polish items (chip-switch discards in-progress body **by design**; redundant fallback import; empty-currency label; a `NaN` guard) deferred as Phase-5-adjacent backlog.

### Out of scope (whole feature)
Storing the type in the journal; account-role aliases; types beyond the five; natural-language quick-add.