### PR TITLE
fix(review): A2 — carry cost/assertion through save-as-template

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -30,6 +30,7 @@
 > | Item | Status | PR | Branch | Date |
 > |---|---|---|---|---|
 > | A1 | ✅ DONE | [#62](https://github.com/naeemba/ledger-cli-ui/pull/62) | `fix/review-a1-edit-cost-assertion` | 2026-07-03 |
+> | A2 | ✅ DONE | [#63](https://github.com/naeemba/ledger-cli-ui/pull/63) | `fix/review-a2-template-cost-assertion` | 2026-07-03 |
 
 A complete, implementation-ready review of ledger-cli-ui covering performance, correctness, error handling, architecture, UX consistency, and dead code. **Security was deliberately excluded** (covered by a separate review). Test files were not reviewed.
 
@@ -92,7 +93,7 @@ postings: tx.postings.map((p) => ({
 
 ### A2. Save-as-template from a transaction row silently drops @@ cost and = assertion annotations
 
-**Status:** 🚧 IN PROGRESS — `fix/review-a2-template-cost-assertion`
+**Status:** ✅ DONE — [PR #63](https://github.com/naeemba/ledger-cli-ui/pull/63) (`fix/review-a2-template-cost-assertion`) — 2026-07-03. `TransactionRow`'s posting shape now carries optional `cost`/`assertion` (`features/transactions/transactionRow.ts`), and both `toTransactionRow` and `toTemplateDraft` pass the annotations through, so a `@@`-balanced multi-currency transaction saved as a template hydrates back into a balanced, submittable draft. `toTemplateDraft` was moved out of the `RowActions` client component into the pure `transactionRow` module so it is unit-testable; `transactionRow.test.ts` pins cost and assertion round-tripping through both mappers. (A1's `transactionToDraft` covers the edit path; A3/A4 remain for the live-draft save and template-hydration hops.)
 
 **Severity:** HIGH · **Effort:** M (half day) · **Location:** `features/transactions/RowActions.tsx:27`
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -92,6 +92,8 @@ postings: tx.postings.map((p) => ({
 
 ### A2. Save-as-template from a transaction row silently drops @@ cost and = assertion annotations
 
+**Status:** 🚧 IN PROGRESS — `fix/review-a2-template-cost-assertion`
+
 **Severity:** HIGH · **Effort:** M (half day) · **Location:** `features/transactions/RowActions.tsx:27`
 
 postingSchema (lib/transactions/schema.ts:91-92) declares optional `cost` and `assertion` fields and templateDraftSchema reuses postingSchema, so templates can legally carry these annotations. But toTemplateDraft maps postings to only {account, amount, currency}, so saving a transaction containing `@@` cost or `=` assertion postings as a template silently loses them. For a multi-currency transaction balanced via `@@` cost, the resulting template hydrates into a draft that fails computeBalance (postings no longer sum to zero per currency), leaving the Save buttons disabled — the template is unusable for its primary purpose without manual repair in the raw tab. Root cause is upstream: TransactionRow itself strips the fields (features/transactions/transactionRow.ts:7 `postings: Array<{ account: string; amount: string; currency: string }>`), so the row type must be widened too.

--- a/features/transactions/RowActions.tsx
+++ b/features/transactions/RowActions.tsx
@@ -4,7 +4,7 @@ import { MoreHorizontal, Pencil, Trash2, BookmarkPlus } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { deleteTransactionAction } from './actions';
-import type { TransactionRow } from './transactionRow';
+import { toTemplateDraft, type TransactionRow } from './transactionRow';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { Button } from '@/components/ui/button';
 import {
@@ -15,21 +15,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { SaveAsTemplateDialog } from '@/features/templates/SaveAsTemplateButton';
-import type { TemplateDraft } from '@/lib/templates/schema';
 import { useRouter } from 'next/navigation';
 
 type Props = { transaction: TransactionRow };
-
-const toTemplateDraft = (t: TransactionRow): TemplateDraft => ({
-  payee: t.payee,
-  status: t.status,
-  note: t.note ?? undefined,
-  postings: t.postings.map((p) => ({
-    account: p.account,
-    amount: p.amount,
-    currency: p.currency,
-  })),
-});
 
 const RowActions = ({ transaction: t }: Props) => {
   const router = useRouter();

--- a/features/transactions/carryAnnotations.util.ts
+++ b/features/transactions/carryAnnotations.util.ts
@@ -1,0 +1,19 @@
+import type { Annotation } from '@/lib/journal/parser';
+
+/**
+ * Carry a posting's cost (`@@`) and balance-assertion (`=`) annotations onto a
+ * mapped posting, omitting each key when absent.
+ *
+ * Every posting mapper (edit draft, raw-block draft, template draft, row view)
+ * must preserve these annotations: they participate in the concurrency
+ * fingerprint and in whether a multi-currency transaction balances to zero.
+ * Dropping one silently breaks a save or an edit, so the idiom lives here once
+ * to keep all mappers in sync.
+ */
+export const carryAnnotations = (p: {
+  cost?: Annotation;
+  assertion?: Annotation;
+}): { cost?: Annotation; assertion?: Annotation } => ({
+  ...(p.cost ? { cost: p.cost } : {}),
+  ...(p.assertion ? { assertion: p.assertion } : {}),
+});

--- a/features/transactions/entry/parsedBlockToDraft.ts
+++ b/features/transactions/entry/parsedBlockToDraft.ts
@@ -1,3 +1,4 @@
+import { carryAnnotations } from '../carryAnnotations.util';
 import type { DraftState } from './draftReducer';
 import type { ParsedBlock } from '@/lib/journal/parser';
 
@@ -22,7 +23,6 @@ export const parsedBlockToDraft = (
     account: p.account,
     amount: p.amount,
     currency: p.currency,
-    ...(p.cost ? { cost: p.cost } : {}),
-    ...(p.assertion ? { assertion: p.assertion } : {}),
+    ...carryAnnotations(p),
   })),
 });

--- a/features/transactions/entry/transactionToDraft.ts
+++ b/features/transactions/entry/transactionToDraft.ts
@@ -1,3 +1,4 @@
+import { carryAnnotations } from '../carryAnnotations.util';
 import type { Transaction } from '@/lib/journal/parser';
 import type { TransactionDraft } from '@/lib/transactions/schema';
 
@@ -24,7 +25,6 @@ export const transactionToDraft = (
     account: p.account,
     amount: p.amount,
     currency: p.currency || defaultCurrency,
-    ...(p.cost ? { cost: p.cost } : {}),
-    ...(p.assertion ? { assertion: p.assertion } : {}),
+    ...carryAnnotations(p),
   })),
 });

--- a/features/transactions/transactionRow.test.ts
+++ b/features/transactions/transactionRow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toTransactionRow } from './transactionRow';
+import { toTransactionRow, toTemplateDraft } from './transactionRow';
 import type { Transaction } from '@/lib/journal/parser';
 
 const sample: Transaction = {
@@ -24,6 +24,20 @@ const sample: Transaction = {
   fingerprint: 'abc',
 };
 
+const withAssertion: Transaction = {
+  ...sample,
+  postings: [
+    { account: 'Assets:Cash', amount: '-5.00', currency: '$' },
+    { account: 'Expenses:Food', amount: '5.00', currency: '$' },
+    {
+      account: 'Assets:Cash',
+      amount: '',
+      currency: '',
+      assertion: { amount: '95.00', currency: '$' },
+    },
+  ],
+};
+
 describe('toTransactionRow', () => {
   it('drops rawBlock and endLine', () => {
     const row = toTransactionRow(sample);
@@ -31,14 +45,30 @@ describe('toTransactionRow', () => {
     expect('endLine' in row).toBe(false);
   });
 
-  it('slims postings to account/amount/currency only', () => {
+  it('carries cost annotations through so they can round-trip', () => {
     const row = toTransactionRow(sample);
     expect(row.postings[0]).toEqual({
       account: 'Expenses:Food',
       amount: '5.00',
       currency: '$',
+      cost: { amount: '1', currency: '€' },
     });
-    expect('cost' in row.postings[0]).toBe(false);
+  });
+
+  it('carries balance-assertion annotations through', () => {
+    const row = toTransactionRow(withAssertion);
+    expect(row.postings[2]).toEqual({
+      account: 'Assets:Cash',
+      amount: '',
+      currency: '',
+      assertion: { amount: '95.00', currency: '$' },
+    });
+  });
+
+  it('omits cost/assertion keys for plain postings', () => {
+    const row = toTransactionRow(sample);
+    expect('cost' in row.postings[1]).toBe(false);
+    expect('assertion' in row.postings[1]).toBe(false);
   });
 
   it('preserves fields the table and row actions consume', () => {
@@ -53,5 +83,43 @@ describe('toTransactionRow', () => {
       note: null,
       fingerprint: 'abc',
     });
+  });
+});
+
+describe('toTemplateDraft', () => {
+  it('carries @@ cost annotations into the template draft', () => {
+    const draft = toTemplateDraft(toTransactionRow(sample));
+    expect(draft.postings[0]).toEqual({
+      account: 'Expenses:Food',
+      amount: '5.00',
+      currency: '$',
+      cost: { amount: '1', currency: '€' },
+    });
+  });
+
+  it('carries = balance assertions into the template draft', () => {
+    const draft = toTemplateDraft(toTransactionRow(withAssertion));
+    expect(draft.postings[2]).toEqual({
+      account: 'Assets:Cash',
+      amount: '',
+      currency: '',
+      assertion: { amount: '95.00', currency: '$' },
+    });
+  });
+
+  it('maps payee, status and note', () => {
+    const draft = toTemplateDraft(
+      toTransactionRow({ ...sample, note: 'morning' })
+    );
+    expect(draft).toMatchObject({
+      payee: 'Coffee',
+      status: 'cleared',
+      note: 'morning',
+    });
+  });
+
+  it('coerces a null note to undefined', () => {
+    const draft = toTemplateDraft(toTransactionRow(sample));
+    expect(draft.note).toBeUndefined();
   });
 });

--- a/features/transactions/transactionRow.ts
+++ b/features/transactions/transactionRow.ts
@@ -1,3 +1,4 @@
+import { carryAnnotations } from './carryAnnotations.util';
 import type { Annotation, Transaction } from '@/lib/journal/parser';
 import type { TemplateDraft } from '@/lib/templates/schema';
 
@@ -27,8 +28,7 @@ export const toTransactionRow = (t: Transaction): TransactionRow => ({
     account: p.account,
     amount: p.amount,
     currency: p.currency,
-    ...(p.cost ? { cost: p.cost } : {}),
-    ...(p.assertion ? { assertion: p.assertion } : {}),
+    ...carryAnnotations(p),
   })),
 });
 
@@ -49,7 +49,6 @@ export const toTemplateDraft = (t: TransactionRow): TemplateDraft => ({
     account: p.account,
     amount: p.amount,
     currency: p.currency,
-    ...(p.cost ? { cost: p.cost } : {}),
-    ...(p.assertion ? { assertion: p.assertion } : {}),
+    ...carryAnnotations(p),
   })),
 });

--- a/features/transactions/transactionRow.ts
+++ b/features/transactions/transactionRow.ts
@@ -1,10 +1,17 @@
-import type { Transaction } from '@/lib/journal/parser';
+import type { Annotation, Transaction } from '@/lib/journal/parser';
+import type { TemplateDraft } from '@/lib/templates/schema';
 
 export type TransactionRow = Omit<
   Transaction,
   'rawBlock' | 'endLine' | 'postings'
 > & {
-  postings: Array<{ account: string; amount: string; currency: string }>;
+  postings: Array<{
+    account: string;
+    amount: string;
+    currency: string;
+    cost?: Annotation;
+    assertion?: Annotation;
+  }>;
 };
 
 export const toTransactionRow = (t: Transaction): TransactionRow => ({
@@ -20,5 +27,29 @@ export const toTransactionRow = (t: Transaction): TransactionRow => ({
     account: p.account,
     amount: p.amount,
     currency: p.currency,
+    ...(p.cost ? { cost: p.cost } : {}),
+    ...(p.assertion ? { assertion: p.assertion } : {}),
+  })),
+});
+
+/**
+ * Build the template draft seeded when saving a transaction row as a template.
+ *
+ * Cost (`@@`) and balance-assertion (`=`) annotations are carried through:
+ * `templateDraftSchema` legally stores them (it reuses `postingSchema`), and a
+ * multi-currency transaction balanced via `@@` cost only sums to zero — so the
+ * hydrated template only submits — when the cost travels with it. Dropping the
+ * annotation would leave the Save buttons permanently disabled.
+ */
+export const toTemplateDraft = (t: TransactionRow): TemplateDraft => ({
+  payee: t.payee,
+  status: t.status,
+  note: t.note ?? undefined,
+  postings: t.postings.map((p) => ({
+    account: p.account,
+    amount: p.amount,
+    currency: p.currency,
+    ...(p.cost ? { cost: p.cost } : {}),
+    ...(p.assertion ? { assertion: p.assertion } : {}),
   })),
 });


