### PR TITLE
fix(transactions): theme codemirror raw editor for dark mode

### DIFF
--- a/features/transactions/entry/LedgerEditor.tsx
+++ b/features/transactions/entry/LedgerEditor.tsx
@@ -100,9 +100,58 @@ export function LedgerEditor({
         return false;
       },
     }),
+    // Drive the editor and its autocomplete dropdown off the app's CSS
+    // variables so it tracks the active light/dark theme (the built-in light
+    // theme is disabled via `theme="none"` on the CodeMirror element below).
     EditorView.theme({
-      '&': { fontSize: '0.875rem' },
-      '.cm-content': { fontFamily: 'var(--font-mono, monospace)' },
+      '&': {
+        fontSize: '0.875rem',
+        backgroundColor: 'transparent',
+        color: 'var(--foreground)',
+      },
+      '&.cm-focused': { outline: 'none' },
+      '.cm-content': {
+        fontFamily: 'var(--font-mono, monospace)',
+        caretColor: 'var(--foreground)',
+      },
+      '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--foreground)' },
+      '.cm-selectionBackground, &.cm-focused .cm-selectionBackground, .cm-content ::selection':
+        {
+          backgroundColor:
+            'color-mix(in oklch, var(--foreground) 18%, transparent)',
+        },
+      '.cm-gutters': {
+        backgroundColor: 'transparent',
+        color: 'var(--muted-foreground)',
+        border: 'none',
+      },
+      '.cm-tooltip': {
+        backgroundColor: 'var(--popover)',
+        color: 'var(--popover-foreground)',
+        border: '1px solid var(--border)',
+        borderRadius: '0.5rem',
+        overflow: 'hidden',
+        boxShadow: '0 4px 12px rgb(0 0 0 / 0.15)',
+      },
+      '.cm-tooltip.cm-tooltip-autocomplete > ul': {
+        fontFamily: 'var(--font-mono, monospace)',
+        maxHeight: '12rem',
+      },
+      '.cm-tooltip.cm-tooltip-autocomplete > ul > li': {
+        color: 'var(--popover-foreground)',
+        padding: '3px 8px',
+      },
+      '.cm-tooltip-autocomplete > ul > li[aria-selected]': {
+        backgroundColor: 'var(--accent)',
+        color: 'var(--accent-foreground)',
+      },
+      '.cm-completionMatchedText': {
+        color: 'var(--primary)',
+        textDecoration: 'none',
+        fontWeight: '600',
+      },
+      '.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionMatchedText':
+        { color: 'inherit' },
     }),
     EditorView.contentAttributes.of({
       'aria-label': ariaLabel ?? 'Transaction ledger text',
@@ -131,6 +180,7 @@ export function LedgerEditor({
         <CodeMirror
           value={value}
           onChange={onChange}
+          theme="none"
           extensions={extensions}
           basicSetup={{
             lineNumbers: false,

--- a/lib/ledger/highlight.ts
+++ b/lib/ledger/highlight.ts
@@ -1,19 +1,41 @@
-import { StreamLanguage } from '@codemirror/language';
+import {
+  HighlightStyle,
+  StreamLanguage,
+  syntaxHighlighting,
+} from '@codemirror/language';
 import type { Extension } from '@codemirror/state';
+import { tags as t } from '@lezer/highlight';
 
-/** Minimal ledger tokenizer for highlighting: date, status, account, amount,
- *  comment. Mapped to CodeMirror's default highlight tags. */
-export const ledgerLanguage = (): Extension =>
-  StreamLanguage.define({
-    token(stream) {
-      if (stream.sol() && stream.match(/\d{4}[-/]\d{2}[-/]\d{2}/)) {
-        return 'keyword'; // date
-      }
-      if (stream.match(/^\s*;.*/)) return 'comment';
-      if (stream.match(/[*!](?=\s)/)) return 'operator'; // status marker
-      if (stream.match(/-?\d[\d,]*(?:\.\d+)?/)) return 'number'; // amount
-      if (stream.match(/[A-Za-z][\w-]*(?::[\w-]+)+/)) return 'variableName'; // account
-      stream.next();
-      return null;
-    },
-  });
+/** Minimal ledger tokenizer: date, status, account, amount, comment. */
+const ledgerTokens = StreamLanguage.define({
+  token(stream) {
+    if (stream.sol() && stream.match(/\d{4}[-/]\d{2}[-/]\d{2}/)) {
+      return 'keyword'; // date
+    }
+    if (stream.match(/^\s*;.*/)) return 'comment';
+    if (stream.match(/[*!](?=\s)/)) return 'operator'; // status marker
+    if (stream.match(/-?\d[\d,]*(?:\.\d+)?/)) return 'number'; // amount
+    if (stream.match(/[A-Za-z][\w-]*(?::[\w-]+)+/)) return 'variableName'; // account
+    stream.next();
+    return null;
+  },
+});
+
+// Account text and comments defer to the app's CSS variables so they track the
+// active (light/dark) theme; the date/status/amount accents are picked to read
+// on both backgrounds.
+const ledgerHighlightStyle = HighlightStyle.define([
+  { tag: t.keyword, color: '#8b5cf6' }, // date
+  { tag: t.operator, color: '#d97706' }, // status marker (* / !)
+  { tag: t.number, color: '#16a34a' }, // amount
+  { tag: t.variableName, color: 'var(--foreground)' }, // account
+  { tag: t.comment, color: 'var(--muted-foreground)', fontStyle: 'italic' },
+]);
+
+/** Ledger syntax highlighting: the tokenizer plus a theme-aware highlight
+ *  style. The style is registered without `fallback`, so it takes precedence
+ *  over basicSetup's light-tuned default highlight style. */
+export const ledgerLanguage = (): Extension => [
+  ledgerTokens,
+  syntaxHighlighting(ledgerHighlightStyle),
+];

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
     "@heroicons/react": "^2.2.0",
+    "@lezer/highlight": "^1.2.3",
     "@naeemba/next-starter": "^0.9.0",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.6)
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
       '@naeemba/next-starter':
         specifier: ^0.9.0
         version: 0.9.0(wvllokjzptfeahnr3uauytiw5a)


### PR DESCRIPTION
## Summary

Follow-up to #55: the CodeMirror raw entry editor rendered with a hardcoded light theme, so in dark mode it showed a white box with low-contrast text and an unstyled autocomplete dropdown.

## Fix

- **`LedgerEditor.tsx`** — disable `@uiw/react-codemirror`'s built-in light theme (`theme="none"`) and drive the editor + autocomplete dropdown off the app's CSS variables: transparent editor background (inherits the card), `--foreground` text/caret, themed selection, and a fully styled dropdown (`--popover` / `--popover-foreground` / `--border`, `--accent` for the selected row, `--primary` for matched text). Because those variables flip with the `.dark` class, one theme block now adapts to both modes.
- **`highlight.ts`** — add a `HighlightStyle` so syntax colors aren't the light-tuned CodeMirror defaults. Account text and comments defer to `--foreground` / `--muted-foreground` (theme-tracking); date, status marker, and amount use fixed accents chosen to read on both backgrounds.

Adds `@lezer/highlight` (for the syntax tag references).

## Testing

- `type-check`, `lint`, the editor's focused tests, and a direct `next build` all clean.
- Visual check across light and dark mode recommended (dropdown contrast + selected-row colors).
