### PR TITLE
fix(entry): keep guided type form open while its draft is incomplete

### DIFF
--- a/features/transactions/entry/TypeLens.tsx
+++ b/features/transactions/entry/TypeLens.tsx
@@ -7,9 +7,9 @@ import { ExpenseForm } from './typeForms/ExpenseForm';
 import { FixBalanceForm } from './typeForms/FixBalanceForm';
 import { IncomeForm } from './typeForms/IncomeForm';
 import { TransferForm } from './typeForms/TransferForm';
-import { isEmptyDraft } from './typeForms/isEmptyDraft';
 import type { TypeFormProps } from './typeForms/props';
-import { TYPE_ADAPTERS, detectType } from './types/registry';
+import { initialPickForDraft, resolveTypeLensState } from './typeLensState';
+import { TYPE_ADAPTERS } from './types/registry';
 import { Button } from '@/components/ui/button';
 
 type Props = TypeFormProps & {
@@ -18,12 +18,11 @@ type Props = TypeFormProps & {
 
 export function TypeLens(props: Props): React.JSX.Element {
   const { draft, getAccountBalance, ...formProps } = props;
-  const detected = detectType(draft);
-  const empty = isEmptyDraft(draft);
-  const [picked, setPicked] = useState<string | null>(null);
+  const [picked, setPicked] = useState<string | null>(() =>
+    initialPickForDraft(draft)
+  );
 
-  const selectedId = picked ?? detected?.id ?? null;
-  const chipsDisabled = !empty && !detected;
+  const { selectedId, chipsDisabled } = resolveTypeLensState(draft, picked);
 
   const renderForm = () => {
     const shared = { draft, ...formProps };

--- a/features/transactions/entry/typeLensState.test.ts
+++ b/features/transactions/entry/typeLensState.test.ts
@@ -1,0 +1,99 @@
+// features/transactions/entry/typeLensState.test.ts
+import { describe, it, expect } from 'vitest';
+import { initDraft } from './draftReducer';
+import { initialPickForDraft, resolveTypeLensState } from './typeLensState';
+import { expenseAdapter } from './types/expense';
+
+const ctx = { defaultCurrency: 'USD' };
+
+const emptyDraft = () => initDraft({ date: '2026-07-05' }, 'USD');
+
+// A guided expense that the user has only started filling: a payee is typed
+// but the accounts and amount are still blank, so no adapter can detect it yet.
+const partialExpenseDraft = () =>
+  expenseAdapter.compile(
+    { ...expenseAdapter.emptyFields(ctx), payee: 'Cafe' },
+    ctx
+  );
+
+const expenseDraft = () =>
+  initDraft(
+    {
+      date: '2026-07-05',
+      payee: 'Cafe',
+      postings: [
+        { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '-5', currency: 'USD' },
+      ],
+    },
+    'USD'
+  );
+
+const unrecognizedDraft = () =>
+  initDraft(
+    {
+      date: '2026-07-05',
+      payee: 'Split',
+      postings: [
+        { account: 'Expenses:Food', amount: '5', currency: 'USD' },
+        { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
+      ],
+    },
+    'USD'
+  );
+
+describe('resolveTypeLensState', () => {
+  it('keeps a picked form open while its draft is still being filled', () => {
+    // Regression: typing a payee before the accounts/amount makes the draft
+    // non-empty yet undetectable. The picked form must stay open, not collapse
+    // into the "doesn't map to a quick type" notice.
+    const { selectedId, chipsDisabled } = resolveTypeLensState(
+      partialExpenseDraft(),
+      'expense'
+    );
+    expect(selectedId).toBe('expense');
+    expect(chipsDisabled).toBe(false);
+  });
+
+  it('offers the pick prompt for an empty draft with nothing picked', () => {
+    const { selectedId, chipsDisabled } = resolveTypeLensState(
+      emptyDraft(),
+      null
+    );
+    expect(selectedId).toBe(null);
+    expect(chipsDisabled).toBe(false);
+  });
+
+  it('selects the detected type for a recognized draft', () => {
+    const { selectedId, chipsDisabled } = resolveTypeLensState(
+      expenseDraft(),
+      null
+    );
+    expect(selectedId).toBe('expense');
+    expect(chipsDisabled).toBe(false);
+  });
+
+  it('disables the chips for an unrecognized incoming draft', () => {
+    const { selectedId, chipsDisabled } = resolveTypeLensState(
+      unrecognizedDraft(),
+      null
+    );
+    expect(selectedId).toBe(null);
+    expect(chipsDisabled).toBe(true);
+  });
+});
+
+describe('initialPickForDraft', () => {
+  it('seeds the detected type so editing it survives a transient mismatch', () => {
+    expect(initialPickForDraft(expenseDraft())).toBe('expense');
+  });
+
+  it('seeds nothing for an empty draft', () => {
+    expect(initialPickForDraft(emptyDraft())).toBe(null);
+  });
+
+  it('seeds nothing for an unrecognized draft', () => {
+    expect(initialPickForDraft(unrecognizedDraft())).toBe(null);
+  });
+});

--- a/features/transactions/entry/typeLensState.ts
+++ b/features/transactions/entry/typeLensState.ts
@@ -1,0 +1,33 @@
+// features/transactions/entry/typeLensState.ts
+import type { DraftState } from './draftReducer';
+import { isEmptyDraft } from './typeForms/isEmptyDraft';
+import { detectType } from './types/registry';
+
+/**
+ * The type to preselect when the Types tab first mounts for a draft. A
+ * recognized draft seeds its detected type so that editing it in the guided
+ * form keeps the form open even if a mid-edit draft briefly stops matching.
+ */
+export const initialPickForDraft = (draft: DraftState): string | null =>
+  detectType(draft)?.id ?? null;
+
+/**
+ * Decide what the Types tab shows for the current draft and the type the user
+ * is working in (`picked`).
+ *
+ * `chipsDisabled` — and, with it, the "doesn't map to a quick type" notice —
+ * fires only for an unrecognized draft the user has *not* engaged: no type is
+ * picked, the draft is non-empty, and nothing detects. Once a type is picked,
+ * the guided form owns the draft, so a partially filled (thus undetectable)
+ * draft must not collapse the form.
+ */
+export const resolveTypeLensState = (
+  draft: DraftState,
+  picked: string | null
+): { selectedId: string | null; chipsDisabled: boolean } => {
+  const detected = detectType(draft);
+  const selectedId = picked ?? detected?.id ?? null;
+  const chipsDisabled =
+    picked === null && !isEmptyDraft(draft) && detected === null;
+  return { selectedId, chipsDisabled };
+};


### PR DESCRIPTION
## Problem

On the Add Transaction page, picking **Expense** on the Types tab and typing a payee *before* filling the accounts/amount collapsed the form into the "This transaction's shape doesn't map to a quick type" notice, breaking the entry flow.

## Root cause

`TypeLens` computed its gate (`chipsDisabled`) purely from the live draft: `!isEmptyDraft(draft) && !detected`. A partially filled form produces a draft that is:

- no longer empty (`isEmptyDraft` returns `false` the moment `payee` is set), yet
- undetectable (empty accounts classify as `unknown`, so `detectType` returns `null`).

So the gate flipped to `true` and swapped the in-progress form out. It conflated *an incoming draft whose shape is unrecognized* with *a form the user is mid-way through filling*.

## Fix

- Extract the decision into a pure, tested helper `typeLensState.ts`:
  - `resolveTypeLensState(draft, picked)` — the unrecognized notice now fires **only when no type is picked**. Once a type is engaged, the guided form owns the draft and stays open.
  - `initialPickForDraft(draft)` — seeds `picked` from the detected type on mount. Because the Types tab unmounts when inactive, this re-seeds each visit, so editing a *recognized* transaction (e.g. clearing a field mid-edit) also no longer collapses the form — same bug class, now covered.
- `TypeLens` seeds `picked` via the initializer and reads its state from the helper.

## Tests

- New `typeLensState.test.ts` (7 cases), including the regression: partial expense + picked type keeps the form open; unrecognized incoming draft still disables the chips.
- Full `features/transactions/entry` suite green (106 tests); `tsc` and eslint clean.