### PR TITLE
fix(review): drop blank posting rows when saving a template (A5)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -34,6 +34,7 @@
 > | A3 | ✅ DONE | [#65](https://github.com/naeemba/ledger-cli-ui/pull/65) | `refactor/txn-model-consolidation` | 2026-07-04 |
 > | A4 | ✅ DONE | [#65](https://github.com/naeemba/ledger-cli-ui/pull/65) | `refactor/txn-model-consolidation` | 2026-07-04 |
 > | G3 | ✅ DONE | [#65](https://github.com/naeemba/ledger-cli-ui/pull/65) | `refactor/txn-model-consolidation` | 2026-07-04 |
+> | A5 | ✅ DONE | [#66](https://github.com/naeemba/ledger-cli-ui/pull/66) | `fix/review-a5-template-blank-rows` | 2026-07-05 |
 
 A complete, implementation-ready review of ledger-cli-ui covering performance, correctness, error handling, architecture, UX consistency, and dead code. **Security was deliberately excluded** (covered by a separate review). Test files were not reviewed.
 
@@ -155,6 +156,8 @@ postings: t.draft.postings.map((p) => ({
 > **Verifier notes** (independent adversarial check, confidence: high): Confirmed as code fact: features/transactions/NewTransaction.tsx:44-48 rebuilds initialDraft postings with only account/amount/currency, discarding cost/assertion that templateDraftSchema permits and DraftPosting supports. However, the finding itself admits it is latent — no current UI writer persists the fields (findings 0/1 strip them first), and templates can only gain annotations via direct action calls. No user-visible impact until the writers are fixed, so severity is low, not medium; it should simply be fixed in the same change set. Suggested spread fix is correct (formatPosting ignores currency on assertion-only postings, so the currency-default override is safe).
 
 ### A5. Blank filler posting rows make 'Save as template' fail with an opaque 'Validation failed.' message
+
+**Status:** ✅ DONE — [PR #66](https://github.com/naeemba/ledger-cli-ui/pull/66) (`fix/review-a5-template-blank-rows`) — 2026-07-05. Fixed at the single template builder: `Transaction.toTemplate()` (`lib/transactions/model.ts`) now drops postings whose account is blank, so the saved shape matches the postings `canSaveTemplate` counted — a two-filled-rows draft with a leftover blank scaffold row saves cleanly instead of returning an opaque `Validation failed.`. As a defensive fallback, `SaveAsTemplateDialog` now surfaces `fieldErrors` via a new pure `saveTemplateErrorMessage(result)` helper (`features/templates/saveTemplateError.ts`) that appends the distinct field messages to the base message, so any remaining validation failure names its cause. Regression tests: `model.test.ts` pins blank-row dropping; `saveTemplateError.test.ts` pins the message composition.
 
 **Severity:** MEDIUM · **Effort:** S (<1h) · **Location:** `features/transactions/entry/TransactionEntry.tsx:162`
 

--- a/features/templates/SaveAsTemplateButton.tsx
+++ b/features/templates/SaveAsTemplateButton.tsx
@@ -4,6 +4,7 @@ import { BookmarkPlus } from 'lucide-react';
 import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
 import { saveTemplateAction } from './actions';
+import { saveTemplateErrorMessage } from './saveTemplateError';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
@@ -54,7 +55,7 @@ export const SaveAsTemplateDialog = ({
       } else if (result.reason === 'name-conflict' && !overwrite) {
         setConflict(true);
       } else {
-        setError(result.message ?? 'Could not save');
+        setError(saveTemplateErrorMessage(result));
       }
     });
   };

--- a/features/templates/saveTemplateError.test.ts
+++ b/features/templates/saveTemplateError.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { saveTemplateErrorMessage } from './saveTemplateError';
+
+describe('saveTemplateErrorMessage', () => {
+  it('returns the bare message when there are no field errors', () => {
+    expect(
+      saveTemplateErrorMessage({
+        ok: false,
+        reason: 'invalid',
+        message: 'Nope',
+      })
+    ).toBe('Nope');
+  });
+
+  it('falls back to a default when no message is present', () => {
+    expect(saveTemplateErrorMessage({ ok: false, reason: 'invalid' })).toBe(
+      'Could not save'
+    );
+  });
+
+  it('appends deduplicated field-error messages so the cause is visible', () => {
+    expect(
+      saveTemplateErrorMessage({
+        ok: false,
+        reason: 'invalid',
+        message: 'Validation failed.',
+        fieldErrors: {
+          'draft.postings.2.account': 'Account is required',
+          'draft.postings.3.account': 'Account is required',
+        },
+      })
+    ).toBe('Validation failed. Account is required');
+  });
+});

--- a/features/templates/saveTemplateError.ts
+++ b/features/templates/saveTemplateError.ts
@@ -1,0 +1,21 @@
+import type { SaveTemplateResult } from './actions/saveTemplate';
+
+type SaveTemplateFailure = Extract<SaveTemplateResult, { ok: false }>;
+
+/**
+ * Human-readable error for a failed template save. The action reports the
+ * offending fields in `fieldErrors` (e.g. a blank posting account), but the
+ * dialog only had room for `message` — leaving the user with a bare
+ * "Validation failed." and no hint. Append the distinct field messages so the
+ * cause is at least named.
+ */
+export const saveTemplateErrorMessage = (
+  result: SaveTemplateFailure
+): string => {
+  const base = result.message ?? 'Could not save';
+  const fieldMessages = result.fieldErrors
+    ? [...new Set(Object.values(result.fieldErrors))]
+    : [];
+  if (fieldMessages.length === 0) return base;
+  return `${base} ${fieldMessages.join(' ')}`;
+};

--- a/lib/transactions/model.test.ts
+++ b/lib/transactions/model.test.ts
@@ -290,4 +290,23 @@ describe('Transaction outputs', () => {
       }).toTemplate().payee
     ).toBe('—');
   });
+
+  it('toTemplate drops blank filler posting rows', () => {
+    const tpl = Transaction.from({
+      date: '',
+      payee: 'Coffee',
+      status: 'none',
+      note: '',
+      postings: [
+        { account: 'Expenses:Food', amount: '10', currency: 'USD' },
+        { account: 'Assets:Cash', amount: '-10', currency: 'USD' },
+        { account: '  ', amount: '', currency: 'USD' },
+      ],
+    }).toTemplate();
+    expect(tpl.postings).toHaveLength(2);
+    expect(tpl.postings.map((p) => p.account)).toEqual([
+      'Expenses:Food',
+      'Assets:Cash',
+    ]);
+  });
 });

--- a/lib/transactions/model.ts
+++ b/lib/transactions/model.ts
@@ -307,11 +307,17 @@ export class Transaction {
   }
 
   toTemplate(): TemplateDraft {
+    // Drop blank filler rows (the default two-row scaffold and leftover "Add
+    // posting" rows) so the saved template matches the postings the entry form
+    // counted as savable — an empty account fails accountSchema and would
+    // otherwise reject the whole template with an opaque "Validation failed."
     return {
       payee: this.payee.trim() || '—',
       status: this.status,
       note: this.note.trim() || undefined,
-      postings: this.postings.map(trimPosting),
+      postings: this.postings
+        .filter((p) => p.account.trim() !== '')
+        .map(trimPosting),
     };
   }
 }


