### PR TITLE
fix(transactions): currency autocomplete + role-aware account placeholders

### DIFF
--- a/features/transactions/EditTransaction.tsx
+++ b/features/transactions/EditTransaction.tsx
@@ -5,7 +5,7 @@ import { getAccountBalance } from './entry/actions/getAccountBalance';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
 import { fingerprintDraft } from '@/lib/journal/fingerprint';
-import { getBaseCurrency, getEntryTabOrder } from '@/lib/settings';
+import { getAvailableCurrencies, getEntryTabOrder } from '@/lib/settings';
 import {
   getAccountSuggestions,
   getPayeeSuggestions,
@@ -17,8 +17,8 @@ const EditTransaction = async ({ uid }: { uid: string }) => {
   const tx = await journalService.findTransaction(user.id, uid);
   if (!tx) notFound();
 
-  const [defaultCurrency, tabOrder] = await Promise.all([
-    getBaseCurrency(),
+  const [{ currencies, base: defaultCurrency }, tabOrder] = await Promise.all([
+    getAvailableCurrencies(),
     getEntryTabOrder(),
   ]);
   const initialDraft = {
@@ -51,6 +51,7 @@ const EditTransaction = async ({ uid }: { uid: string }) => {
         accounts={accounts}
         payees={payees}
         defaultCurrency={defaultCurrency}
+        currencies={currencies}
         tabOrder={tabOrder}
         getAccountBalance={getAccountBalance}
       />

--- a/features/transactions/NewTransaction.tsx
+++ b/features/transactions/NewTransaction.tsx
@@ -4,7 +4,7 @@ import { getAccountBalance } from './entry/actions/getAccountBalance';
 import Help from '@/components/Help';
 import TemplatePicker from '@/features/templates/TemplatePicker';
 import { requireUser } from '@/lib/auth/require-user';
-import { getBaseCurrency, getEntryTabOrder } from '@/lib/settings';
+import { getAvailableCurrencies, getEntryTabOrder } from '@/lib/settings';
 import { templateRepository } from '@/lib/templates';
 import type { TransactionDraft } from '@/lib/transactions/schema';
 import {
@@ -21,8 +21,8 @@ const NewTransaction = async ({ templateId }: Props) => {
     getPayeeSuggestions(),
     templateRepository.list(user.id),
   ]);
-  const [defaultCurrency, tabOrder] = await Promise.all([
-    getBaseCurrency(),
+  const [{ currencies, base: defaultCurrency }, tabOrder] = await Promise.all([
+    getAvailableCurrencies(),
     getEntryTabOrder(),
   ]);
 
@@ -77,6 +77,7 @@ const NewTransaction = async ({ templateId }: Props) => {
         accounts={accounts}
         payees={payees}
         defaultCurrency={defaultCurrency}
+        currencies={currencies}
         tabOrder={tabOrder}
         submitAction={createTransactionAction}
         getAccountBalance={getAccountBalance}

--- a/features/transactions/entry/FormLens.tsx
+++ b/features/transactions/entry/FormLens.tsx
@@ -9,7 +9,7 @@ import type {
   DraftState,
   DraftStatus,
 } from './draftReducer';
-import { Field, SectionLabel } from './typeForms/fields';
+import { CurrencyCombobox, Field, SectionLabel } from './typeForms/fields';
 import Combobox from '@/components/Combobox';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -22,6 +22,7 @@ type Props = {
   accounts: string[];
   payees: string[];
   defaultCurrency: string;
+  currencies?: string[];
   fieldErrors?: Record<string, string>;
 };
 
@@ -31,6 +32,7 @@ export function FormLens({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
   fieldErrors,
 }: Props): React.JSX.Element {
   const balance = computeBalance(draft.postings);
@@ -130,6 +132,7 @@ export function FormLens({
               key={idx}
               posting={posting}
               accounts={accounts}
+              currencies={currencies}
               canRemove={draft.postings.length > 2}
               onChange={(patch) =>
                 dispatch({ type: 'setPosting', index: idx, patch })
@@ -167,12 +170,14 @@ export function FormLens({
 const PostingRow = ({
   posting,
   accounts,
+  currencies,
   canRemove,
   onChange,
   onRemove,
 }: {
   posting: DraftPosting;
   accounts: string[];
+  currencies: string[];
   canRemove: boolean;
   onChange: (patch: Partial<DraftPosting>) => void;
   onRemove: () => void;
@@ -191,11 +196,10 @@ const PostingRow = ({
         placeholder="Amount"
         className="flex-1 text-right tabular-nums sm:flex-none"
       />
-      <Input
-        type="text"
+      <CurrencyCombobox
         value={posting.currency}
-        onChange={(e) => onChange({ currency: e.target.value })}
-        placeholder="Currency"
+        onChange={(currency) => onChange({ currency })}
+        currencies={currencies}
         className="w-24 sm:w-auto"
       />
       <Button

--- a/features/transactions/entry/TransactionEntry.tsx
+++ b/features/transactions/entry/TransactionEntry.tsx
@@ -40,6 +40,8 @@ export type TransactionEntryProps = {
   accounts: string[];
   payees: string[];
   defaultCurrency: string;
+  /** Commodities already used in the journal, for currency autocomplete. */
+  currencies?: string[];
   mode?: 'create' | 'edit';
   // `date` is optional on the prop so server-side template prefill can omit it
   // and let the client compute today's date in the user's local timezone.
@@ -64,6 +66,7 @@ const TransactionEntry = ({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
   mode,
   initialDraft,
   uid,
@@ -194,6 +197,7 @@ const TransactionEntry = ({
               accounts={accounts}
               payees={payees}
               defaultCurrency={defaultCurrency}
+              currencies={currencies}
               getAccountBalance={getAccountBalance ?? defaultGetAccountBalance}
             />
           )}
@@ -205,6 +209,7 @@ const TransactionEntry = ({
               accounts={accounts}
               payees={payees}
               defaultCurrency={defaultCurrency}
+              currencies={currencies}
               fieldErrors={fieldErrors}
             />
           )}

--- a/features/transactions/entry/typeForms/ExchangeForm.tsx
+++ b/features/transactions/entry/typeForms/ExchangeForm.tsx
@@ -5,9 +5,8 @@ import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { exchangeAdapter, type ExchangeFields } from '../types/exchange';
 import { HeaderFieldsEditor } from './HeaderFields';
-import { Field, SectionLabel, AccountField } from './fields';
+import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
-import { Input } from '@/components/ui/input';
 
 export function ExchangeForm({
   draft,
@@ -15,6 +14,7 @@ export function ExchangeForm({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
 }: TypeFormProps): React.JSX.Element {
   const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
   const [fields, setFields] = useState<ExchangeFields>(
@@ -42,11 +42,10 @@ export function ExchangeForm({
         placeholder="Amount"
         className="flex-1 text-right tabular-nums"
       />
-      <Input
-        type="text"
+      <CurrencyCombobox
         value={currency}
-        onChange={(e) => onCurrency(e.target.value)}
-        placeholder="Currency"
+        onChange={onCurrency}
+        currencies={currencies}
         className="w-24"
       />
     </div>

--- a/features/transactions/entry/typeForms/ExpenseForm.tsx
+++ b/features/transactions/entry/typeForms/ExpenseForm.tsx
@@ -6,9 +6,8 @@ import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { expenseAdapter, type ExpenseFields } from '../types/expense';
 import { HeaderFieldsEditor } from './HeaderFields';
-import { Field, SectionLabel, AccountField } from './fields';
+import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
-import { Input } from '@/components/ui/input';
 
 export function ExpenseForm({
   draft,
@@ -16,6 +15,7 @@ export function ExpenseForm({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
 }: TypeFormProps): React.JSX.Element {
   const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
   const [fields, setFields] = useState<ExpenseFields>(
@@ -50,11 +50,10 @@ export function ExpenseForm({
               placeholder="Amount"
               className="flex-1 text-right tabular-nums"
             />
-            <Input
-              type="text"
+            <CurrencyCombobox
               value={fields.currency}
-              onChange={(e) => update({ ...fields, currency: e.target.value })}
-              placeholder="Currency"
+              onChange={(currency) => update({ ...fields, currency })}
+              currencies={currencies}
               className="w-24"
             />
           </div>

--- a/features/transactions/entry/typeForms/FixBalanceForm.tsx
+++ b/features/transactions/entry/typeForms/FixBalanceForm.tsx
@@ -6,9 +6,8 @@ import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { fixBalanceAdapter, type FixBalanceFields } from '../types/fixBalance';
 import { HeaderFieldsEditor } from './HeaderFields';
-import { Field, SectionLabel, AccountField } from './fields';
+import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
-import { Input } from '@/components/ui/input';
 
 export type FixBalanceFormProps = TypeFormProps & {
   getAccountBalance: (account: string, currency: string) => Promise<string>;
@@ -20,6 +19,7 @@ export function FixBalanceForm({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
   getAccountBalance,
 }: FixBalanceFormProps): React.JSX.Element {
   const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
@@ -93,13 +93,12 @@ export function FixBalanceForm({
               placeholder="Target"
               className="flex-1 text-right tabular-nums"
             />
-            <Input
-              type="text"
+            <CurrencyCombobox
               value={fields.targetCurrency}
-              onChange={(e) =>
-                update({ ...fields, targetCurrency: e.target.value })
+              onChange={(targetCurrency) =>
+                update({ ...fields, targetCurrency })
               }
-              placeholder="Currency"
+              currencies={currencies}
               className="w-24"
             />
           </div>

--- a/features/transactions/entry/typeForms/IncomeForm.tsx
+++ b/features/transactions/entry/typeForms/IncomeForm.tsx
@@ -6,9 +6,8 @@ import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { incomeAdapter, type IncomeFields } from '../types/income';
 import { HeaderFieldsEditor } from './HeaderFields';
-import { Field, SectionLabel, AccountField } from './fields';
+import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
-import { Input } from '@/components/ui/input';
 
 export function IncomeForm({
   draft,
@@ -16,6 +15,7 @@ export function IncomeForm({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
 }: TypeFormProps): React.JSX.Element {
   const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
   const [fields, setFields] = useState<IncomeFields>(
@@ -50,11 +50,10 @@ export function IncomeForm({
               placeholder="Amount"
               className="flex-1 text-right tabular-nums"
             />
-            <Input
-              type="text"
+            <CurrencyCombobox
               value={fields.currency}
-              onChange={(e) => update({ ...fields, currency: e.target.value })}
-              placeholder="Currency"
+              onChange={(currency) => update({ ...fields, currency })}
+              currencies={currencies}
               className="w-24"
             />
           </div>

--- a/features/transactions/entry/typeForms/TransferForm.tsx
+++ b/features/transactions/entry/typeForms/TransferForm.tsx
@@ -6,9 +6,8 @@ import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { transferAdapter, type TransferFields } from '../types/transfer';
 import { HeaderFieldsEditor } from './HeaderFields';
-import { Field, SectionLabel, AccountField } from './fields';
+import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
-import { Input } from '@/components/ui/input';
 
 export function TransferForm({
   draft,
@@ -16,6 +15,7 @@ export function TransferForm({
   accounts,
   payees,
   defaultCurrency,
+  currencies = [],
 }: TypeFormProps): React.JSX.Element {
   const ctx = useMemo(() => ({ defaultCurrency }), [defaultCurrency]);
   const [fields, setFields] = useState<TransferFields>(
@@ -50,11 +50,10 @@ export function TransferForm({
               placeholder="Amount"
               className="flex-1 text-right tabular-nums"
             />
-            <Input
-              type="text"
+            <CurrencyCombobox
               value={fields.currency}
-              onChange={(e) => update({ ...fields, currency: e.target.value })}
-              placeholder="Currency"
+              onChange={(currency) => update({ ...fields, currency })}
+              currencies={currencies}
               className="w-24"
             />
           </div>

--- a/features/transactions/entry/typeForms/fields.test.tsx
+++ b/features/transactions/entry/typeForms/fields.test.tsx
@@ -1,6 +1,12 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
-import { Field, SectionLabel, AccountField, optionsForRoles } from './fields';
+import {
+  Field,
+  SectionLabel,
+  AccountField,
+  optionsForRoles,
+  placeholderForRole,
+} from './fields';
 
 const html = (node: React.ReactNode) => renderToStaticMarkup(node);
 
@@ -45,5 +51,31 @@ describe('fields primitives', () => {
       />
     );
     expect(out).toContain('Spent on');
+  });
+
+  it('placeholderForRole derives a role-appropriate example', () => {
+    expect(placeholderForRole('asset')).toBe('Account, e.g. Assets:Checking');
+    expect(placeholderForRole('income')).toBe('Account, e.g. Income:Salary');
+    expect(placeholderForRole('expense')).toBe('Account, e.g. Expenses:Food');
+  });
+
+  it('placeholderForRole uses the first (primary) role for multi-role fields', () => {
+    expect(placeholderForRole(['asset', 'liability'])).toBe(
+      'Account, e.g. Assets:Checking'
+    );
+  });
+
+  it('AccountField uses the role-derived placeholder when none is passed', () => {
+    const out = html(
+      <AccountField
+        label="Paid from"
+        role={['asset', 'liability']}
+        accounts={[]}
+        value=""
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Assets:Checking');
+    expect(out).not.toContain('Expenses:Food');
   });
 });

--- a/features/transactions/entry/typeForms/fields.tsx
+++ b/features/transactions/entry/typeForms/fields.tsx
@@ -40,13 +40,34 @@ export const optionsForRoles = (
   return [...seen];
 };
 
+const ROLE_EXAMPLE: Record<AccountRole, string> = {
+  asset: 'Assets:Checking',
+  liability: 'Liabilities:CreditCard',
+  income: 'Income:Salary',
+  expense: 'Expenses:Food',
+  equity: 'Equity:Opening Balances',
+  unknown: 'Assets:Checking',
+};
+
+/**
+ * Builds a placeholder whose example matches the account role of the field, so
+ * an asset picker doesn't suggest "Expenses:Food". For multi-role fields the
+ * first role wins (it's the primary one — e.g. "asset" for "Paid from").
+ */
+export const placeholderForRole = (
+  role: AccountRole | AccountRole[]
+): string => {
+  const first = (Array.isArray(role) ? role[0] : role) ?? 'unknown';
+  return `Account, e.g. ${ROLE_EXAMPLE[first]}`;
+};
+
 export const AccountField = ({
   label,
   role,
   accounts,
   value,
   onChange,
-  placeholder = 'Account (full path, e.g. Expenses:Food)',
+  placeholder,
   error,
 }: {
   label: string;
@@ -64,8 +85,33 @@ export const AccountField = ({
         value={value}
         onChange={onChange}
         options={options}
-        placeholder={placeholder}
+        placeholder={placeholder ?? placeholderForRole(role)}
       />
     </Field>
   );
 };
+
+/**
+ * Inline currency picker used alongside an amount input. Autocompletes against
+ * the commodities already present in the journal while still accepting any
+ * free-typed ticker.
+ */
+export const CurrencyCombobox = ({
+  value,
+  onChange,
+  currencies,
+  className,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  currencies: string[];
+  className?: string;
+}) => (
+  <Combobox
+    value={value}
+    onChange={onChange}
+    options={currencies}
+    placeholder="Currency"
+    triggerClassName={className}
+  />
+);

--- a/features/transactions/entry/typeForms/props.ts
+++ b/features/transactions/entry/typeForms/props.ts
@@ -7,4 +7,6 @@ export type TypeFormProps = {
   accounts: string[];
   payees: string[];
   defaultCurrency: string;
+  /** Commodities already used in the journal, for currency autocomplete. */
+  currencies?: string[];
 };


### PR DESCRIPTION
## Problem

Two regressions in the typed transaction entry forms (Types tab):

1. **Currency fields had no autocomplete** — they were plain text inputs, unlike the account/payee pickers.
2. **Account placeholders were always `Expenses:Food`** — `AccountField` had a hardcoded default placeholder that no form overrode, so even asset/income/liability pickers suggested an expense account.

## Changes

- **Role-aware placeholders**: `AccountField` now derives its placeholder example from the field's `role` (asset → `Assets:Checking`, income → `Income:Salary`, liability → `Liabilities:CreditCard`, etc.). Multi-role fields use the primary (first) role. Fixing the shared component fixes all five type forms at once.
- **Currency autocomplete**: a new `CurrencyCombobox` (wrapping the existing `Combobox`, free-text still allowed) replaces the plain currency inputs across the type forms and the Form-tab posting rows. It autocompletes against the journal's commodities, threaded from `getAvailableCurrencies()` through `TransactionEntry` → `TypeLens`/`FormLens` → each form.

## Testing

- `pnpm vitest run features/transactions` — 130 passed
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — clean
- Added coverage for the new `placeholderForRole` helper.