### PR TITLE
fix(amounts): parse commodity in either position; visible text selection

### DIFF
--- a/app/balance/[from]/[to]/page.tsx
+++ b/app/balance/[from]/[to]/page.tsx
@@ -7,6 +7,7 @@ import SaveViewButton from '@/features/savedViews/SaveViewButton';
 import { requireUser } from '@/lib/auth/require-user';
 import { savedViewService } from '@/lib/savedViews';
 import { getBaseCurrency } from '@/lib/settings';
+import { parseAmountParts } from '@/utils/amountParts';
 import { parseISODate, toISODate } from '@/utils/date';
 import formatAmount from '@/utils/formatAmount';
 import formatDate, { Format } from '@/utils/formatDate';
@@ -148,7 +149,7 @@ const PeriodBalance = async ({
                 const [account, raw] = each.split('|');
                 return {
                   account,
-                  spend: Number((raw.split(' ')[1] ?? '0').replaceAll(',', '')),
+                  spend: parseAmountParts(raw).signed,
                 };
               })}
               xKey="account"

--- a/app/globals.css
+++ b/app/globals.css
@@ -226,7 +226,7 @@ table tbody tr:hover {
 }
 
 ::selection {
-  background: color-mix(in oklch, var(--accent) 30%, transparent);
+  background: color-mix(in oklch, var(--fg) 18%, transparent);
 }
 
 @layer base {

--- a/features/accounts/FriendlyBalance.test.tsx
+++ b/features/accounts/FriendlyBalance.test.tsx
@@ -8,10 +8,18 @@ describe('FriendlyBalance', () => {
   it('renders an em-dash for a blank balance', () => {
     expect(html(<FriendlyBalance amount="" role="asset" />)).toContain('—');
   });
-  it('renders an em-dash for a non-numeric (non-converted commodity) amount', () => {
-    expect(html(<FriendlyBalance amount="20 AAPL" role="asset" />)).toContain(
-      '—'
-    );
+  it('renders an em-dash when there is no numeric amount at all', () => {
+    expect(html(<FriendlyBalance amount="AAPL" role="asset" />)).toContain('—');
+  });
+  it('shows the original amount inline for an un-converted suffix commodity', () => {
+    // Un-converted holdings (e.g. shares or crypto with no exchange rate) must
+    // show their real amount rather than vanish behind an em-dash — the
+    // BaseCurrencyBanner promises "affected reports show original currencies
+    // inline".
+    const out = html(<FriendlyBalance amount="20 AAPL" role="asset" />);
+    expect(out).toContain('AAPL');
+    expect(out).toMatch(/20/);
+    expect(out).not.toContain('—');
   });
   it('shows an up arrow and positive color for an asset with money', () => {
     const out = html(<FriendlyBalance amount="$ 2,340.00" role="asset" />);

--- a/features/accounts/amountParts.test.ts
+++ b/features/accounts/amountParts.test.ts
@@ -26,6 +26,30 @@ describe('parseAmountParts', () => {
       signed: 1000,
     });
   });
+  it('parses a suffix (amount-first) word commodity like Kirt', () => {
+    expect(parseAmountParts('71,214.5302 Kirt')).toEqual({
+      unit: 'Kirt',
+      magnitude: '71,214.5302',
+      negative: false,
+      signed: 71214.5302,
+    });
+  });
+  it('parses a negative suffix commodity', () => {
+    expect(parseAmountParts('-1,234.56 Kirt')).toEqual({
+      unit: 'Kirt',
+      magnitude: '1,234.56',
+      negative: true,
+      signed: -1234.56,
+    });
+  });
+  it('parses a glued prefix symbol without a space', () => {
+    expect(parseAmountParts('$33000.00')).toEqual({
+      unit: '$',
+      magnitude: '33000.00',
+      negative: false,
+      signed: 33000,
+    });
+  });
   it('parses a unit-less amount', () => {
     expect(parseAmountParts('42.50')).toEqual({
       unit: '',

--- a/features/accounts/amountParts.ts
+++ b/features/accounts/amountParts.ts
@@ -1,28 +1,4 @@
-export type AmountParts = {
-  unit: string;
-  magnitude: string;
-  negative: boolean;
-  signed: number;
-};
-
-/**
- * Split a ledger amount string (e.g. "$ 3,170.00", "$ -200.00", "USD 1,000.00")
- * into its unit, its magnitude (ledger's original digits, sign stripped), a
- * negativity flag, and the numeric value. Unit-first, matching utils/formatAmount.
- */
-export function parseAmountParts(raw: string): AmountParts {
-  const trimmed = (raw ?? '').trim();
-  if (!trimmed) return { unit: '', magnitude: '', negative: false, signed: 0 };
-
-  const parts = trimmed.split(/\s+/);
-  let unit = '';
-  let numStr = trimmed;
-  if (parts.length >= 2) {
-    unit = parts[0];
-    numStr = parts[1];
-  }
-  const negative = numStr.startsWith('-');
-  const magnitude = numStr.replace(/^-/, '');
-  const signed = Number(numStr.replaceAll(',', '')) || 0;
-  return { unit, magnitude, negative, signed };
-}
+// Re-exported from utils so lower layers (utils/formatAmount) can share the
+// same parser without a features → utils inversion. Feature-local consumers
+// (FriendlyBalance) keep importing from here.
+export { parseAmountParts, type AmountParts } from '@/utils/amountParts';

--- a/features/dashboard/Dashboard.utils.ts
+++ b/features/dashboard/Dashboard.utils.ts
@@ -1,3 +1,4 @@
+import { parseAmountParts } from '@/utils/amountParts';
 import runLedger from '@/utils/runLedger';
 
 export const getHighestExpense = (stdout: string): string => {
@@ -5,9 +6,8 @@ export const getHighestExpense = (stdout: string): string => {
   stdout.split('\n').forEach((expense) => {
     if (!expense) return;
     const amountField = expense.split('|')[1];
-    const amountToken = amountField?.split(' ')[1];
-    if (!amountToken) return;
-    const amount = Number(amountToken.replaceAll(',', ''));
+    if (!amountField) return;
+    const amount = parseAmountParts(amountField).signed;
     if (Number.isFinite(amount) && amount > highestExpense.amount) {
       highestExpense = { amount, str: expense };
     }

--- a/utils/amountParts.ts
+++ b/utils/amountParts.ts
@@ -1,0 +1,40 @@
+export type AmountParts = {
+  unit: string;
+  magnitude: string;
+  negative: boolean;
+  signed: number;
+};
+
+// Matches the numeric token of a ledger amount: an optional leading minus,
+// grouped digits, and an optional decimal fraction. Used to locate the number
+// regardless of where the commodity sits relative to it.
+const NUMBER_TOKEN = /-?[\d,]+(?:\.\d+)?/;
+
+/**
+ * Split a ledger amount string into its unit, its magnitude (ledger's original
+ * digits, sign stripped), a negativity flag, and the numeric value.
+ *
+ * Ledger renders the commodity on EITHER side of the number depending on how
+ * the commodity was first seen: a prefix symbol (`$ 3,170.00`, `$33000.00`),
+ * a prefix code (`USD 1,000.00`), or a suffix code (`71,214.5302 Kirt`,
+ * `0.5 BTC`). We therefore locate the numeric token first and treat whatever
+ * remains as the unit, rather than assuming the number is in a fixed position.
+ */
+export function parseAmountParts(raw: string): AmountParts {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return { unit: '', magnitude: '', negative: false, signed: 0 };
+
+  const match = NUMBER_TOKEN.exec(trimmed);
+  if (!match) {
+    // No numeric token at all — surface the raw text as the unit so callers can
+    // still show something rather than silently dropping it.
+    return { unit: trimmed, magnitude: '', negative: false, signed: 0 };
+  }
+
+  const numStr = match[0];
+  const unit = trimmed.replace(numStr, '').trim();
+  const negative = numStr.startsWith('-');
+  const magnitude = numStr.replace(/^-/, '');
+  const signed = Number(numStr.replaceAll(',', '')) || 0;
+  return { unit, magnitude, negative, signed };
+}

--- a/utils/formatAmount.test.tsx
+++ b/utils/formatAmount.test.tsx
@@ -52,4 +52,16 @@ describe('formatAmount', () => {
     expect(out).toContain('text-negative');
     expect(out).toMatch(/1,234,567\.89/);
   });
+
+  it('renders the number for a suffix commodity when withUnit is false (Kirt rows regression)', () => {
+    const out = html(formatAmount('71,214.5302 Kirt', false));
+    expect(out).toMatch(/71,214\.5302/);
+    expect(out).not.toContain('Kirt');
+  });
+
+  it('renders both unit and number for a suffix commodity when withUnit is true', () => {
+    const out = html(formatAmount('71,214.5302 Kirt', true));
+    expect(out).toContain('Kirt');
+    expect(out).toMatch(/71,214\.5302/);
+  });
 });

--- a/utils/formatAmount.tsx
+++ b/utils/formatAmount.tsx
@@ -1,3 +1,5 @@
+import { parseAmountParts } from '@/utils/amountParts';
+
 // Adds comma thousands separators to the integer part of a numeric string
 // while preserving its original decimal places. Operates on the string (not a
 // parsed Number) so ledger's display precision — including trailing zeros — is
@@ -30,14 +32,17 @@ const formatAmount = (str: string | undefined | null, withUnit: boolean) => {
   if (!str || !str.trim()) {
     return <span className="text-muted-foreground">—</span>;
   }
-  const splitted = str.split(' ');
-  if (splitted.length < 2) {
+  const { unit, magnitude, negative } = parseAmountParts(str);
+  // No numeric token was found (e.g. a bare commodity word) — render the raw
+  // string rather than dropping it.
+  if (magnitude === '') {
     return formatAmountWithoutUnit(str);
-  } else if (withUnit) {
-    return formatAmountWithoutUnit(splitted[1], splitted[0]);
-  } else {
-    return formatAmountWithoutUnit(splitted[1]);
   }
+  const signedNumber = `${negative ? '-' : ''}${magnitude}`;
+  return formatAmountWithoutUnit(
+    signedNumber,
+    withUnit ? unit || undefined : undefined
+  );
 };
 
 export default formatAmount;


### PR DESCRIPTION
## Problem

Two bugs surfaced while looking at a journal that uses a suffix-rendered commodity (`Kirt`) and no exchange rate for BTC:

1. **Amounts lose their number.** On the Periodic Balance page every row rendered just `Kirt` with no figure (while the total looked right by accident). Root cause: amount rendering assumed the commodity always precedes the number (`$ 100`), but ledger prints *word* commodities **after** the number (`71,214.5302 Kirt`). Everything that grabbed "the 2nd whitespace token" picked up the commodity instead of the value — affecting the balance rows, the chart bars (`NaN`), and the dashboard highest-expense picker. The same mis-parse made un-converted holdings (e.g. un-priced BTC/shares) render as an em-dash `—` on the Accounts page, i.e. **holdings appeared to vanish**.

2. **Text selection invisible in light mode.** `::selection` reused `--accent`, which is a near-white neutral in light mode, so the selection highlight was imperceptible on the near-white page. Text was selectable; you just couldn't see it.

## Fix

- Add `utils/amountParts.ts`: a parser that locates the numeric token regardless of commodity placement — prefix symbol (`$ 100` / `$100`), prefix code (`USD 100`), suffix code (`71,214.5302 Kirt`, `0.5 BTC`).
- Route `formatAmount`, the periodic-balance chart, the dashboard highest-expense picker, and `FriendlyBalance` through it. `features/accounts/amountParts.ts` now re-exports from `utils/` (no import churn for existing consumers).
- Un-converted commodities now show their original amount inline, matching the `BaseCurrencyBanner` promise ("affected reports show original currencies inline"). Updated the `FriendlyBalance` test that had codified the em-dash bug.
- `::selection` now uses `--fg`, visible in both light and dark themes.

## Verification

- `vitest run` — 888 passed (added regression tests for suffix commodities, negative suffix, glued prefix symbol, and the Kirt-row render).
- `tsc --noEmit` clean, eslint clean.

## Not included

The multi-commodity **continuation-line drop** in `lib/balance/parse.ts` (`if (!line.includes('|')) continue;` discards ledger's stacked extra-commodity lines) is a separate latent bug, left for a follow-up.