### PR DESCRIPTION
## What & why (REVIEW.md item A5)

Saving a transaction as a template failed with an opaque **"Validation failed."** whenever the draft still carried a blank posting row — the default two-row scaffold or a leftover "Add posting" row. `canSaveTemplate` only counts postings with non-empty accounts (`>= 2`), but `Transaction.toTemplate()` mapped **every** posting into the template. An empty account fails `accountSchema` (`min(1)`), so a draft with two filled rows plus one blank row was rejected server-side while both filled rows looked perfectly valid — a UX dead-end for the feature's primary purpose.

## Fix

- **Root cause** — `Transaction.toTemplate()` (`lib/transactions/model.ts`), the single template builder, now filters out postings whose account is blank, so the saved shape matches what `canSaveTemplate` counted. The other caller (`RowActions`) builds from parsed transactions, which never carry blank accounts, so it is unaffected.
- **Defensive fallback** — `SaveAsTemplateDialog` previously rendered only `result.message` and dropped `fieldErrors` entirely. It now composes the message through a new pure `saveTemplateErrorMessage(result)` helper (`features/templates/saveTemplateError.ts`) that appends the distinct field-error messages, so any remaining validation failure names its cause instead of a bare "Validation failed."

## Tests

- `lib/transactions/model.test.ts` — `toTemplate` drops blank filler posting rows.
- `features/templates/saveTemplateError.test.ts` — message composition (bare message, default fallback, deduplicated field errors).

Full suite green (875 tests), `tsc --noEmit` clean, `eslint` clean.