### PR TITLE
fix(crypto): stop unlock redirect loop on prefetch RSC requests

### DIFF
--- a/components/crypto/CryptoGate.test.ts
+++ b/components/crypto/CryptoGate.test.ts
@@ -54,6 +54,14 @@ describe('CryptoGate', () => {
     expect(redirectMock).not.toHaveBeenCalled();
   });
 
+  it('redirects an unset user to /crypto/setup on a real navigation', async () => {
+    setHeaders({ 'x-pathname': '/dashboard', 'RSC': '1' });
+    cryptoStatus.mockResolvedValue('unset');
+    const { CryptoGate } = await import('./CryptoGate');
+    await expect(CryptoGate()).rejects.toThrow('NEXT_REDIRECT');
+    expect(redirectMock).toHaveBeenCalledWith('/crypto/setup');
+  });
+
   it('does NOT redirect an unset user on a prefetch request', async () => {
     setHeaders({ 'x-pathname': '/dashboard', 'purpose': 'prefetch' });
     cryptoStatus.mockResolvedValue('unset');

--- a/components/crypto/CryptoGate.test.ts
+++ b/components/crypto/CryptoGate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const headerStore = new Map<string, string>();
+const redirectMock = vi.fn((_dest: string): never => {
+  // Mirror Next's redirect(), which throws to halt rendering.
+  throw new Error('NEXT_REDIRECT');
+});
+const getOptionalUser = vi.fn();
+const cryptoStatus = vi.fn();
+
+vi.mock('next/headers', () => ({
+  headers: async () => new Headers(Object.fromEntries(headerStore)),
+}));
+vi.mock('next/navigation', () => ({
+  redirect: (dest: string) => redirectMock(dest),
+}));
+vi.mock('@/lib/auth/require-user', () => ({
+  getOptionalUser: () => getOptionalUser(),
+}));
+vi.mock('@/lib/crypto/gate', () => ({
+  cryptoStatus: (id: string) => cryptoStatus(id),
+}));
+
+const setHeaders = (h: Record<string, string>) => {
+  headerStore.clear();
+  for (const [k, v] of Object.entries(h)) headerStore.set(k, v);
+};
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  getOptionalUser.mockReset();
+  cryptoStatus.mockReset();
+  getOptionalUser.mockResolvedValue({ id: 'u1', email: 'u@e.co' });
+});
+
+describe('CryptoGate', () => {
+  it('redirects a locked user to /crypto/unlock on a real navigation', async () => {
+    setHeaders({ 'x-pathname': '/dashboard', 'RSC': '1' });
+    cryptoStatus.mockResolvedValue('locked');
+    const { CryptoGate } = await import('./CryptoGate');
+    await expect(CryptoGate()).rejects.toThrow('NEXT_REDIRECT');
+    expect(redirectMock).toHaveBeenCalledWith('/crypto/unlock');
+  });
+
+  it('does NOT redirect a locked user on a prefetch request (avoids the _rsc storm)', async () => {
+    setHeaders({
+      'x-pathname': '/dashboard',
+      'RSC': '1',
+      'next-router-prefetch': '1',
+    });
+    cryptoStatus.mockResolvedValue('locked');
+    const { CryptoGate } = await import('./CryptoGate');
+    await expect(CryptoGate()).resolves.toBeNull();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT redirect an unset user on a prefetch request', async () => {
+    setHeaders({ 'x-pathname': '/dashboard', 'purpose': 'prefetch' });
+    cryptoStatus.mockResolvedValue('unset');
+    const { CryptoGate } = await import('./CryptoGate');
+    await expect(CryptoGate()).resolves.toBeNull();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on the unlock page itself', async () => {
+    setHeaders({ 'x-pathname': '/crypto/unlock' });
+    cryptoStatus.mockResolvedValue('locked');
+    const { CryptoGate } = await import('./CryptoGate');
+    await expect(CryptoGate()).resolves.toBeNull();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/components/crypto/CryptoGate.tsx
+++ b/components/crypto/CryptoGate.tsx
@@ -1,6 +1,7 @@
 import { isAuthPath } from '@/components/AppShell/authPaths';
 import { isCryptoPath } from '@/components/AppShell/cryptoPaths';
 import { isPublicPath } from '@/components/AppShell/publicPaths';
+import { isPrefetchRequest } from '@/components/crypto/isPrefetchRequest';
 import { getOptionalUser } from '@/lib/auth/require-user';
 import { cryptoStatus } from '@/lib/crypto/gate';
 import { headers } from 'next/headers';
@@ -10,7 +11,8 @@ import { redirect } from 'next/navigation';
  * users to /crypto/unlock. No-op on auth/public/crypto paths. Correctness is
  * still backstopped by LockedError at the data layer. */
 export async function CryptoGate() {
-  const pathname = (await headers()).get('x-pathname') ?? '';
+  const h = await headers();
+  const pathname = h.get('x-pathname') ?? '';
   if (
     !pathname ||
     isAuthPath(pathname) ||
@@ -21,6 +23,16 @@ export async function CryptoGate() {
   }
   const user = await getOptionalUser();
   if (!user) return null; // proxy already redirects unauthenticated users
+
+  // A prefetch RSC request that receives a redirect is retried by the App
+  // Router in a tight loop (vercel/next.js#48438). After a deploy drops the
+  // in-RAM DEK, every route bounces to /crypto/unlock, so prefetched nav links
+  // (sidebar/header) would replay that redirect endlessly — the `unlock?_rsc`
+  // storm + blank screen the user sees. Never redirect a prefetch; the real
+  // navigation or full reload that follows redirects normally, and the data
+  // layer's LockedError is the hard backstop regardless.
+  if (isPrefetchRequest(h)) return null;
+
   const status = await cryptoStatus(user.id);
   if (status === 'unset') redirect('/crypto/setup');
   if (status === 'locked') redirect('/crypto/unlock');

--- a/components/crypto/isPrefetchRequest.test.ts
+++ b/components/crypto/isPrefetchRequest.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isPrefetchRequest } from './isPrefetchRequest';
+
+const h = (init: Record<string, string>) => new Headers(init);
+
+describe('isPrefetchRequest', () => {
+  it('detects the next-router-prefetch header', () => {
+    expect(isPrefetchRequest(h({ 'next-router-prefetch': '1' }))).toBe(true);
+  });
+
+  it('detects the purpose: prefetch header (case-insensitive)', () => {
+    expect(isPrefetchRequest(h({ purpose: 'prefetch' }))).toBe(true);
+    expect(isPrefetchRequest(h({ Purpose: 'Prefetch' }))).toBe(true);
+  });
+
+  it('is false for a real navigation RSC request (RSC set, no prefetch markers)', () => {
+    expect(isPrefetchRequest(h({ RSC: '1' }))).toBe(false);
+  });
+
+  it('is false for a plain document request', () => {
+    expect(isPrefetchRequest(h({}))).toBe(false);
+  });
+
+  it('ignores a non-1 next-router-prefetch value', () => {
+    expect(isPrefetchRequest(h({ 'next-router-prefetch': '0' }))).toBe(false);
+  });
+});

--- a/components/crypto/isPrefetchRequest.ts
+++ b/components/crypto/isPrefetchRequest.ts
@@ -1,0 +1,18 @@
+/**
+ * True when the incoming request is a Next.js App Router *prefetch* RSC request
+ * rather than a real navigation or a full document load.
+ *
+ * The server gate must never `redirect()` on a prefetch: the App Router retries
+ * a prefetch that receives a redirect in a tight loop (vercel/next.js#48438),
+ * which — once the in-RAM DEK is dropped on deploy and every route bounces to
+ * `/crypto/unlock` — turns into a storm of `/crypto/unlock?_rsc=` requests and a
+ * blank screen. Real navigations and full reloads carry neither header, so they
+ * still redirect normally.
+ *
+ * Two signals are checked because `next-router-prefetch` is not reliably present
+ * on every prefetch (vercel/next.js#85836); `purpose: prefetch` covers the rest.
+ * Header lookups are case-insensitive via the Headers API.
+ */
+export const isPrefetchRequest = (headers: Headers): boolean =>
+  headers.get('next-router-prefetch') === '1' ||
+  headers.get('purpose')?.toLowerCase() === 'prefetch';


### PR DESCRIPTION
## Problem

After a deploy, the journal locks (the in-RAM DEK is dropped on server restart — expected) and the user sees a **storm of `/crypto/unlock?_rsc=` requests and a blank screen**. A hard refresh recovers and lands on the unlock page.

## Root cause

`CryptoGate` is mounted in the root `app/layout.tsx` and calls `redirect('/crypto/unlock')` when locked. On deploy every user becomes locked, so every protected route bounces to unlock. The sidebar/header nav `<Link>`s prefetch by default, and **the App Router retries a prefetch that receives a redirect in a tight loop** ([vercel/next.js#48438](https://github.com/vercel/next.js/issues/48438)) — hence the `_rsc` storm + white screen. A full reload works because it's a normal 307, not an RSC prefetch.

The earlier wordmark `prefetch={false}` fix (96f1c13) only covered two links on the unlock/setup pages, not the app-wide nav.

## Fix

Never `redirect()` on a prefetch. New `isPrefetchRequest` helper detects prefetches via `next-router-prefetch: 1` **or** `purpose: prefetch` (both, since [#85836](https://github.com/vercel/next.js/issues/85836) reports the first is sometimes missing). `CryptoGate` returns `null` on a prefetch and only redirects on real navigations / full loads. The data layer's `LockedError` remains the hard backstop. One fix point covers all prefetchable links without degrading prefetch perf for unlocked users.

## Tests

- New unit tests: gate redirects on real navigation, stays silent on prefetch; `isPrefetchRequest` header matrix.
- Full suite green (840 tests), lint + type-check clean.

## Verification note

Root cause is grounded in the Next.js issue tracker and the existing in-code comment that already diagnosed this class of bug; logic is unit-tested. The production storm was **not** reproduced end-to-end (needs a prod build + mid-session restart).