### PR TITLE
fix(transactions): correct fix-balance current balance and format amounts

### DIFF
--- a/features/transactions/AmountInput.util.test.ts
+++ b/features/transactions/AmountInput.util.test.ts
@@ -3,6 +3,7 @@ import {
   cleanAmountInput,
   groupAmountInput,
   caretAfterFormat,
+  decimalPlaces,
 } from './AmountInput.util';
 
 describe('cleanAmountInput', () => {
@@ -57,6 +58,29 @@ describe('groupAmountInput', () => {
 
   it('returns empty for empty input', () => {
     expect(groupAmountInput('')).toBe('');
+  });
+});
+
+describe('decimalPlaces', () => {
+  it('counts digits after the decimal point', () => {
+    expect(decimalPlaces('1779.540')).toBe(3);
+    expect(decimalPlaces('220.46')).toBe(2);
+  });
+
+  it('returns 0 when there is no decimal point', () => {
+    expect(decimalPlaces('1234')).toBe(0);
+  });
+
+  it('ignores comma separators', () => {
+    expect(decimalPlaces('1,779.540')).toBe(3);
+  });
+
+  it('returns 0 for a trailing dot with no decimals', () => {
+    expect(decimalPlaces('1234.')).toBe(0);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(decimalPlaces('')).toBe(0);
   });
 });
 

--- a/features/transactions/AmountInput.util.ts
+++ b/features/transactions/AmountInput.util.ts
@@ -50,6 +50,15 @@ export const caretAfterFormat = (
   return formatted.length;
 };
 
+// Counts the decimal places in a raw number string (digits after a single dot).
+// Used to render a derived amount at the same precision as its source rather
+// than a hard-coded scale.
+export const decimalPlaces = (raw: string): number => {
+  const clean = cleanAmountInput(raw);
+  const dot = clean.indexOf('.');
+  return dot === -1 ? 0 : clean.length - dot - 1;
+};
+
 const SIGNIFICANT = /[0-9.-]/;
 
 export const countSignificant = (value: string, end: number): number => {

--- a/features/transactions/entry/actions/getAccountBalance.ts
+++ b/features/transactions/entry/actions/getAccountBalance.ts
@@ -15,7 +15,7 @@ export async function getAccountBalance(
   if (!isSafeLedgerArg(acct)) return '0';
   if (ccy !== '' && !isSafeLedgerArg(ccy)) return '0';
   try {
-    const args = ['balance', '--no-total', '--collapse', '--format', '%A|%T\n'];
+    const args = ['balance', '--no-total', '--format', '%A|%T\n'];
     if (ccy) args.push('-X', ccy);
     // `--` stops ledger option parsing so a crafted account can't smuggle a flag.
     args.push('--', acct);

--- a/features/transactions/entry/typeForms/FixBalanceForm.tsx
+++ b/features/transactions/entry/typeForms/FixBalanceForm.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import AmountInput from '../../AmountInput';
-import { groupAmountInput } from '../../AmountInput.util';
+import { groupAmountInput, decimalPlaces } from '../../AmountInput.util';
 import { headerOf } from '../types/adapter';
 import { fixBalanceAdapter, type FixBalanceFields } from '../types/fixBalance';
 import { HeaderFieldsEditor } from './HeaderFields';
@@ -64,7 +64,9 @@ export function FixBalanceForm({
 
   const implied =
     current !== null && fields.targetAmount.trim() !== ''
-      ? (Number(fields.targetAmount) - Number(current)).toFixed(2)
+      ? (Number(fields.targetAmount) - Number(current)).toFixed(
+          Math.max(decimalPlaces(current), decimalPlaces(fields.targetAmount))
+        )
       : null;
 
   return (

--- a/features/transactions/entry/typeForms/FixBalanceForm.tsx
+++ b/features/transactions/entry/typeForms/FixBalanceForm.tsx
@@ -3,6 +3,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import AmountInput from '../../AmountInput';
+import { groupAmountInput } from '../../AmountInput.util';
 import { headerOf } from '../types/adapter';
 import { fixBalanceAdapter, type FixBalanceFields } from '../types/fixBalance';
 import { HeaderFieldsEditor } from './HeaderFields';
@@ -105,10 +106,11 @@ export function FixBalanceForm({
         <div className="text-xs text-muted-foreground tabular-nums">
           {current === null
             ? 'Enter an account to see its current balance.'
-            : `Now: ${current} ${fields.targetCurrency}`}
+            : `Now: ${groupAmountInput(current)} ${fields.targetCurrency}`}
           {implied !== null && (
             <span className="ml-2">
-              · Implied adjustment: {implied} {fields.targetCurrency}
+              · Implied adjustment: {groupAmountInput(implied)}{' '}
+              {fields.targetCurrency}
             </span>
           )}
         </div>


### PR DESCRIPTION
## Problem

On the add-transaction **Types → Fix balance** form, selecting an account showed two bugs:

1. **Wrong current balance** — always displayed `Now: 0`, regardless of the account's real balance.
2. **Unformatted figures** — the "Now" and "Implied adjustment" amounts rendered without thousands separators (e.g. `134097806.00`).

## Cause

1. `getAccountBalance` ran `ledger balance` with `--collapse`, which relabels the emitted row to the top-level account (e.g. `Assets`). `extractAccountBalance` matches the exact account name (`Assets:Bank:Blubank`), so the row never matched and the fallback `"0"` was returned.
2. The `current` and `implied` values were interpolated raw into the display string.

## Fix

- Drop `--collapse`. The exact-match row now carries the correct rolled-up `%T` total for the account (verified against a real journal: `Assets:Bank:Blubank|KIRT 1,779.540`).
- Format both displayed figures with `groupAmountInput` — the same grouping helper the `AmountInput` field uses — so display never drifts from the input.

## Verification

- `tsc --noEmit` clean.
- `fixBalancePreview` + `AmountInput.util` tests pass (22).
- End-to-end lookup against a real journal returns the correct balance.