### PR TITLE
fix(theme): repair light-mode accent contrast failures

### DIFF
--- a/app/balance/[from]/[to]/page.tsx
+++ b/app/balance/[from]/[to]/page.tsx
@@ -122,7 +122,7 @@ const PeriodBalance = async ({
                   <tr key={index}>
                     <td>
                       <Link
-                        className="block text-fg hover:text-accent"
+                        className="block text-fg hover:text-accent-text"
                         href={`/accounts/${encodeURIComponent(columns[0])}`}
                       >
                         {columns[0]}

--- a/app/balance/page.tsx
+++ b/app/balance/page.tsx
@@ -81,7 +81,7 @@ const Balance = async () => {
                     <tr key={index}>
                       <td>
                         <Link
-                          className="block text-fg hover:text-accent"
+                          className="block text-fg hover:text-accent-text"
                           href={`/accounts/${encodeURIComponent(columns[0])}`}
                         >
                           {columns[0]}

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -74,7 +74,7 @@ const Debts = async () => {
                     <tr key={idx}>
                       <td>
                         <Link
-                          className="block text-fg hover:text-accent"
+                          className="block text-fg hover:text-accent-text"
                           href={`/accounts/${encodeURIComponent(columns[0])}`}
                         >
                           {columns[0]}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,11 @@
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
 
-@custom-variant dark (&:is(.dark *));
+/* Dark mode is OS-driven (no `.dark` toggle exists), so the `dark:` utility
+   variant must follow the same media query the palette flips on — otherwise
+   every `dark:` utility is dead. If a manual theme toggle is ever added, this
+   and the dark palette block below both need a `.dark` selector path. */
+@custom-variant dark (@media (prefers-color-scheme: dark));
 
 @theme inline {
   --color-bg: var(--bg);
@@ -14,6 +18,7 @@
   --color-subtle: var(--subtle);
   --color-accent: var(--accent);
   --color-accent-fg: var(--accent-fg);
+  --color-accent-text: var(--accent-text);
   --color-positive: var(--positive);
   --color-negative: var(--negative);
   --font-heading: var(--font-sans);
@@ -65,8 +70,13 @@
   --card-fg: oklch(22% 0.015 250);
   --border: oklch(0.922 0 0);
   --subtle: oklch(96% 0.006 250);
+  /* --accent is a subtle hover *surface* (near-bg neutral); --accent-fg is the
+     readable text that sits on it (NOT white — that was a 1.09:1 failure). */
   --accent: oklch(0.97 0 0);
-  --accent-fg: oklch(100% 0 0);
+  --accent-fg: oklch(0.205 0 0);
+  /* --accent-text is the vivid brand-accent *text* color (link hovers, etc.),
+     a separate role from the --accent surface; saturated enough to read on bg. */
+  --accent-text: oklch(48% 0.13 165);
   --positive: oklch(50% 0.13 165);
   --negative: oklch(54% 0.18 25);
 
@@ -117,6 +127,7 @@
     --subtle: oklch(25% 0.015 250);
     --accent: oklch(72% 0.14 165);
     --accent-fg: oklch(20% 0.05 165);
+    --accent-text: oklch(72% 0.14 165);
     --positive: oklch(74% 0.14 165);
     --negative: oklch(72% 0.16 25);
 

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -218,7 +218,7 @@ const Dashboard = async () => {
                       <td>{row.payee || '—'}</td>
                       <td>
                         <Link
-                          className="text-fg hover:text-accent"
+                          className="text-fg hover:text-accent-text"
                           href={`/accounts/${encodeURIComponent(row.account)}`}
                         >
                           {row.account}

--- a/features/portfolio/Portfolio.tsx
+++ b/features/portfolio/Portfolio.tsx
@@ -130,7 +130,7 @@ const Portfolio = async () => {
                 <tr key={row.account}>
                   <td>
                     <Link
-                      className="block text-fg hover:text-accent"
+                      className="block text-fg hover:text-accent-text"
                       href={`/accounts/${encodeURIComponent(row.account)}`}
                     >
                       {row.account}

--- a/features/reconcile/Reconcile.tsx
+++ b/features/reconcile/Reconcile.tsx
@@ -81,7 +81,7 @@ const Reconcile = async () => {
                   <td>{row.payee || '—'}</td>
                   <td>
                     <Link
-                      className="text-fg hover:text-accent"
+                      className="text-fg hover:text-accent-text"
                       href={`/accounts/${encodeURIComponent(row.account)}`}
                     >
                       {row.account}


### PR DESCRIPTION
## Summary

Audit of the light/dark palette surfaced three contrast problems, all in light mode and all confirmed with measured WCAG ratios (oklch → sRGB → relative luminance). The rest of the palette already passes AA in both themes.

## Issues fixed

**1. White text on a near-white accent surface — 1.09:1 (FAIL)**
Light `--accent-fg` was pure white sitting on the `.97` neutral `--accent` surface. Every `bg-accent text-accent-foreground` consumer was effectively invisible in light mode: the active entry tab, the sidebar logo badge, dropdown/select focused rows, and the CodeMirror selected autocomplete row. Set `--accent-fg` to a dark value → **16.4:1**. Dark mode already paired correctly and is unchanged.

**2. `--accent` overloaded as both a surface and a text color — 1.04:1 (FAIL)**
`hover:text-accent` link hovers rendered the `.97` gray *as text* on the page background — invisible in light. The token was doing double duty: a subtle hover **surface** (needs near-bg neutral) and a vivid brand **text** color (needs saturation). Split out a dedicated `--accent-text` token that flips per theme, and pointed the six link hovers at it → **5.6:1 light / 8.2:1 dark**.

**3. Dead `dark:` utilities**
The `dark:` variant keyed off a `.dark` class that never exists — dark mode is OS-driven via `@media (prefers-color-scheme: dark)`. Every `dark:` override in the shadcn primitives (input/button/select/textarea/dropdown) was dead. Pointed the variant at the same media query so they activate with the OS theme. Verified in the built CSS that these now emit inside the dark media block.

## Files

- `app/globals.css` — `dark:` variant → media query; `--accent-fg` light value; new `--accent-text` token (+ `@theme inline` mapping)
- 6 pages/features — `hover:text-accent` → `hover:text-accent-text`

## Verification

- Recomputed all affected pairs: 1.09→16.4, 1.04→5.6 (light) / 8.2 (dark)
- `pnpm lint`, `tsc --noEmit`, and `next build` all pass
- Confirmed in compiled CSS: `text-accent-text` utility emitted, and `dark:` utilities now compile under `@media (prefers-color-scheme:dark)`

Not yet eyeballed in a browser — changes are CSS-variable/token level and verified by math + build output.

## Note

Because the `dark:` variant now follows the OS media query, the app stays OS-locked (as it already was). A future manual light/dark toggle would need a `.dark` selector path on both the variant and the dark palette block — flagged in a comment at the change site.