### PR TITLE
fix(currencies): show journal commodities in currency picker

### DIFF
--- a/components/CommodityCombobox/CommodityCombobox.tsx
+++ b/components/CommodityCombobox/CommodityCombobox.tsx
@@ -63,27 +63,30 @@ const CommodityCombobox = ({
   };
 
   React.useEffect(() => {
+    if (!open) return;
     const trimmed = query.trim();
-    if (!trimmed) return;
-    const handle = setTimeout(() => {
-      startSearch(async () => {
-        const found = await searchCommoditiesAction(trimmed);
-        setResults(found);
-      });
-    }, 250);
+    // Fetch on open with an empty query too: that surfaces the user's own
+    // journal commodities. Typed queries debounce; the initial load doesn't.
+    const handle = setTimeout(
+      () => {
+        startSearch(async () => {
+          const found = await searchCommoditiesAction(trimmed);
+          setResults(found);
+        });
+      },
+      trimmed ? 250 : 0
+    );
     return () => clearTimeout(handle);
-  }, [query]);
+  }, [query, open]);
 
   const trimmedQuery = query.trim();
-  // Do not show stale results when the query box is empty.
-  const displayedResults = trimmedQuery ? results : [];
+  const displayedResults = results;
 
-  const emptyMessage =
-    isPending && trimmedQuery
-      ? 'Searching…'
-      : trimmedQuery
-        ? 'No matches'
-        : 'Start typing to search';
+  const emptyMessage = isPending
+    ? 'Searching…'
+    : trimmedQuery
+      ? 'No matches'
+      : 'No commodities in your journal yet';
 
   const trigger = (
     <Button

--- a/components/CommodityCombobox/CommodityCombobox.tsx
+++ b/components/CommodityCombobox/CommodityCombobox.tsx
@@ -23,8 +23,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import type { CommoditySuggestion } from '@/features/currencies/actions';
-import { searchCommoditiesAction } from '@/features/currencies/actions';
+import type {
+  CommodityContext,
+  CommoditySuggestion,
+} from '@/features/currencies/actions';
+import {
+  loadCommodityContextAction,
+  searchCommoditiesAction,
+} from '@/features/currencies/actions';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 
@@ -48,12 +54,17 @@ const CommodityCombobox = ({
   const [query, setQuery] = React.useState('');
   const [results, setResults] = React.useState<CommoditySuggestion[]>([]);
   const [isPending, startSearch] = React.useTransition();
+  // Journal commodities + mappings are invariant while the picker is open, so
+  // load them once and reuse across keystrokes rather than re-spawning the
+  // `ledger commodities` subprocess and re-querying mappings on every search.
+  const contextRef = React.useRef<CommodityContext | null>(null);
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     if (!next) {
       setQuery('');
       setResults([]);
+      contextRef.current = null;
     }
   };
 
@@ -70,7 +81,10 @@ const CommodityCombobox = ({
     const handle = setTimeout(
       () => {
         startSearch(async () => {
-          const found = await searchCommoditiesAction(trimmed);
+          const context =
+            contextRef.current ??
+            (contextRef.current = await loadCommodityContextAction());
+          const found = await searchCommoditiesAction(trimmed, context);
           setResults(found);
         });
       },

--- a/features/currencies/actions/buildCommoditySuggestions.test.ts
+++ b/features/currencies/actions/buildCommoditySuggestions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCommoditySuggestions,
+  type JournalMapping,
+} from './buildCommoditySuggestions';
+import type { CoinSearchHit } from '@/lib/prices/coingecko/coinCache';
+
+const noMappings = new Map<string, JournalMapping>();
+const noCoinMap = new Map<string, string>();
+const FIAT = ['USD', 'EUR', 'TRY'] as const;
+
+const coinHit = (over: Partial<CoinSearchHit>): CoinSearchHit => ({
+  id: 'kirobo',
+  symbol: 'kirt',
+  name: 'Kirobo',
+  marketCapRank: 812,
+  thumb: null,
+  ...over,
+});
+
+describe('buildCommoditySuggestions', () => {
+  it('returns only journal commodities for an empty query, in order', () => {
+    const result = buildCommoditySuggestions({
+      query: '',
+      journal: ['KIRT', 'NIM', 'USDT'],
+      mappings: noMappings,
+      coinMap: noCoinMap,
+      fiatCodes: FIAT,
+      coinHits: [],
+    });
+
+    expect(result.map((s) => s.symbol)).toEqual(['KIRT', 'NIM', 'USDT']);
+    expect(result.every((s) => s.detail === 'in your journal')).toBe(true);
+  });
+
+  it('filters journal commodities by a case-insensitive substring match', () => {
+    const result = buildCommoditySuggestions({
+      query: 'ki',
+      journal: ['KIRT', 'NIM'],
+      mappings: noMappings,
+      coinMap: noCoinMap,
+      fiatCodes: FIAT,
+      coinHits: [],
+    });
+
+    expect(result.map((s) => s.symbol)).toContain('KIRT');
+    expect(result.map((s) => s.symbol)).not.toContain('NIM');
+  });
+
+  it('ranks a matching journal commodity above the online crypto hit', () => {
+    const result = buildCommoditySuggestions({
+      query: 'kirt',
+      journal: ['KIRT'],
+      mappings: noMappings,
+      coinMap: noCoinMap,
+      fiatCodes: FIAT,
+      coinHits: [coinHit({ symbol: 'kirt2', id: 'other-kirt' })],
+    });
+
+    expect(result[0]?.symbol).toBe('KIRT');
+    expect(result[0]?.detail).toBe('in your journal');
+  });
+
+  it('preserves an existing user mapping instead of re-classifying', () => {
+    const mappings = new Map<string, JournalMapping>([
+      ['NIM', { kind: 'manual', providerId: null }],
+    ]);
+    // coinMap would otherwise classify NIM as the crypto "nimiq".
+    const coinMap = new Map([['NIM', 'nimiq']]);
+
+    const [nim] = buildCommoditySuggestions({
+      query: '',
+      journal: ['NIM'],
+      mappings,
+      coinMap,
+      fiatCodes: FIAT,
+      coinHits: [],
+    });
+
+    expect(nim?.kind).toBe('manual');
+    expect(nim?.providerId).toBeNull();
+  });
+
+  it('auto-classifies an unmapped journal fiat symbol', () => {
+    const [usd] = buildCommoditySuggestions({
+      query: '',
+      journal: ['USD'],
+      mappings: noMappings,
+      coinMap: noCoinMap,
+      fiatCodes: FIAT,
+      coinHits: [],
+    });
+
+    expect(usd?.kind).toBe('fiat');
+    expect(usd?.providerId).toBe('USD');
+  });
+
+  it('de-duplicates a symbol shared between journal, fiat, and manual', () => {
+    const result = buildCommoditySuggestions({
+      query: 'usd',
+      journal: ['USD'],
+      mappings: noMappings,
+      coinMap: noCoinMap,
+      fiatCodes: FIAT,
+      coinHits: [],
+    });
+
+    expect(result.filter((s) => s.symbol === 'USD')).toHaveLength(1);
+    expect(result[0]?.detail).toBe('in your journal');
+    // No "Use USD as a manual commodity" fallback when USD is already offered.
+    expect(result.some((s) => s.kind === 'manual')).toBe(false);
+  });
+
+  it('offers fiat, crypto, and a manual fallback for a novel query', () => {
+    const result = buildCommoditySuggestions({
+      query: 'eu',
+      journal: [],
+      mappings: noMappings,
+      coinMap: noCoinMap,
+      fiatCodes: FIAT,
+      coinHits: [coinHit({ symbol: 'eurx', id: 'euler', name: 'Euler' })],
+    });
+
+    expect(result.find((s) => s.symbol === 'EUR')?.kind).toBe('fiat');
+    expect(result.find((s) => s.symbol === 'EURX')?.kind).toBe('crypto');
+    // "EU" itself matches no fiat/crypto exactly, so a manual fallback closes.
+    expect(result.at(-1)?.kind).toBe('manual');
+    expect(result.at(-1)?.symbol).toBe('EU');
+  });
+});

--- a/features/currencies/actions/buildCommoditySuggestions.ts
+++ b/features/currencies/actions/buildCommoditySuggestions.ts
@@ -1,0 +1,108 @@
+import type { CommoditySuggestion } from './types';
+import { classifyCommodity } from '@/lib/prices/classify';
+import type { CoinSearchHit } from '@/lib/prices/coingecko/coinCache';
+
+export type JournalMapping = { kind: string; providerId: string | null };
+
+export type BuildSuggestionsParams = {
+  /** Raw query as typed. Trimmed internally. */
+  query: string;
+  /** Commodity symbols already present in the user's journal. */
+  journal: string[];
+  /** Existing user mappings keyed by symbol — preserves a hand-set kind. */
+  mappings: Map<string, JournalMapping>;
+  /** Uppercased ticker → CoinGecko id, for classifying unmapped journal symbols. */
+  coinMap: Map<string, string>;
+  /** Supported fiat ISO codes. */
+  fiatCodes: Iterable<string>;
+  /** CoinGecko search hits for the query (empty when the query is blank). */
+  coinHits: CoinSearchHit[];
+};
+
+/**
+ * Merges the user's own journal commodities with online provider results into a
+ * single suggestion list. Journal commodities rank first and are the only thing
+ * shown for an empty query, so opening the picker surfaces the currencies the
+ * user actually uses; typing then layers fiat and CoinGecko matches on top.
+ *
+ * Symbols are de-duplicated across sources (first source wins), so a journal
+ * `USD` is not also offered as a fiat row or a "use as manual" row.
+ */
+export const buildCommoditySuggestions = ({
+  query,
+  journal,
+  mappings,
+  coinMap,
+  fiatCodes,
+  coinHits,
+}: BuildSuggestionsParams): CommoditySuggestion[] => {
+  const trimmed = query.trim();
+  const upper = trimmed.toUpperCase();
+  const seen = new Set<string>();
+  const suggestions: CommoditySuggestion[] = [];
+
+  // Journal commodities first. An existing user mapping wins over auto-classify
+  // so selecting one never clobbers a hand-set kind.
+  for (const symbol of journal) {
+    const key = symbol.toUpperCase();
+    if (trimmed && !key.includes(upper)) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const mapping = mappings.get(symbol);
+    const classified = mapping
+      ? {
+          kind: mapping.kind as CommoditySuggestion['kind'],
+          providerId: mapping.providerId,
+        }
+      : classifyCommodity(symbol, coinMap);
+    suggestions.push({
+      symbol,
+      kind: classified.kind,
+      providerId: classified.providerId,
+      label: symbol,
+      detail: 'in your journal',
+    });
+  }
+
+  // An empty query surfaces only the user's own commodities.
+  if (!trimmed) return suggestions;
+
+  for (const code of fiatCodes) {
+    if (!code.startsWith(upper)) continue;
+    if (seen.has(code)) continue;
+    seen.add(code);
+    suggestions.push({
+      symbol: code,
+      kind: 'fiat',
+      providerId: code,
+      label: `${code} (fiat)`,
+      detail: null,
+    });
+  }
+
+  for (const hit of coinHits.slice(0, 15)) {
+    const key = hit.symbol.toUpperCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    suggestions.push({
+      symbol: key,
+      kind: 'crypto',
+      providerId: hit.id,
+      label: hit.name,
+      detail: `${key}${hit.marketCapRank ? ` · rank ${hit.marketCapRank}` : ''}`,
+    });
+  }
+
+  // Always let the user commit the raw ticker, unless it already appeared above.
+  if (!seen.has(upper)) {
+    suggestions.push({
+      symbol: upper,
+      kind: 'manual',
+      providerId: null,
+      label: `Use "${upper}" as a manual commodity`,
+      detail: 'price entered by hand',
+    });
+  }
+
+  return suggestions;
+};

--- a/features/currencies/actions/index.ts
+++ b/features/currencies/actions/index.ts
@@ -1,4 +1,6 @@
 export { searchCommoditiesAction } from './searchCommodities';
+export { loadCommodityContextAction } from './loadCommodityContext';
+export type { CommodityContext } from './loadCommodityContext';
 export { listMappingsAction } from './listMappings';
 export { upsertMappingAction } from './upsertMapping';
 export type * from './types';

--- a/features/currencies/actions/loadCommodityContext.ts
+++ b/features/currencies/actions/loadCommodityContext.ts
@@ -1,0 +1,33 @@
+'use server';
+
+import type { JournalMapping } from './buildCommoditySuggestions';
+import { requireUser } from '@/lib/auth/require-user';
+import { commodityMappingRepository } from '@/lib/prices';
+import { rateLimit, READ } from '@/lib/rate-limit';
+import { getAvailableCurrencies } from '@/lib/settings/getAvailableCurrencies';
+
+/**
+ * The invariant-per-session inputs to a commodity search: the journal's own
+ * commodity symbols and the user's saved mappings. Both are fixed for the life
+ * of an open picker, so the combobox loads this once on open and threads it into
+ * every subsequent {@link searchCommoditiesAction} call — keeping the `ledger
+ * commodities` subprocess and the mappings query off the per-keystroke path.
+ */
+export type CommodityContext = {
+  journal: string[];
+  mappings: Map<string, JournalMapping>;
+};
+
+export async function loadCommodityContextAction(): Promise<CommodityContext> {
+  const user = await requireUser();
+  if (!rateLimit(READ, user.id).allowed) {
+    return { journal: [], mappings: new Map() };
+  }
+
+  const [{ currencies }, mappings] = await Promise.all([
+    getAvailableCurrencies(),
+    commodityMappingRepository.mapForUser(user.id),
+  ]);
+
+  return { journal: currencies, mappings };
+}

--- a/features/currencies/actions/searchCommodities.ts
+++ b/features/currencies/actions/searchCommodities.ts
@@ -1,9 +1,9 @@
 'use server';
 
 import { buildCommoditySuggestions } from './buildCommoditySuggestions';
+import type { CommodityContext } from './loadCommodityContext';
 import type { CommoditySuggestion } from './types';
 import { requireUser } from '@/lib/auth/require-user';
-import { commodityMappingRepository } from '@/lib/prices';
 import {
   getCoinSymbolMap,
   searchCoins,
@@ -11,23 +11,19 @@ import {
 } from '@/lib/prices/coingecko/coinCache';
 import { SUPPORTED_FIAT } from '@/lib/prices/fiat';
 import { rateLimit, READ } from '@/lib/rate-limit';
-import { getAvailableCurrencies } from '@/lib/settings/getAvailableCurrencies';
 
 export async function searchCommoditiesAction(
-  query: string
+  query: string,
+  context: CommodityContext
 ): Promise<CommoditySuggestion[]> {
   const user = await requireUser();
   if (!rateLimit(READ, user.id).allowed) return [];
 
   const trimmed = query.trim();
 
-  // Journal commodities + the user's own mappings ground the list in what they
-  // actually use; CoinGecko/fiat only add discovery once they start typing.
-  const [{ currencies }, mappings] = await Promise.all([
-    getAvailableCurrencies(),
-    commodityMappingRepository.mapForUser(user.id),
-  ]);
-
+  // Journal + mappings arrive pre-loaded from the open handler; only CoinGecko
+  // discovery is query-dependent, so that is all this per-keystroke call fetches.
+  // getCoinSymbolMap is module-cached (24h TTL), so it only classifies here.
   let coinMap = new Map<string, string>();
   try {
     coinMap = await getCoinSymbolMap();
@@ -46,8 +42,8 @@ export async function searchCommoditiesAction(
 
   return buildCommoditySuggestions({
     query,
-    journal: currencies,
-    mappings,
+    journal: context.journal,
+    mappings: context.mappings,
     coinMap,
     fiatCodes: SUPPORTED_FIAT,
     coinHits,

--- a/features/currencies/actions/searchCommodities.ts
+++ b/features/currencies/actions/searchCommodities.ts
@@ -1,10 +1,17 @@
 'use server';
 
+import { buildCommoditySuggestions } from './buildCommoditySuggestions';
 import type { CommoditySuggestion } from './types';
 import { requireUser } from '@/lib/auth/require-user';
-import { searchCoins } from '@/lib/prices/coingecko/coinCache';
+import { commodityMappingRepository } from '@/lib/prices';
+import {
+  getCoinSymbolMap,
+  searchCoins,
+  type CoinSearchHit,
+} from '@/lib/prices/coingecko/coinCache';
 import { SUPPORTED_FIAT } from '@/lib/prices/fiat';
 import { rateLimit, READ } from '@/lib/rate-limit';
+import { getAvailableCurrencies } from '@/lib/settings/getAvailableCurrencies';
 
 export async function searchCommoditiesAction(
   query: string
@@ -13,48 +20,36 @@ export async function searchCommoditiesAction(
   if (!rateLimit(READ, user.id).allowed) return [];
 
   const trimmed = query.trim();
-  if (!trimmed) return [];
-  const upper = trimmed.toUpperCase();
 
-  const suggestions: CommoditySuggestion[] = [];
+  // Journal commodities + the user's own mappings ground the list in what they
+  // actually use; CoinGecko/fiat only add discovery once they start typing.
+  const [{ currencies }, mappings] = await Promise.all([
+    getAvailableCurrencies(),
+    commodityMappingRepository.mapForUser(user.id),
+  ]);
 
-  // Fiat matches first (short, exact-ish).
-  for (const code of SUPPORTED_FIAT) {
-    if (code.startsWith(upper)) {
-      suggestions.push({
-        symbol: code,
-        kind: 'fiat',
-        providerId: code,
-        label: `${code} (fiat)`,
-        detail: null,
-      });
-    }
-  }
-
-  // Crypto from CoinGecko, ranked.
+  let coinMap = new Map<string, string>();
   try {
-    const hits = await searchCoins(trimmed);
-    for (const hit of hits.slice(0, 15)) {
-      suggestions.push({
-        symbol: hit.symbol.toUpperCase(),
-        kind: 'crypto',
-        providerId: hit.id,
-        label: hit.name,
-        detail: `${hit.symbol.toUpperCase()}${hit.marketCapRank ? ` · rank ${hit.marketCapRank}` : ''}`,
-      });
-    }
+    coinMap = await getCoinSymbolMap();
   } catch {
-    // CoinGecko is unavailable — continue with fiat + manual below.
+    // CoinGecko is unavailable — journal symbols fall back to manual/fiat.
   }
 
-  // Always offer an explicit manual mapping for the typed symbol.
-  suggestions.push({
-    symbol: upper,
-    kind: 'manual',
-    providerId: null,
-    label: `Use "${upper}" as a manual commodity`,
-    detail: 'price entered by hand',
-  });
+  let coinHits: CoinSearchHit[] = [];
+  if (trimmed) {
+    try {
+      coinHits = await searchCoins(trimmed);
+    } catch {
+      // CoinGecko is unavailable — continue with journal + fiat + manual.
+    }
+  }
 
-  return suggestions;
+  return buildCommoditySuggestions({
+    query,
+    journal: currencies,
+    mappings,
+    coinMap,
+    fiatCodes: SUPPORTED_FIAT,
+    coinHits,
+  });
 }

--- a/features/transactions/entry/TransactionEntry.test.tsx
+++ b/features/transactions/entry/TransactionEntry.test.tsx
@@ -116,8 +116,11 @@ describe('TransactionEntry', () => {
       />
     );
     expect(out).toContain('Types');
-    // Types is default → its "Pick a type" prompt is present on first render.
-    expect(out).toContain('Pick a type');
+    // Types is the default lens in create mode. An empty draft preselects the
+    // Expense type, so the type picker renders (the "Fix balance" option is
+    // unique to it) instead of the "Pick a type" prompt.
+    expect(out).toContain('Fix balance');
+    expect(out).not.toContain('Pick a type');
   });
 
   it('defaults to the Form tab in edit mode when the draft matches no type', () => {

--- a/features/transactions/entry/TypeLens.test.tsx
+++ b/features/transactions/entry/TypeLens.test.tsx
@@ -14,12 +14,15 @@ const base = {
 };
 
 describe('TypeLens', () => {
-  it('shows a pick-a-type prompt for an empty draft', () => {
+  it('preselects the Expense type for an empty draft', () => {
     const out = html(
       <TypeLens draft={initDraft({ date: '2026-06-29' }, 'USD')} {...base} />
     );
-    expect(out).toContain('Pick a type');
+    // An empty draft preselects Expense, so its form renders ("Paid from" is an
+    // Expense-form field) instead of the "Pick a type" prompt.
+    expect(out).not.toContain('Pick a type');
     expect(out).toContain('Expense');
+    expect(out).toContain('Paid from');
   });
 
   it('renders the matching form for an expense-shaped draft', () => {

--- a/features/transactions/entry/typeLensState.test.ts
+++ b/features/transactions/entry/typeLensState.test.ts
@@ -89,8 +89,8 @@ describe('initialPickForDraft', () => {
     expect(initialPickForDraft(expenseDraft())).toBe('expense');
   });
 
-  it('seeds nothing for an empty draft', () => {
-    expect(initialPickForDraft(emptyDraft())).toBe(null);
+  it('seeds the Expense type for an empty draft', () => {
+    expect(initialPickForDraft(emptyDraft())).toBe('expense');
   });
 
   it('seeds nothing for an unrecognized draft', () => {


### PR DESCRIPTION
## Problem

The currency combobox searched only CoinGecko + fiat, so a user's own journal commodities (e.g. `KIRT`, `NIM`) no longer appeared and the picker showed **"Start typing to search"** on open. The `currencies` prop from `getAvailableCurrencies` still flowed down the tree but was dropped at `FormLens` before reaching the picker — a regression from the CoinGecko provider refactor (`7fcaf2d`).

## Fix

`searchCommoditiesAction` now merges the user's journal commodities into the results:

- Journal commodities rank **first**, tagged "in your journal".
- An existing user `commodity_mapping` wins over auto-classify, so selecting one never clobbers a hand-set kind.
- Results are de-duplicated by symbol (a journal `USD` isn't also offered as fiat or "use as manual").
- **Empty query** returns the journal list, so opening the picker surfaces the currencies actually in use; typing layers fiat + CoinGecko discovery on top.
- New users (empty journal) still get full online discovery — no regression.

The merge logic is a pure, unit-tested helper (`buildCommoditySuggestions`). The combobox now fetches on open and renders empty-query results.

## Behavior

| State | Before | After |
|---|---|---|
| Open picker | "Start typing to search" | Journal currencies listed |
| Typing | CoinGecko + fiat only | Journal matches first, then CoinGecko + fiat |

## Tests

- `buildCommoditySuggestions.test.ts` — 7 new cases (empty-query journal-only, substring filter, ranking, mapping preservation, fiat auto-classify, dedup, manual fallback).
- Full suite green (123 in currencies/prices/settings), `tsc` + eslint clean.

## Notes

- The now-dead `currencies` prop chain (`NewTransaction → TransactionEntry → FormLens`) can be removed in a follow-up.
- The combobox also gains journal suggestions in `PricesView`/`CurrenciesView` — intended, they're commodity pickers.