### PR DESCRIPTION
## A2 — Save-as-template silently drops `@@` cost and `=` assertion annotations

Saving a transaction row as a template dropped its `@@` cost and `=` balance-assertion annotations. `TransactionRow`'s posting shape was narrowed to `{account, amount, currency}`, and both `toTransactionRow` and `toTemplateDraft` mapped only those three fields — even though `templateDraftSchema` legally stores the annotations (it reuses `postingSchema`).

Impact: a multi-currency transaction balanced via `@@` cost hydrated into a template whose postings no longer summed to zero, so `computeBalance`/`canSubmit` left the Save buttons permanently disabled — the template was unusable for its primary purpose. Assertion-only postings degraded into blank auto-balance rows, silently changing semantics.

### Fix
- Widen the `TransactionRow` posting shape to carry optional `cost`/`assertion`, and pass them through in `toTransactionRow` and `toTemplateDraft`.
- Move `toTemplateDraft` out of the `RowActions` client component into the pure `transactionRow` module so it is unit-testable alongside `toTransactionRow`.
- Regression tests cover cost and assertion round-tripping through both mappers.

### Verification
- `npx vitest run` — 869 passed
- `npx tsc --noEmit` — clean
- `npx eslint` — clean

Tracked in `REVIEW.md` (workstream A, item A2).