### PR TITLE
fix(review): A3 — carry cost/assertion through entry-form save-as-template

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -31,7 +31,7 @@
 > |---|---|---|---|---|
 > | A1 | ✅ DONE | [#62](https://github.com/naeemba/ledger-cli-ui/pull/62) | `fix/review-a1-edit-cost-assertion` | 2026-07-03 |
 > | A2 | ✅ DONE | [#63](https://github.com/naeemba/ledger-cli-ui/pull/63) | `fix/review-a2-template-cost-assertion` | 2026-07-03 |
-| A3 | 🚧 IN PROGRESS | — | `fix/review-a3-entry-template-cost-assertion` | 2026-07-03 |
+| A3 | ✅ DONE | [#64](https://github.com/naeemba/ledger-cli-ui/pull/64) | `fix/review-a3-entry-template-cost-assertion` | 2026-07-03 |
 
 A complete, implementation-ready review of ledger-cli-ui covering performance, correctness, error handling, architecture, UX consistency, and dead code. **Security was deliberately excluded** (covered by a separate review). Test files were not reviewed.
 
@@ -114,7 +114,7 @@ postings: t.postings.map((p) => ({
 
 ### A3. Save-as-template from the entry form also strips cost/assertion from the live draft
 
-**Status:** 🚧 IN PROGRESS — `fix/review-a3-entry-template-cost-assertion`. Extracted the inline `templateDraft` construction into a pure, unit-tested `draftToTemplateDraft(draft)` helper (`features/transactions/entry/draftToTemplateDraft.ts`) that carries each posting's `@@` cost and `=` assertion through the shared `carryAnnotations` idiom (the same helper A1/A2 use), so a cost-balanced multi-currency draft now saves as a balanced, submittable template. `draftToTemplateDraft.test.ts` pins cost/assertion round-tripping plus field trimming. (A4 — template hydration in NewTransaction — remains the last stripping hop.)
+**Status:** ✅ DONE — [PR #64](https://github.com/naeemba/ledger-cli-ui/pull/64) (`fix/review-a3-entry-template-cost-assertion`) — 2026-07-03. Extracted the inline `templateDraft` construction into a pure, unit-tested `draftToTemplateDraft(draft)` helper (`features/transactions/entry/draftToTemplateDraft.ts`) that carries each posting's `@@` cost and `=` assertion through the shared `carryAnnotations` idiom (the same helper A1/A2 use), so a cost-balanced multi-currency draft now saves as a balanced, submittable template. `draftToTemplateDraft.test.ts` pins cost/assertion round-tripping plus field trimming. (A4 — template hydration in NewTransaction — remains the last stripping hop.)
 
 **Severity:** HIGH · **Effort:** S (<1h) · **Location:** `features/transactions/entry/TransactionEntry.tsx:156`
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -31,6 +31,7 @@
 > |---|---|---|---|---|
 > | A1 | ✅ DONE | [#62](https://github.com/naeemba/ledger-cli-ui/pull/62) | `fix/review-a1-edit-cost-assertion` | 2026-07-03 |
 > | A2 | ✅ DONE | [#63](https://github.com/naeemba/ledger-cli-ui/pull/63) | `fix/review-a2-template-cost-assertion` | 2026-07-03 |
+| A3 | 🚧 IN PROGRESS | — | `fix/review-a3-entry-template-cost-assertion` | 2026-07-03 |
 
 A complete, implementation-ready review of ledger-cli-ui covering performance, correctness, error handling, architecture, UX consistency, and dead code. **Security was deliberately excluded** (covered by a separate review). Test files were not reviewed.
 
@@ -112,6 +113,8 @@ postings: t.postings.map((p) => ({
 > **Verifier notes** (independent adversarial check, confidence: high): Confirmed. Parser postings carry optional cost/assertion (lib/journal/parser.ts:30-31), but TransactionRow (features/transactions/transactionRow.ts:7) and toTemplateDraft (features/transactions/RowActions.tsx:27-31) both strip them, while templateDraftSchema (lib/templates/schema.ts, reuses postingSchema) legally stores them. Downstream impact verified: computeBalance/canSubmit (TransactionEntry.tsx:144-150, entry/balance.ts:20-29) rely on p.cost for @@-balanced multi-currency transactions, so the hydrated template is unbalanced and the Save buttons stay disabled. Additionally, assertion-only postings degrade into blank-amount auto-balance postings, silently changing semantics. Suggested fix (widen TransactionRow posting shape and pass fields through both mappers) is correct.
 
 ### A3. Save-as-template from the entry form also strips cost/assertion from the live draft
+
+**Status:** 🚧 IN PROGRESS — `fix/review-a3-entry-template-cost-assertion`. Extracted the inline `templateDraft` construction into a pure, unit-tested `draftToTemplateDraft(draft)` helper (`features/transactions/entry/draftToTemplateDraft.ts`) that carries each posting's `@@` cost and `=` assertion through the shared `carryAnnotations` idiom (the same helper A1/A2 use), so a cost-balanced multi-currency draft now saves as a balanced, submittable template. `draftToTemplateDraft.test.ts` pins cost/assertion round-tripping plus field trimming. (A4 — template hydration in NewTransaction — remains the last stripping hop.)
 
 **Severity:** HIGH · **Effort:** S (<1h) · **Location:** `features/transactions/entry/TransactionEntry.tsx:156`
 

--- a/features/transactions/entry/TransactionEntry.tsx
+++ b/features/transactions/entry/TransactionEntry.tsx
@@ -22,6 +22,7 @@ import {
   initDraft,
   serializeDraftJson,
 } from './draftReducer';
+import { draftToTemplateDraft } from './draftToTemplateDraft';
 import { detectType } from './types/registry';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -149,16 +150,7 @@ const TransactionEntry = ({
     (balanceKind === 'balanced' || balanceKind === 'auto-balance') &&
     !(active === 'raw' && rawError !== null);
 
-  const templateDraft: TemplateDraft = {
-    payee: draft.payee.trim() || '—',
-    status: draft.status,
-    note: draft.note.trim() || undefined,
-    postings: draft.postings.map((p) => ({
-      account: p.account.trim(),
-      amount: p.amount.trim(),
-      currency: p.currency.trim(),
-    })),
-  };
+  const templateDraft: TemplateDraft = draftToTemplateDraft(draft);
   const canSaveTemplate =
     draft.payee.trim() !== '' &&
     draft.postings.filter((p) => p.account.trim() !== '').length >= 2;

--- a/features/transactions/entry/draftToTemplateDraft.test.ts
+++ b/features/transactions/entry/draftToTemplateDraft.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { DraftState } from './draftReducer';
+import { draftToTemplateDraft } from './draftToTemplateDraft';
+
+const baseDraft = (postings: DraftState['postings']): DraftState => ({
+  date: '2024-01-15',
+  payee: 'Coffee Shop',
+  status: 'cleared',
+  note: '',
+  postings,
+});
+
+describe('draftToTemplateDraft', () => {
+  it('trims payee, status, note and postings', () => {
+    const draft = baseDraft([
+      { account: '  Expenses:Food  ', amount: ' 10.00 ', currency: ' USD ' },
+      { account: 'Assets:Cash', amount: '-10.00', currency: 'USD' },
+    ]);
+    draft.note = '  a note  ';
+
+    const result = draftToTemplateDraft(draft);
+
+    expect(result.payee).toBe('Coffee Shop');
+    expect(result.status).toBe('cleared');
+    expect(result.note).toBe('a note');
+    expect(result.postings[0]).toEqual({
+      account: 'Expenses:Food',
+      amount: '10.00',
+      currency: 'USD',
+    });
+  });
+
+  it('carries @@ cost annotations through to the template draft', () => {
+    const draft = baseDraft([
+      {
+        account: 'Assets:USD',
+        amount: '100',
+        currency: 'USD',
+        cost: { currency: 'EUR', amount: '90' },
+      },
+      { account: 'Assets:EUR', amount: '-90', currency: 'EUR' },
+    ]);
+
+    const result = draftToTemplateDraft(draft);
+
+    expect(result.postings[0].cost).toEqual({
+      currency: 'EUR',
+      amount: '90',
+    });
+  });
+
+  it('carries = balance-assertion annotations through to the template draft', () => {
+    const draft = baseDraft([
+      {
+        account: 'Assets:Cash',
+        amount: '10.00',
+        currency: 'USD',
+        assertion: { currency: 'USD', amount: '500.00' },
+      },
+      { account: 'Income:Gift', amount: '-10.00', currency: 'USD' },
+    ]);
+
+    const result = draftToTemplateDraft(draft);
+
+    expect(result.postings[0].assertion).toEqual({
+      currency: 'USD',
+      amount: '500.00',
+    });
+  });
+});

--- a/features/transactions/entry/draftToTemplateDraft.ts
+++ b/features/transactions/entry/draftToTemplateDraft.ts
@@ -1,0 +1,22 @@
+import { carryAnnotations } from '../carryAnnotations.util';
+import type { DraftState } from './draftReducer';
+import type { TemplateDraft } from '@/lib/templates/schema';
+
+/**
+ * Build the `TemplateDraft` saved by "Save as template" from the live entry
+ * draft. Trims text fields and carries each posting's `@@` cost and `=`
+ * balance-assertion annotations through {@link carryAnnotations} — dropping
+ * them would rehydrate a cost-balanced multi-currency template into an
+ * unbalanced, unsubmittable draft.
+ */
+export const draftToTemplateDraft = (draft: DraftState): TemplateDraft => ({
+  payee: draft.payee.trim() || '—',
+  status: draft.status,
+  note: draft.note.trim() || undefined,
+  postings: draft.postings.map((p) => ({
+    account: p.account.trim(),
+    amount: p.amount.trim(),
+    currency: p.currency.trim(),
+    ...carryAnnotations(p),
+  })),
+});


### PR DESCRIPTION
## A3 — Save-as-template from the entry form strips `@@` cost / `=` assertion

### Problem
When building the `TemplateDraft` from the live entry draft, `TransactionEntry` mapped each posting to only `{account, amount, currency}`, silently dropping the `@@` cost and `=` balance-assertion annotations that `DraftPosting` carries and `templateDraftSchema` legally accepts. A multi-currency draft balanced via `@@` cost then rehydrated into a template whose postings no longer sum to zero per currency, leaving the Save buttons disabled — the template was unusable for its primary purpose. This was the second independent stripping site (beyond RowActions / A2).

### Fix
Extracted the inline `templateDraft` construction into a pure, unit-tested `draftToTemplateDraft(draft)` helper (`features/transactions/entry/draftToTemplateDraft.ts`) that carries both annotations through the shared `carryAnnotations` idiom — the same helper the edit (A1) and row (A2) paths already use, keeping all posting mappers in sync. `draftToTemplateDraft.test.ts` pins cost/assertion round-tripping plus field trimming.

A4 (template hydration in `NewTransaction`) remains the last stripping hop in this pipeline.

### Verification
- `npx vitest run` — 872 tests green (3 new)
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean

Refs REVIEW.md item **A3**.