### PR TITLE
feat(prices): known-prices list and per-commodity history page

### DIFF
--- a/app/prices/[symbol]/page.tsx
+++ b/app/prices/[symbol]/page.tsx
@@ -1,0 +1,24 @@
+import { PriceHistoryView } from '@/features/prices';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+import { notFound } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
+
+const PriceHistoryPage = async ({
+  params,
+}: {
+  params: Promise<{ symbol: string }>;
+}) => {
+  const user = await requireUser();
+  const { symbol: symbolParam } = await params;
+  const symbol = decodeURIComponent(symbolParam);
+
+  const held = await priceService.listHeldCommodities(user.id);
+  if (!held.includes(symbol)) notFound();
+
+  const points = await priceService.listPriceHistory(user.id, symbol);
+  return <PriceHistoryView symbol={symbol} points={points} />;
+};
+
+export default PriceHistoryPage;

--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -1,4 +1,4 @@
-import { PricesView } from '@/features/prices';
+import { PricesTabs } from '@/features/prices';
 import { requireUser } from '@/lib/auth/require-user';
 import { priceService } from '@/lib/prices';
 
@@ -6,14 +6,16 @@ export const dynamic = 'force-dynamic';
 
 const PricesPage = async () => {
   const user = await requireUser();
-  const [prices, commodities, baseCurrency] = await Promise.all([
+  const [known, prices, commodities, baseCurrency] = await Promise.all([
+    priceService.listKnownPrices(user.id),
     priceService.listManualPrices(user.id),
     priceService.listNormalizedSymbolsForUser(user.id),
     priceService.resolveBaseCurrency(user.id),
   ]);
 
   return (
-    <PricesView
+    <PricesTabs
+      known={known}
       prices={prices}
       commodities={commodities}
       baseCurrency={baseCurrency}

--- a/docs/superpowers/plans/2026-07-08-known-prices-page.md
+++ b/docs/superpowers/plans/2026-07-08-known-prices-page.md
@@ -1,0 +1,1026 @@
+# Known Prices Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only view of the latest price `ledger` knows for every held commodity, plus a per-commodity price-history page.
+
+**Architecture:** A new pure-function module (`lib/prices/knownPrices.ts`) parses `ledger` price output and derives price provenance. Two new `PriceService` methods shell out through the existing `runLedgerForUser` helper (which passes `--file` + `--price-db`). The `/prices` route becomes tabbed — a new "Known prices" list plus the existing manual-entry form — and a new `/prices/[symbol]` route renders a recharts chart + table.
+
+**Tech Stack:** Next.js (App Router, server components), TypeScript, Drizzle (Postgres), recharts 3.9.2, vitest, Ledger CLI 3.4.1.
+
+## Global Constraints
+
+- Ledger is invoked only through `runLedgerForUser(userId, args, journalRepo)` — it already passes `--file <mainPath>` and `--price-db <priceDbPath>`. Never call `execFile('ledger')` directly.
+- Base currency comes from `PriceService.resolveBaseCurrency(userId)` (currently returns `'USD'`).
+- Stale threshold: a price older than **7 days** is stale.
+- The exact prices format string (used verbatim) is:
+  `%(format_date(date,'%Y-%m-%d'))|%(quantity(scrub(display_amount)))|%(commodity(scrub(display_amount)))\n`
+- Naming: spell identifiers out in full — no abbreviations (`commodity` not `comm`, `history` not `hist`). Canonical domain acronyms (`USD`, `url`, `id`) are allowed.
+- No self-reference: no mention of any AI tool in code, comments, or commit messages.
+- recharts (3.9.2) is already a dependency — do not add charting libraries.
+
+## File Structure
+
+- Create `lib/prices/knownPrices.ts` — pure helpers + shared types (`PricePoint`, `KnownPrice`, `PriceSource`, `PRICES_FORMAT`, `STALE_THRESHOLD_DAYS`, `parsePriceHistory`, `deriveSource`, `ageInDays`).
+- Create `lib/prices/knownPrices.test.ts` — unit tests for the pure helpers.
+- Modify `lib/prices/service.ts` — add `listHeldCommodities`, `listPriceHistory`, `listKnownPrices`.
+- Modify `lib/prices/service.test.ts` — integration tests for the new service methods.
+- Modify `lib/prices/index.ts` — re-export new types + views.
+- Create `features/prices/PriceHistoryView.tsx` — recharts line chart + dated table (client component).
+- Create `features/prices/KnownPricesView.tsx` — the list table (client component, rows link to detail).
+- Create `features/prices/PricesTabs.tsx` — client wrapper switching between "Known prices" and "Manual entry" via the existing `TabBar`.
+- Modify `features/prices/index.ts` — export `KnownPricesView`, `PriceHistoryView`, `PricesTabs`.
+- Modify `app/prices/page.tsx` — also fetch known prices; render `PricesTabs`.
+- Create `app/prices/[symbol]/page.tsx` — validate symbol, fetch history, render `PriceHistoryView`.
+
+---
+
+### Task 1: Price parsing + provenance helpers (pure)
+
+**Files:**
+- Create: `lib/prices/knownPrices.ts`
+- Test: `lib/prices/knownPrices.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeCommoditySymbol` from `./symbols`.
+- Produces:
+  - `PRICES_FORMAT: string`
+  - `STALE_THRESHOLD_DAYS = 7`
+  - `type PricePoint = { date: string; price: number; quote: string }`
+  - `type PriceSource = 'fetched' | 'manual' | 'journal' | 'base' | 'none'`
+  - `type KnownPrice = { symbol: string; price: number | null; quote: string | null; date: string | null; ageDays: number | null; stale: boolean; source: PriceSource }`
+  - `parsePriceHistory(stdout: string): PricePoint[]`
+  - `ageInDays(dateIso: string, todayIso: string): number`
+  - `deriveSource(args: { symbolNormalized: string | null; quoteNormalized: string | null; date: string | null; base: string; manualKeys: Set<string>; fetchedKeys: Set<string> }): PriceSource`
+  - `priceKey(symbol: string, quote: string, date: string): string` — builds `` `${symbol}|${quote}|${date}` ``.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/prices/knownPrices.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  parsePriceHistory,
+  ageInDays,
+  deriveSource,
+  priceKey,
+  STALE_THRESHOLD_DAYS,
+} from './knownPrices';
+
+describe('parsePriceHistory', () => {
+  it('parses date|quantity|quote rows into points', () => {
+    const stdout = '2026-01-01|40000|$\n2026-06-15|50000|$\n';
+    expect(parsePriceHistory(stdout)).toEqual([
+      { date: '2026-01-01', price: 40000, quote: '$' },
+      { date: '2026-06-15', price: 50000, quote: '$' },
+    ]);
+  });
+
+  it('strips thousands separators from the quantity', () => {
+    expect(parsePriceHistory('2026-01-01|1,234.50|$\n')).toEqual([
+      { date: '2026-01-01', price: 1234.5, quote: '$' },
+    ]);
+  });
+
+  it('dedupes exact (date, price) duplicates', () => {
+    const stdout = '2026-01-01|40000|$\n2026-01-01|40000|$\n2026-01-02|40000|$\n';
+    expect(parsePriceHistory(stdout)).toEqual([
+      { date: '2026-01-01', price: 40000, quote: '$' },
+      { date: '2026-01-02', price: 40000, quote: '$' },
+    ]);
+  });
+
+  it('skips blank and malformed lines', () => {
+    const stdout = '\n2026-01-01|40000|$\ngarbage\n|bad|\n';
+    expect(parsePriceHistory(stdout)).toEqual([
+      { date: '2026-01-01', price: 40000, quote: '$' },
+    ]);
+  });
+});
+
+describe('ageInDays', () => {
+  it('counts whole UTC days between two ISO dates', () => {
+    expect(ageInDays('2026-07-01', '2026-07-08')).toBe(7);
+    expect(ageInDays('2026-07-08', '2026-07-08')).toBe(0);
+  });
+});
+
+describe('deriveSource', () => {
+  const base = 'USD';
+  const empty = new Set<string>();
+
+  it('returns base when the symbol is the base currency', () => {
+    expect(
+      deriveSource({ symbolNormalized: 'USD', quoteNormalized: 'USD', date: null, base, manualKeys: empty, fetchedKeys: empty })
+    ).toBe('base');
+  });
+
+  it('returns none when there is no date', () => {
+    expect(
+      deriveSource({ symbolNormalized: 'BTC', quoteNormalized: 'USD', date: null, base, manualKeys: empty, fetchedKeys: empty })
+    ).toBe('none');
+  });
+
+  it('prefers manual over fetched when both match', () => {
+    const key = priceKey('BTC', 'USD', '2026-06-15');
+    expect(
+      deriveSource({ symbolNormalized: 'BTC', quoteNormalized: 'USD', date: '2026-06-15', base, manualKeys: new Set([key]), fetchedKeys: new Set([key]) })
+    ).toBe('manual');
+  });
+
+  it('returns fetched when only the fetched set matches', () => {
+    const key = priceKey('BTC', 'USD', '2026-06-15');
+    expect(
+      deriveSource({ symbolNormalized: 'BTC', quoteNormalized: 'USD', date: '2026-06-15', base, manualKeys: empty, fetchedKeys: new Set([key]) })
+    ).toBe('fetched');
+  });
+
+  it('falls back to journal when nothing matches', () => {
+    expect(
+      deriveSource({ symbolNormalized: 'BTC', quoteNormalized: 'USD', date: '2026-06-15', base, manualKeys: empty, fetchedKeys: empty })
+    ).toBe('journal');
+  });
+});
+
+it('exposes a 7 day stale threshold', () => {
+  expect(STALE_THRESHOLD_DAYS).toBe(7);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/prices/knownPrices.test.ts`
+Expected: FAIL — cannot resolve `./knownPrices`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/prices/knownPrices.ts`:
+
+```ts
+import { normalizeCommoditySymbol } from './symbols';
+
+/**
+ * Machine-parseable prices report format: one `date|quantity|quote` line per
+ * price point. `quantity` is the numeric price, `quote` is the commodity the
+ * price is denominated in (e.g. `$`). Must be passed verbatim to
+ * `ledger prices <symbol> --prices-format <PRICES_FORMAT>`.
+ */
+export const PRICES_FORMAT =
+  "%(format_date(date,'%Y-%m-%d'))|%(quantity(scrub(display_amount)))|%(commodity(scrub(display_amount)))\n";
+
+export const STALE_THRESHOLD_DAYS = 7;
+
+export type PricePoint = { date: string; price: number; quote: string };
+
+export type PriceSource = 'fetched' | 'manual' | 'journal' | 'base' | 'none';
+
+export type KnownPrice = {
+  symbol: string;
+  price: number | null;
+  quote: string | null;
+  date: string | null;
+  ageDays: number | null;
+  stale: boolean;
+  source: PriceSource;
+};
+
+export const priceKey = (symbol: string, quote: string, date: string): string =>
+  `${symbol}|${quote}|${date}`;
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse `ledger prices --prices-format PRICES_FORMAT` output into points. */
+export const parsePriceHistory = (stdout: string): PricePoint[] => {
+  const seen = new Set<string>();
+  const points: PricePoint[] = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [date, quantity, quote] = trimmed.split('|');
+    if (!date || !quantity || !quote) continue;
+    if (!DATE_PATTERN.test(date)) continue;
+    const price = Number(quantity.replace(/,/g, ''));
+    if (!Number.isFinite(price)) continue;
+    const key = `${date}|${price}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    points.push({ date, price, quote });
+  }
+  return points;
+};
+
+/** Whole UTC days from `dateIso` to `todayIso` (both `YYYY-MM-DD`). */
+export const ageInDays = (dateIso: string, todayIso: string): number => {
+  const a = Date.parse(`${dateIso}T00:00:00Z`);
+  const b = Date.parse(`${todayIso}T00:00:00Z`);
+  return Math.round((b - a) / 86_400_000);
+};
+
+/**
+ * Determine where the latest price came from. `ledger` carries no provenance,
+ * so we correlate the (symbol, quote, date) key against the manual- and
+ * fetched-price sets built from the database. Manual wins when both match.
+ */
+export const deriveSource = (args: {
+  symbolNormalized: string | null;
+  quoteNormalized: string | null;
+  date: string | null;
+  base: string;
+  manualKeys: Set<string>;
+  fetchedKeys: Set<string>;
+}): PriceSource => {
+  const { symbolNormalized, quoteNormalized, date, base, manualKeys, fetchedKeys } = args;
+  if (symbolNormalized && symbolNormalized === base) return 'base';
+  if (!date || !symbolNormalized || !quoteNormalized) return 'none';
+  const key = priceKey(symbolNormalized, quoteNormalized, date);
+  if (manualKeys.has(key)) return 'manual';
+  if (fetchedKeys.has(key)) return 'fetched';
+  return 'journal';
+};
+
+/** Re-exported so the service normalizes symbols the same way. */
+export { normalizeCommoditySymbol };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run lib/prices/knownPrices.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/prices/knownPrices.ts lib/prices/knownPrices.test.ts
+git commit -m "feat(prices): add price-history parser and provenance helpers"
+```
+
+---
+
+### Task 2: Service — `listHeldCommodities` and `listPriceHistory`
+
+**Files:**
+- Modify: `lib/prices/service.ts`
+- Test: `lib/prices/service.test.ts`
+
+**Interfaces:**
+- Consumes: `runLedgerForUser` (already imported), `parsePriceHistory`, `PRICES_FORMAT`, `PricePoint` from `./knownPrices`; `this.deps.journalRepo`.
+- Produces:
+  - `listHeldCommodities(userId: string): Promise<string[]>` — raw commodity symbols from `ledger commodities`, trimmed, blanks dropped, original order.
+  - `listPriceHistory(userId: string, symbol: string): Promise<PricePoint[]>` — ascending by date; `[]` when ledger errors or the symbol has no price.
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new top-level `describe` block to `lib/prices/service.test.ts`, following the file's existing idiom — each `describe` owns its `ctx`/`service` via `beforeEach`/`afterEach` and seeds through the file's existing `seedUser(ctx, id, postings, baseCurrency)` helper:
+
+```ts
+describe('PriceService known-price reads', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('prices-known-');
+    service = new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+      mappingRepo: new CommodityMappingRepository(ctx.db),
+    });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('lists held commodities including the base symbol', async () => {
+    await seedUser(
+      ctx,
+      'u-comm',
+      [
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const held = await service.listHeldCommodities('u-comm');
+    expect(held).toContain('BTC');
+    expect(held).toContain('$');
+  });
+
+  it('returns ascending price points for a held commodity', async () => {
+    await seedUser(
+      ctx,
+      'u-hist',
+      [
+        'P 2026-01-01 BTC $40000',
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const points = await service.listPriceHistory('u-hist', 'BTC');
+    expect(points.length).toBeGreaterThanOrEqual(2);
+    expect(points.at(-1)).toEqual({ date: '2026-06-15', price: 50000, quote: '$' });
+  });
+});
+```
+
+> All of `setupTestDb`, `teardownTestDb`, `TestDbContext`, `seedUser`, `PriceService`, and the four repository classes are already imported at the top of `service.test.ts` (they are used by the existing describe blocks). No new imports are needed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/prices/service.test.ts -t "known-price reads"`
+Expected: FAIL — `service.listHeldCommodities is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/prices/service.ts` add the import near the other `./` imports:
+
+```ts
+import {
+  PRICES_FORMAT,
+  parsePriceHistory,
+  type PricePoint,
+} from './knownPrices';
+```
+
+Add these methods to the `PriceService` class (next to `listNormalizedSymbolsForUser`):
+
+```ts
+/** Raw commodity symbols the user holds, as `ledger commodities` prints them. */
+async listHeldCommodities(userId: string): Promise<string[]> {
+  let stdout: string;
+  try {
+    stdout = await runLedgerForUser(userId, ['commodities'], this.deps.journalRepo);
+  } catch {
+    return [];
+  }
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Full known price history for one commodity, ascending by date. */
+async listPriceHistory(userId: string, symbol: string): Promise<PricePoint[]> {
+  let stdout: string;
+  try {
+    stdout = await runLedgerForUser(
+      userId,
+      ['prices', symbol, '--prices-format', PRICES_FORMAT],
+      this.deps.journalRepo
+    );
+  } catch {
+    return [];
+  }
+  return parsePriceHistory(stdout);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run lib/prices/service.test.ts -t "known-price reads"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/prices/service.ts lib/prices/service.test.ts
+git commit -m "feat(prices): read held commodities and per-commodity price history"
+```
+
+---
+
+### Task 3: Service — `listKnownPrices`
+
+**Files:**
+- Modify: `lib/prices/service.ts`
+- Test: `lib/prices/service.test.ts`
+
+**Interfaces:**
+- Consumes: `listHeldCommodities`, `listPriceHistory`, `resolveBaseCurrency`, `this.deps.manualRepo.listForUser`, `this.deps.commodityRepo.listForQuote`; `deriveSource`, `ageInDays`, `priceKey`, `normalizeCommoditySymbol`, `STALE_THRESHOLD_DAYS`, `KnownPrice` from `./knownPrices`; `utcDate` (already defined in the file).
+- Produces:
+  - `listKnownPrices(userId: string): Promise<KnownPrice[]>` — one row per held commodity, sorted by `symbol` ascending. Base-currency row synthesized (`price: 1`, `source: 'base'`). Unpriced commodities produce a gap row (`price: null`, `source: 'none'`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append another top-level `describe` block to `lib/prices/service.test.ts`, same idiom as Task 2:
+
+```ts
+describe('PriceService.listKnownPrices', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('prices-list-');
+    service = new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+      mappingRepo: new CommodityMappingRepository(ctx.db),
+    });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('reports latest price, base row, and journal source', async () => {
+    await seedUser(
+      ctx,
+      'u-known',
+      [
+        'P 2026-01-01 BTC $40000',
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto        1 BTC @ $40000',
+        '    Assets:Metal         2 GOLD @ $10',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const rows = await service.listKnownPrices('u-known');
+    const bySymbol = Object.fromEntries(rows.map((r) => [r.symbol, r]));
+
+    // BTC: latest journal price, denominated in $.
+    expect(bySymbol.BTC.price).toBe(50000);
+    expect(bySymbol.BTC.date).toBe('2026-06-15');
+    expect(bySymbol.BTC.source).toBe('journal');
+    expect(bySymbol.BTC.stale).toBe(true); // 2026-06-15 is well over 7 days old
+
+    // GOLD held with a cost → has a price row.
+    expect(bySymbol.GOLD.price).toBe(10);
+
+    // Base currency row synthesized.
+    expect(bySymbol['$'].source).toBe('base');
+    expect(bySymbol['$'].price).toBe(1);
+    expect(bySymbol['$'].stale).toBe(false);
+  });
+
+  it('labels a fetched price as fetched', async () => {
+    await seedUser(
+      ctx,
+      'u-fetch',
+      [
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    // Record a fetched price on the same day/value as the latest known price.
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'BTC',
+        quote: 'USD',
+        price: 50000,
+        fetchedAt: new Date('2026-06-15T00:00:00Z'),
+        fetchedDate: '2026-06-15',
+      },
+    ]);
+    const rows = await service.listKnownPrices('u-fetch');
+    const btc = rows.find((r) => r.symbol === 'BTC');
+    expect(btc?.source).toBe('fetched');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/prices/service.test.ts -t listKnownPrices`
+Expected: FAIL — `service.listKnownPrices is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the import from `./knownPrices` in `service.ts` to include the helpers:
+
+```ts
+import {
+  PRICES_FORMAT,
+  STALE_THRESHOLD_DAYS,
+  ageInDays,
+  deriveSource,
+  normalizeCommoditySymbol as normalizeSymbol,
+  parsePriceHistory,
+  priceKey,
+  type KnownPrice,
+  type PricePoint,
+} from './knownPrices';
+```
+
+> Note: `service.ts` already imports `normalizeCommoditySymbol` from `./symbols`. Keep that import and alias the re-export here as `normalizeSymbol` to avoid a duplicate binding, OR simply use the existing `normalizeCommoditySymbol` import and drop it from this import list. Pick one; do not import the same name twice.
+
+Add the method to `PriceService`:
+
+```ts
+/** Latest known price for every held commodity, with provenance and staleness. */
+async listKnownPrices(userId: string): Promise<KnownPrice[]> {
+  const base = await this.resolveBaseCurrency(userId);
+  const [held, manual, fetched] = await Promise.all([
+    this.listHeldCommodities(userId),
+    this.deps.manualRepo.listForUser(userId),
+    this.deps.commodityRepo.listForQuote(base),
+  ]);
+
+  const manualKeys = new Set(
+    manual.map((row) => priceKey(row.symbol, row.quote, utcDate(row.pricedAt)))
+  );
+  const fetchedKeys = new Set(
+    fetched.map((row) => priceKey(row.symbol, row.quote, row.fetchedDate))
+  );
+
+  const today = utcDate(new Date());
+
+  const rows = await Promise.all(
+    held.map(async (symbol): Promise<KnownPrice> => {
+      const symbolNormalized = normalizeSymbol(symbol);
+
+      if (symbolNormalized && symbolNormalized === base) {
+        return {
+          symbol,
+          price: 1,
+          quote: base,
+          date: null,
+          ageDays: null,
+          stale: false,
+          source: 'base',
+        };
+      }
+
+      const history = await this.listPriceHistory(userId, symbol);
+      const latest: PricePoint | undefined = history.at(-1);
+
+      if (!latest) {
+        return {
+          symbol,
+          price: null,
+          quote: null,
+          date: null,
+          ageDays: null,
+          stale: false,
+          source: 'none',
+        };
+      }
+
+      const quoteNormalized = normalizeSymbol(latest.quote) ?? latest.quote;
+      const ageDays = ageInDays(latest.date, today);
+      return {
+        symbol,
+        price: latest.price,
+        quote: latest.quote,
+        date: latest.date,
+        ageDays,
+        stale: ageDays > STALE_THRESHOLD_DAYS,
+        source: deriveSource({
+          symbolNormalized,
+          quoteNormalized,
+          date: latest.date,
+          base,
+          manualKeys,
+          fetchedKeys,
+        }),
+      };
+    })
+  );
+
+  return rows.sort((a, b) => a.symbol.localeCompare(b.symbol));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run lib/prices/service.test.ts -t listKnownPrices`
+Expected: PASS both cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/prices/service.ts lib/prices/service.test.ts
+git commit -m "feat(prices): assemble known-prices list with provenance and gaps"
+```
+
+---
+
+### Task 4: Export new types and re-exports
+
+**Files:**
+- Modify: `lib/prices/index.ts`
+
+**Interfaces:**
+- Produces: barrel exports of `KnownPrice`, `PricePoint`, `PriceSource` from `lib/prices`.
+
+- [ ] **Step 1: Add exports**
+
+In `lib/prices/index.ts`, after the existing `export type { CommodityPriceRow } ...` line, add:
+
+```ts
+export type {
+  KnownPrice,
+  PricePoint,
+  PriceSource,
+} from './knownPrices';
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+Run: `pnpm type-check`
+Expected: PASS (no output errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/prices/index.ts
+git commit -m "chore(prices): export known-price types from barrel"
+```
+
+---
+
+### Task 5: Commodity detail page — chart + table
+
+**Files:**
+- Create: `features/prices/PriceHistoryView.tsx`
+- Create: `app/prices/[symbol]/page.tsx`
+- Modify: `features/prices/index.ts`
+
+**Interfaces:**
+- Consumes: `priceService.listHeldCommodities`, `priceService.listPriceHistory`, `PricePoint`, `requireUser`, `notFound`.
+- Produces: `PriceHistoryView` (default or named export) with props `{ symbol: string; points: PricePoint[] }`.
+
+- [ ] **Step 1: Create the view component**
+
+Create `features/prices/PriceHistoryView.tsx`:
+
+```tsx
+'use client';
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { TableScroll } from '@/components/ui/table';
+import type { PricePoint } from '@/lib/prices';
+
+type Props = { symbol: string; points: PricePoint[] };
+
+export const PriceHistoryView = ({ symbol, points }: Props) => {
+  const quote = points.at(-1)?.quote ?? '';
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
+      <header className="space-y-1">
+        <a href="/prices" className="text-sm text-muted-foreground hover:underline">
+          ← Back to prices
+        </a>
+        <h1 className="text-2xl font-semibold">{symbol} price history</h1>
+      </header>
+
+      {points.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          Ledger has no price history for {symbol}.
+        </p>
+      ) : (
+        <>
+          <div className="h-72 w-full rounded-2xl border border-border bg-card p-4 shadow-sm">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={points} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis dataKey="date" tick={{ fontSize: 12 }} minTickGap={24} />
+                <YAxis tick={{ fontSize: 12 }} width={72} domain={['auto', 'auto']} />
+                <Tooltip
+                  formatter={(value: number) => [`${value} ${quote}`, 'Price']}
+                />
+                <Line type="monotone" dataKey="price" dot={false} strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+            <TableScroll bleed={false}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th className="text-right">Price</th>
+                    <th>Quote</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...points].reverse().map((point) => (
+                    <tr key={`${point.date}-${point.price}`}>
+                      <td className="whitespace-nowrap text-muted-foreground">
+                        {point.date}
+                      </td>
+                      <td className="text-right tabular-nums whitespace-nowrap">
+                        {point.price}
+                      </td>
+                      <td className="whitespace-nowrap">{point.quote}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </TableScroll>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Export it**
+
+In `features/prices/index.ts` add:
+
+```ts
+export { PriceHistoryView } from './PriceHistoryView';
+```
+
+- [ ] **Step 3: Create the route**
+
+Create `app/prices/[symbol]/page.tsx`:
+
+```tsx
+import { PriceHistoryView } from '@/features/prices';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+import { notFound } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
+
+const PriceHistoryPage = async ({
+  params,
+}: {
+  params: Promise<{ symbol: string }>;
+}) => {
+  const user = await requireUser();
+  const { symbol: symbolParam } = await params;
+  const symbol = decodeURIComponent(symbolParam);
+
+  const held = await priceService.listHeldCommodities(user.id);
+  if (!held.includes(symbol)) notFound();
+
+  const points = await priceService.listPriceHistory(user.id, symbol);
+  return <PriceHistoryView symbol={symbol} points={points} />;
+};
+
+export default PriceHistoryPage;
+```
+
+- [ ] **Step 4: Type-check + build the route**
+
+Run: `pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/prices/PriceHistoryView.tsx features/prices/index.ts "app/prices/[symbol]/page.tsx"
+git commit -m "feat(prices): add per-commodity price-history page"
+```
+
+---
+
+### Task 6: Known-prices list + tabbed /prices page
+
+**Files:**
+- Create: `features/prices/KnownPricesView.tsx`
+- Create: `features/prices/PricesTabs.tsx`
+- Modify: `features/prices/index.ts`
+- Modify: `app/prices/page.tsx`
+
+**Interfaces:**
+- Consumes: `KnownPrice`, `ManualPrice`, existing `PricesView`, `TabBar` from `@/features/transactions/entry/TabBar`.
+- Produces:
+  - `KnownPricesView` with props `{ rows: KnownPrice[] }`.
+  - `PricesTabs` with props `{ known: KnownPrice[]; prices: ManualPrice[]; commodities: string[]; baseCurrency: string }`.
+
+- [ ] **Step 1: Create the list view**
+
+Create `features/prices/KnownPricesView.tsx`:
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { TableScroll } from '@/components/ui/table';
+import type { KnownPrice } from '@/lib/prices';
+
+type Props = { rows: KnownPrice[] };
+
+const sourceLabel: Record<KnownPrice['source'], string> = {
+  fetched: 'Fetched',
+  manual: 'Manual',
+  journal: 'Journal',
+  base: 'Base',
+  none: '—',
+};
+
+const ageLabel = (row: KnownPrice): string => {
+  if (row.ageDays === null) return '—';
+  if (row.ageDays === 0) return 'today';
+  if (row.ageDays === 1) return '1 day ago';
+  return `${row.ageDays} days ago`;
+};
+
+export const KnownPricesView = ({ rows }: Props) => (
+  <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+    <TableScroll bleed={false}>
+      <table>
+        <thead>
+          <tr>
+            <th>Commodity</th>
+            <th className="text-right">Latest price</th>
+            <th>Date</th>
+            <th>Age</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                No commodities
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={row.symbol}>
+                <td className="font-medium">
+                  <Link
+                    href={`/prices/${encodeURIComponent(row.symbol)}`}
+                    className="hover:underline"
+                  >
+                    {row.symbol}
+                  </Link>
+                </td>
+                <td className="text-right tabular-nums whitespace-nowrap">
+                  {row.price === null
+                    ? <span className="text-muted-foreground">no price</span>
+                    : `${row.price} ${row.quote ?? ''}`.trim()}
+                </td>
+                <td className="whitespace-nowrap text-muted-foreground">
+                  {row.date ?? '—'}
+                </td>
+                <td className="whitespace-nowrap">
+                  <span className={row.stale ? 'text-amber-600 dark:text-amber-500' : 'text-muted-foreground'}>
+                    {ageLabel(row)}
+                    {row.stale ? ' · stale' : ''}
+                  </span>
+                </td>
+                <td className="whitespace-nowrap text-muted-foreground">
+                  {sourceLabel[row.source]}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </TableScroll>
+  </div>
+);
+```
+
+- [ ] **Step 2: Create the tabs wrapper**
+
+Create `features/prices/PricesTabs.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { TabBar } from '@/features/transactions/entry/TabBar';
+import type { ManualPrice } from '@/db/schema';
+import type { KnownPrice } from '@/lib/prices';
+import { KnownPricesView } from './KnownPricesView';
+import { PricesView } from './PricesView';
+
+type Props = {
+  known: KnownPrice[];
+  prices: ManualPrice[];
+  commodities: string[];
+  baseCurrency: string;
+};
+
+const TABS = [
+  { id: 'known', label: 'Known prices' },
+  { id: 'manual', label: 'Manual entry' },
+];
+
+export const PricesTabs = ({ known, prices, commodities, baseCurrency }: Props) => {
+  const [active, setActive] = useState('known');
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
+      <header>
+        <h1 className="text-2xl font-semibold">Prices</h1>
+      </header>
+      <TabBar tabs={TABS} active={active} onSelect={setActive} />
+      {active === 'known' ? (
+        <KnownPricesView rows={known} />
+      ) : (
+        <PricesView
+          prices={prices}
+          commodities={commodities}
+          baseCurrency={baseCurrency}
+        />
+      )}
+    </div>
+  );
+};
+```
+
+> `PricesView` renders its own `<header>` with an `<h1>Prices</h1>`. That duplicates the wrapper header on the manual tab. Remove the `<header>…</header>` block (the `h1` + description paragraph) from `features/prices/PricesView.tsx` so the page has a single title, OR keep PricesView's header and drop the one in `PricesTabs`. Pick one; the plan assumes you keep the `PricesTabs` header and delete PricesView's outer `<header>` block and its surrounding `max-w-3xl` wrapper padding so it nests cleanly.
+
+- [ ] **Step 3: Export both**
+
+In `features/prices/index.ts` add:
+
+```ts
+export { KnownPricesView } from './KnownPricesView';
+export { PricesTabs } from './PricesTabs';
+```
+
+- [ ] **Step 4: Wire the page**
+
+Replace `app/prices/page.tsx` body to fetch known prices and render the tabs:
+
+```tsx
+import { PricesTabs } from '@/features/prices';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+
+export const dynamic = 'force-dynamic';
+
+const PricesPage = async () => {
+  const user = await requireUser();
+  const [known, prices, commodities, baseCurrency] = await Promise.all([
+    priceService.listKnownPrices(user.id),
+    priceService.listManualPrices(user.id),
+    priceService.listNormalizedSymbolsForUser(user.id),
+    priceService.resolveBaseCurrency(user.id),
+  ]);
+
+  return (
+    <PricesTabs
+      known={known}
+      prices={prices}
+      commodities={commodities}
+      baseCurrency={baseCurrency}
+    />
+  );
+};
+
+export default PricesPage;
+```
+
+- [ ] **Step 5: Type-check, lint, and run the existing suite**
+
+Run: `pnpm type-check && pnpm vitest run lib/prices`
+Expected: PASS.
+
+- [ ] **Step 6: Manual smoke check**
+
+Run: `pnpm dev`, sign in, open `/prices`. Verify the "Known prices" tab lists held commodities with prices, dates, age, and source; the base currency (USD/`$`) shows as `Base`; clicking a commodity opens `/prices/<symbol>` with a chart + table; the "Manual entry" tab still works.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add features/prices/KnownPricesView.tsx features/prices/PricesTabs.tsx features/prices/index.ts features/prices/PricesView.tsx app/prices/page.tsx
+git commit -m "feat(prices): tabbed prices page with known-prices list"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Tabbed `/prices` (known + manual) → Task 6. ✓
+- `/prices/[symbol]` chart + table → Task 5. ✓
+- Held commodities incl. base, gaps shown → Task 3 (`listKnownPrices`). ✓
+- Columns latest price+quote / date / age+stale / source → Tasks 3 (data) + 6 (render). ✓
+- Ledger commands via `runLedgerForUser` with verified format → Tasks 2–3. ✓
+- Source correlation against manual + fetched tables → Tasks 1 (`deriveSource`) + 3. ✓
+- Tests: parser, latest-selection, source correlation, gaps, base → Tasks 1 + 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. One conditional instruction (PricesView header dedupe) is spelled out with an explicit chosen path.
+
+**Type consistency:** `KnownPrice` / `PricePoint` / `PriceSource` defined in Task 1 and consumed unchanged in Tasks 3/5/6. `listHeldCommodities`, `listPriceHistory`, `listKnownPrices` signatures match between definition (Tasks 2–3) and callers (Tasks 5–6). `PRICES_FORMAT` used verbatim.
+
+**Note for the implementer:** `resolveBaseCurrency` currently returns `'USD'`; the base row and fetched-price quote correlation assume USD. If base-currency selection becomes per-user later, the `quoteNormalized` correlation still holds because it reads the actual ledger quote.

--- a/docs/superpowers/specs/2026-07-08-known-prices-page-design.md
+++ b/docs/superpowers/specs/2026-07-08-known-prices-page-design.md
@@ -1,0 +1,154 @@
+# Known Prices Page — Design
+
+Date: 2026-07-08
+Status: Approved (pending spec review)
+
+## Goal
+
+Give the user a read-only view of **what price `ledger` currently knows for
+each commodity they hold**, plus a per-commodity **price-history** page. This is
+distinct from the existing `/prices` page, which is a manual-entry form for
+recording rates the price provider does not cover.
+
+## User-facing shape
+
+1. `/prices` becomes **tabbed**:
+   - **Known prices** (new, default tab): a table of every held commodity with
+     its latest known price, the date of that price, its age/staleness, and the
+     source of that price.
+   - **Manual entry** (existing `PricesView`, moved under a tab, otherwise
+     unchanged).
+2. `/prices/[symbol]` (new): a **commodity detail** page — a recharts line chart
+   of the price over time on top, a dated price-history table below, and a back
+   link to the list.
+
+## Data sources & ledger commands
+
+All ledger calls go through the existing `runLedgerForUser` (or the
+request-scoped `runLedger`) helper, which already passes `--file <mainPath>` and
+`--price-db <priceDbPath>`. That is what makes the report faithful: `ledger`
+merges the journal's own `P`/`@` prices (from `--file`) with the app-generated
+price database of fetched + manual prices (from `--price-db`). No new env
+handling is required.
+
+### Commands (verified against Ledger 3.4.1)
+
+- **Held commodities:** `ledger commodities` → one symbol per line. Reports only
+  commodities that appear in **postings** (a commodity that exists solely as a
+  `P` directive is intentionally excluded — the user wants commodities they
+  hold).
+- **All known prices (for the list):** `ledger pricedb` → reparseable lines of
+  the form `P YYYY/MM/DD HH:MM:SS SYMBOL AMOUNT`, e.g.
+  `P 2026/06/01 00:00:00 BTC $45000`. One row per price-change day and per
+  posting day, across all held commodities.
+- **History for one commodity (for the detail page):**
+  `ledger prices <symbol>` → `YYYY/MM/DD SYMBOL AMOUNT` rows for that symbol
+  only. Because the symbol is fixed by the query, the parser only needs the date
+  and amount from each row (no symbol disambiguation).
+
+### Parsing notes
+
+- `pricedb` line: split into `P`, date, time, **symbol**, **amount (rest of
+  line)**. A multiword commodity is quoted by ledger (`"MUTUAL FUND"`); the
+  parser must be quote-aware for the symbol field. Amount is everything after
+  the symbol (may itself carry a trailing commodity, e.g. `45000 GBP`).
+- Do **not** use `--prices-format` with `%(commodity)` — in the prices report
+  that field resolves to the price's *quote* commodity (`$`), not the priced
+  symbol. Parse the positional output instead.
+- Dedupe history rows by `(date, amount)`; posting days inject rows that
+  duplicate the prevailing price.
+- **Latest price per commodity** = the row with the maximum date for that
+  symbol.
+
+### Pitfall discovered during design
+
+`ledger`'s report commands walk the **posting stream** — with zero postings,
+even `commodities`/`pricedb` return nothing. Ambient `LEDGER_FILE` /
+`LEDGER_PRICE_DB` env vars (present in the developer's shell) also silently
+merge an unrelated price db into results. Neither affects the app path, which
+always passes explicit `--file`/`--price-db`, but local manual testing must
+neutralize the environment (`env -i` + `--init-file /dev/null`) to reproduce
+app behavior.
+
+## Column semantics (Known prices tab)
+
+| Column | Source | Notes |
+|---|---|---|
+| Commodity | `ledger commodities` | Every held commodity, incl. base currency. |
+| Latest price + quote | `ledger pricedb` latest row | e.g. `$45,000.00`. |
+| Date | latest row date | Date of that price. |
+| Age / staleness | `today − date` | Badge when older than the stale threshold (default **7 days**). |
+| Source | correlation (below) | `fetched` \| `manual` \| `journal` \| `base` \| `none` (gap row). |
+
+### Coverage rules
+
+- **All held commodities appear**, including the base currency (USD).
+- The **base currency** row is synthesized: price `1.00 USD`, source `base`,
+  never stale (it is the numeraire; ledger reports no price for it).
+- A held commodity with **no known price** shows a `no price` row (gap), so the
+  user can spot missing coverage.
+
+### Source correlation
+
+`ledger` output does not carry provenance. Determine the source of the latest
+`(symbol, date, price)` by cross-referencing:
+
+1. Base currency → `base`.
+2. Match against manual prices (`manualRepository.listForUser`) → `manual`.
+3. Match against fetched prices (`repository` / `listForQuote`) → `fetched`.
+4. Otherwise the price came from a journal `P`/`@` directive → `journal`.
+
+Match on symbol + date (day granularity); price value is a tiebreaker. If a
+day has both a manual and fetched entry, prefer the one the price-db generator
+would have won with (documented in `regenerateUserPriceDb`).
+
+## Service layer (`lib/prices/service.ts`)
+
+Two new methods, both shelling through `runLedgerForUser`/`runLedger`:
+
+- `listKnownPrices(userId): Promise<KnownPrice[]>`
+  - Runs `commodities` + `pricedb`, builds latest-per-symbol, applies coverage
+    rules (base row, gap rows), runs source correlation.
+  - `KnownPrice = { symbol, price: string | null, quote: string | null,
+    date: string | null, ageDays: number | null, stale: boolean,
+    source: 'fetched' | 'manual' | 'journal' | 'base' | 'none' }`.
+- `listPriceHistory(userId, symbol): Promise<PricePoint[]>`
+  - Runs `prices <symbol>`, parses + dedupes.
+  - `PricePoint = { date: string, price: number, quote: string }`.
+
+Symbol is URL-encoded in the route (`encodeURIComponent`) to tolerate `$`,
+spaces, etc.; the page decodes and validates it against the held-commodity list
+before shelling out (guards against arbitrary argument injection into
+`ledger`).
+
+## UI
+
+- `features/prices/`:
+  - `KnownPricesView.tsx` — the list table (client component; sortable by
+    symbol/age is a nice-to-have, not required).
+  - `PriceHistoryView.tsx` — recharts `LineChart` + dated table.
+  - Wrap existing `PricesView` + new `KnownPricesView` in a tabs component on
+    the `/prices` page (reuse the app's existing tabs UI).
+- `app/prices/page.tsx` — fetch `listKnownPrices` alongside the existing manual
+  data; render tabbed view.
+- `app/prices/[symbol]/page.tsx` — `requireUser`, decode + validate symbol,
+  fetch `listPriceHistory`, render `PriceHistoryView`.
+
+recharts (3.9.2) is already a dependency.
+
+## Testing
+
+- Parser unit tests: `pricedb` output → rows (incl. quoted multiword symbol,
+  amount with trailing commodity, empty output).
+- `prices <symbol>` output → history points, dedupe of posting-day duplicates.
+- Latest-per-symbol selection (max date).
+- Source correlation: each of base / manual / fetched / journal, plus the
+  manual-vs-fetched-same-day tiebreak.
+- Coverage: gap row for held-but-unpriced commodity; base-currency row
+  synthesized.
+
+## Out of scope
+
+- Editing prices from this view (manual entry stays on its tab).
+- Normalizing quotes to the base currency (show the raw quote ledger stores).
+- Interpolating a continuous daily price series (chart plots known points only).

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { TableScroll } from '@/components/ui/table';
+import type { KnownPrice } from '@/lib/prices';
+import Link from 'next/link';
+
+type Props = { rows: KnownPrice[] };
+
+const sourceLabel: Record<KnownPrice['source'], string> = {
+  fetched: 'Fetched',
+  manual: 'Manual',
+  journal: 'Journal',
+  base: 'Base',
+  none: '—',
+};
+
+const ageLabel = (row: KnownPrice): string => {
+  if (row.ageDays === null) return '—';
+  if (row.ageDays === 0) return 'today';
+  if (row.ageDays === 1) return '1 day ago';
+  return `${row.ageDays} days ago`;
+};
+
+export const KnownPricesView = ({ rows }: Props) => (
+  <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+    <TableScroll bleed={false}>
+      <table>
+        <thead>
+          <tr>
+            <th>Commodity</th>
+            <th className="text-right">Latest price</th>
+            <th>Date</th>
+            <th>Age</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={5}
+                className="py-6 text-center text-muted-foreground"
+              >
+                No commodities
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={row.symbol}>
+                <td className="font-medium">
+                  <Link
+                    href={`/prices/${encodeURIComponent(row.symbol)}`}
+                    className="hover:underline"
+                  >
+                    {row.symbol}
+                  </Link>
+                </td>
+                <td className="text-right tabular-nums whitespace-nowrap">
+                  {row.price === null ? (
+                    <span className="text-muted-foreground">no price</span>
+                  ) : (
+                    `${row.price} ${row.quote ?? ''}`.trim()
+                  )}
+                </td>
+                <td className="whitespace-nowrap text-muted-foreground">
+                  {row.date ?? '—'}
+                </td>
+                <td className="whitespace-nowrap">
+                  <span
+                    className={
+                      row.stale
+                        ? 'text-amber-600 dark:text-amber-500'
+                        : 'text-muted-foreground'
+                    }
+                  >
+                    {ageLabel(row)}
+                    {row.stale ? ' · stale' : ''}
+                  </span>
+                </td>
+                <td className="whitespace-nowrap text-muted-foreground">
+                  {sourceLabel[row.source]}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </TableScroll>
+  </div>
+);

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -6,6 +6,10 @@ import Link from 'next/link';
 
 type Props = { rows: KnownPrice[] };
 
+const priceFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 8,
+});
+
 const sourceLabel: Record<KnownPrice['source'], string> = {
   fetched: 'Fetched',
   manual: 'Manual',
@@ -59,7 +63,7 @@ export const KnownPricesView = ({ rows }: Props) => (
                   {row.price === null ? (
                     <span className="text-muted-foreground">no price</span>
                   ) : (
-                    `${row.price} ${row.quote ?? ''}`.trim()
+                    `${priceFormatter.format(row.price)} ${row.quote ?? ''}`.trim()
                   )}
                 </td>
                 <td className="whitespace-nowrap text-muted-foreground">

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -1,14 +1,11 @@
 'use client';
 
+import { priceFormatter } from './format.util';
 import { TableScroll } from '@/components/ui/table';
 import type { KnownPrice } from '@/lib/prices';
 import Link from 'next/link';
 
 type Props = { rows: KnownPrice[] };
-
-const priceFormatter = new Intl.NumberFormat('en-US', {
-  maximumFractionDigits: 8,
-});
 
 const sourceLabel: Record<KnownPrice['source'], string> = {
   fetched: 'Fetched',

--- a/features/prices/PriceHistoryView.tsx
+++ b/features/prices/PriceHistoryView.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { TableScroll } from '@/components/ui/table';
+import type { PricePoint } from '@/lib/prices';
+import Link from 'next/link';
+
+type Props = { symbol: string; points: PricePoint[] };
+
+export const PriceHistoryView = ({ symbol, points }: Props) => {
+  const quote = points.at(-1)?.quote ?? '';
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
+      <header className="space-y-1">
+        <Link
+          href="/prices"
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Back to prices
+        </Link>
+        <h1 className="text-2xl font-semibold">{symbol} price history</h1>
+      </header>
+
+      {points.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          Ledger has no price history for {symbol}.
+        </p>
+      ) : (
+        <>
+          <div className="h-72 w-full rounded-2xl border border-border bg-card p-4 shadow-sm">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={points}
+                margin={{ top: 8, right: 16, bottom: 8, left: 8 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  className="stroke-border"
+                />
+                <XAxis dataKey="date" tick={{ fontSize: 12 }} minTickGap={24} />
+                <YAxis
+                  tick={{ fontSize: 12 }}
+                  width={72}
+                  domain={['auto', 'auto']}
+                />
+                <Tooltip
+                  formatter={(value) => [`${value ?? ''} ${quote}`, 'Price']}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="price"
+                  dot={false}
+                  strokeWidth={2}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+            <TableScroll bleed={false}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th className="text-right">Price</th>
+                    <th>Quote</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...points].reverse().map((point) => (
+                    <tr key={`${point.date}-${point.price}`}>
+                      <td className="whitespace-nowrap text-muted-foreground">
+                        {point.date}
+                      </td>
+                      <td className="text-right tabular-nums whitespace-nowrap">
+                        {point.price}
+                      </td>
+                      <td className="whitespace-nowrap">{point.quote}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </TableScroll>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/features/prices/PriceHistoryView.tsx
+++ b/features/prices/PriceHistoryView.tsx
@@ -15,6 +15,10 @@ import Link from 'next/link';
 
 type Props = { symbol: string; points: PricePoint[] };
 
+const priceFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 8,
+});
+
 export const PriceHistoryView = ({ symbol, points }: Props) => {
   const quote = points.at(-1)?.quote ?? '';
 
@@ -51,9 +55,15 @@ export const PriceHistoryView = ({ symbol, points }: Props) => {
                   tick={{ fontSize: 12 }}
                   width={72}
                   domain={['auto', 'auto']}
+                  tickFormatter={(value) =>
+                    priceFormatter.format(value as number)
+                  }
                 />
                 <Tooltip
-                  formatter={(value) => [`${value ?? ''} ${quote}`, 'Price']}
+                  formatter={(value) => [
+                    `${priceFormatter.format(value as number)} ${quote}`,
+                    'Price',
+                  ]}
                 />
                 <Line
                   type="monotone"
@@ -82,7 +92,7 @@ export const PriceHistoryView = ({ symbol, points }: Props) => {
                         {point.date}
                       </td>
                       <td className="text-right tabular-nums whitespace-nowrap">
-                        {point.price}
+                        {priceFormatter.format(point.price)}
                       </td>
                       <td className="whitespace-nowrap">{point.quote}</td>
                     </tr>

--- a/features/prices/PriceHistoryView.tsx
+++ b/features/prices/PriceHistoryView.tsx
@@ -9,18 +9,21 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { priceFormatter } from './format.util';
 import { TableScroll } from '@/components/ui/table';
 import type { PricePoint } from '@/lib/prices';
+import { normalizeCommoditySymbol } from '@/lib/prices/symbols';
 import Link from 'next/link';
 
 type Props = { symbol: string; points: PricePoint[] };
 
-const priceFormatter = new Intl.NumberFormat('en-US', {
-  maximumFractionDigits: 8,
-});
+// Match the known-prices list, which renders the normalized quote (e.g. `$`
+// becomes `USD`) so the same commodity reads identically on both pages.
+const displayQuote = (raw: string): string =>
+  raw ? (normalizeCommoditySymbol(raw) ?? raw) : raw;
 
 export const PriceHistoryView = ({ symbol, points }: Props) => {
-  const quote = points.at(-1)?.quote ?? '';
+  const quote = displayQuote(points.at(-1)?.quote ?? '');
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
@@ -94,7 +97,9 @@ export const PriceHistoryView = ({ symbol, points }: Props) => {
                       <td className="text-right tabular-nums whitespace-nowrap">
                         {priceFormatter.format(point.price)}
                       </td>
-                      <td className="whitespace-nowrap">{point.quote}</td>
+                      <td className="whitespace-nowrap">
+                        {displayQuote(point.quote)}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/features/prices/PricesTabs.tsx
+++ b/features/prices/PricesTabs.tsx
@@ -36,11 +36,18 @@ export const PricesTabs = ({
       {active === 'known' ? (
         <KnownPricesView rows={known} />
       ) : (
-        <PricesView
-          prices={prices}
-          commodities={commodities}
-          baseCurrency={baseCurrency}
-        />
+        <>
+          <p className="text-muted-foreground text-sm">
+            Record exchange rates for commodities (e.g. KIRT) your price
+            provider doesn&apos;t cover. Each rate is dated, so historical
+            reports use the rate in effect at the time.
+          </p>
+          <PricesView
+            prices={prices}
+            commodities={commodities}
+            baseCurrency={baseCurrency}
+          />
+        </>
       )}
     </div>
   );

--- a/features/prices/PricesTabs.tsx
+++ b/features/prices/PricesTabs.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { KnownPricesView } from './KnownPricesView';
+import { PricesView } from './PricesView';
+import type { ManualPrice } from '@/db/schema';
+import { TabBar } from '@/features/transactions/entry/TabBar';
+import type { KnownPrice } from '@/lib/prices';
+
+type Props = {
+  known: KnownPrice[];
+  prices: ManualPrice[];
+  commodities: string[];
+  baseCurrency: string;
+};
+
+const TABS = [
+  { id: 'known', label: 'Known prices' },
+  { id: 'manual', label: 'Manual entry' },
+];
+
+export const PricesTabs = ({
+  known,
+  prices,
+  commodities,
+  baseCurrency,
+}: Props) => {
+  const [active, setActive] = useState('known');
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
+      <header>
+        <h1 className="text-2xl font-semibold">Prices</h1>
+      </header>
+      <TabBar tabs={TABS} active={active} onSelect={setActive} />
+      {active === 'known' ? (
+        <KnownPricesView rows={known} />
+      ) : (
+        <PricesView
+          prices={prices}
+          commodities={commodities}
+          baseCurrency={baseCurrency}
+        />
+      )}
+    </div>
+  );
+};

--- a/features/prices/PricesView.tsx
+++ b/features/prices/PricesView.tsx
@@ -69,16 +69,7 @@ export const PricesView = ({ prices, commodities, baseCurrency }: Props) => {
   });
 
   return (
-    <div className="mx-auto w-full max-w-3xl space-y-8 p-4">
-      <header>
-        <h1 className="text-2xl font-semibold">Prices</h1>
-        <p className="text-muted-foreground text-sm">
-          Record exchange rates for commodities (e.g. KIRT) your price provider
-          doesn&apos;t cover. Each rate is dated, so historical reports use the
-          rate in effect at the time.
-        </p>
-      </header>
-
+    <div className="space-y-8">
       <form action={formAction} className="space-y-4 rounded-lg border p-4">
         <input type="hidden" name="draft" value={draft} />
 

--- a/features/prices/format.util.ts
+++ b/features/prices/format.util.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared number formatter for commodity prices. Kept in one place so the
+ * known-prices list and the price-history detail view can't drift on the
+ * fraction-digit precision they render.
+ */
+export const priceFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 8,
+});

--- a/features/prices/index.ts
+++ b/features/prices/index.ts
@@ -1,2 +1,4 @@
 export { PricesView } from './PricesView';
 export { PriceHistoryView } from './PriceHistoryView';
+export { KnownPricesView } from './KnownPricesView';
+export { PricesTabs } from './PricesTabs';

--- a/features/prices/index.ts
+++ b/features/prices/index.ts
@@ -1,1 +1,2 @@
 export { PricesView } from './PricesView';
+export { PriceHistoryView } from './PriceHistoryView';

--- a/lib/prices/index.ts
+++ b/lib/prices/index.ts
@@ -39,3 +39,4 @@ export type {
 } from './provider';
 export { renderPriceDb, hasGeneratedBanner, BANNER_MARKER } from './formatter';
 export type { CommodityPriceRow } from './formatter';
+export type { KnownPrice, PricePoint, PriceSource } from './knownPrices';

--- a/lib/prices/knownPrices.test.ts
+++ b/lib/prices/knownPrices.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePriceHistory,
+  ageInDays,
+  deriveSource,
+  priceKey,
+  STALE_THRESHOLD_DAYS,
+} from './knownPrices';
+
+describe('parsePriceHistory', () => {
+  it('parses date|quantity|quote rows into points', () => {
+    const stdout = '2026-01-01|40000|$\n2026-06-15|50000|$\n';
+    expect(parsePriceHistory(stdout)).toEqual([
+      { date: '2026-01-01', price: 40000, quote: '$' },
+      { date: '2026-06-15', price: 50000, quote: '$' },
+    ]);
+  });
+
+  it('strips thousands separators from the quantity', () => {
+    expect(parsePriceHistory('2026-01-01|1,234.50|$\n')).toEqual([
+      { date: '2026-01-01', price: 1234.5, quote: '$' },
+    ]);
+  });
+
+  it('dedupes exact (date, price) duplicates', () => {
+    const stdout =
+      '2026-01-01|40000|$\n2026-01-01|40000|$\n2026-01-02|40000|$\n';
+    expect(parsePriceHistory(stdout)).toEqual([
+      { date: '2026-01-01', price: 40000, quote: '$' },
+      { date: '2026-01-02', price: 40000, quote: '$' },
+    ]);
+  });
+
+  it('skips blank and malformed lines', () => {
+    const stdout = '\n2026-01-01|40000|$\ngarbage\n|bad|\n';
+    expect(parsePriceHistory(stdout)).toEqual([
+      { date: '2026-01-01', price: 40000, quote: '$' },
+    ]);
+  });
+});
+
+describe('ageInDays', () => {
+  it('counts whole UTC days between two ISO dates', () => {
+    expect(ageInDays('2026-07-01', '2026-07-08')).toBe(7);
+    expect(ageInDays('2026-07-08', '2026-07-08')).toBe(0);
+  });
+});
+
+describe('deriveSource', () => {
+  const base = 'USD';
+  const empty = new Set<string>();
+
+  it('returns base when the symbol is the base currency', () => {
+    expect(
+      deriveSource({
+        symbolNormalized: 'USD',
+        quoteNormalized: 'USD',
+        date: null,
+        base,
+        manualKeys: empty,
+        fetchedKeys: empty,
+      })
+    ).toBe('base');
+  });
+
+  it('returns none when there is no date', () => {
+    expect(
+      deriveSource({
+        symbolNormalized: 'BTC',
+        quoteNormalized: 'USD',
+        date: null,
+        base,
+        manualKeys: empty,
+        fetchedKeys: empty,
+      })
+    ).toBe('none');
+  });
+
+  it('prefers manual over fetched when both match', () => {
+    const key = priceKey('BTC', 'USD', '2026-06-15');
+    expect(
+      deriveSource({
+        symbolNormalized: 'BTC',
+        quoteNormalized: 'USD',
+        date: '2026-06-15',
+        base,
+        manualKeys: new Set([key]),
+        fetchedKeys: new Set([key]),
+      })
+    ).toBe('manual');
+  });
+
+  it('returns fetched when only the fetched set matches', () => {
+    const key = priceKey('BTC', 'USD', '2026-06-15');
+    expect(
+      deriveSource({
+        symbolNormalized: 'BTC',
+        quoteNormalized: 'USD',
+        date: '2026-06-15',
+        base,
+        manualKeys: empty,
+        fetchedKeys: new Set([key]),
+      })
+    ).toBe('fetched');
+  });
+
+  it('falls back to journal when nothing matches', () => {
+    expect(
+      deriveSource({
+        symbolNormalized: 'BTC',
+        quoteNormalized: 'USD',
+        date: '2026-06-15',
+        base,
+        manualKeys: empty,
+        fetchedKeys: empty,
+      })
+    ).toBe('journal');
+  });
+});
+
+it('exposes a 7 day stale threshold', () => {
+  expect(STALE_THRESHOLD_DAYS).toBe(7);
+});

--- a/lib/prices/knownPrices.test.ts
+++ b/lib/prices/knownPrices.test.ts
@@ -3,6 +3,7 @@ import {
   parsePriceHistory,
   ageInDays,
   deriveSource,
+  latestGenuinePrice,
   priceKey,
   STALE_THRESHOLD_DAYS,
 } from './knownPrices';
@@ -116,8 +117,52 @@ describe('deriveSource', () => {
       })
     ).toBe('journal');
   });
+
+  it('returns journal when symbolNormalized is null but a date is present', () => {
+    expect(
+      deriveSource({
+        symbolNormalized: null,
+        quoteNormalized: 'USD',
+        date: '2026-06-15',
+        base,
+        manualKeys: empty,
+        fetchedKeys: empty,
+      })
+    ).toBe('journal');
+  });
 });
 
 it('exposes a 7 day stale threshold', () => {
   expect(STALE_THRESHOLD_DAYS).toBe(7);
+});
+
+describe('latestGenuinePrice', () => {
+  it('returns null for empty input', () => {
+    expect(latestGenuinePrice([])).toBeNull();
+  });
+
+  it('uses the first (set) date when the price never changes across posting rows', () => {
+    const points = [
+      { date: '2026-01-01', price: 40000, quote: '$' },
+      { date: '2026-01-02', price: 40000, quote: '$' },
+      { date: '2026-07-01', price: 40000, quote: '$' },
+    ];
+    expect(latestGenuinePrice(points)).toEqual({
+      date: '2026-01-01',
+      price: 40000,
+      quote: '$',
+    });
+  });
+
+  it('returns the change date when the price changes', () => {
+    const points = [
+      { date: '2026-01-01', price: 40000, quote: '$' },
+      { date: '2026-06-15', price: 50000, quote: '$' },
+    ];
+    expect(latestGenuinePrice(points)).toEqual({
+      date: '2026-06-15',
+      price: 50000,
+      quote: '$',
+    });
+  });
 });

--- a/lib/prices/knownPrices.ts
+++ b/lib/prices/knownPrices.ts
@@ -1,0 +1,90 @@
+import { normalizeCommoditySymbol } from './symbols';
+
+/**
+ * Machine-parseable prices report format: one `date|quantity|quote` line per
+ * price point. `quantity` is the numeric price, `quote` is the commodity the
+ * price is denominated in (e.g. `$`). Must be passed verbatim to
+ * `ledger prices <symbol> --prices-format <PRICES_FORMAT>`.
+ */
+export const PRICES_FORMAT =
+  "%(format_date(date,'%Y-%m-%d'))|%(quantity(scrub(display_amount)))|%(commodity(scrub(display_amount)))\n";
+
+export const STALE_THRESHOLD_DAYS = 7;
+
+export type PricePoint = { date: string; price: number; quote: string };
+
+export type PriceSource = 'fetched' | 'manual' | 'journal' | 'base' | 'none';
+
+export type KnownPrice = {
+  symbol: string;
+  price: number | null;
+  quote: string | null;
+  date: string | null;
+  ageDays: number | null;
+  stale: boolean;
+  source: PriceSource;
+};
+
+export const priceKey = (symbol: string, quote: string, date: string): string =>
+  `${symbol}|${quote}|${date}`;
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse `ledger prices --prices-format PRICES_FORMAT` output into points. */
+export const parsePriceHistory = (stdout: string): PricePoint[] => {
+  const seen = new Set<string>();
+  const points: PricePoint[] = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [date, quantity, quote] = trimmed.split('|');
+    if (!date || !quantity || !quote) continue;
+    if (!DATE_PATTERN.test(date)) continue;
+    const price = Number(quantity.replace(/,/g, ''));
+    if (!Number.isFinite(price)) continue;
+    const key = `${date}|${price}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    points.push({ date, price, quote });
+  }
+  return points;
+};
+
+/** Whole UTC days from `dateIso` to `todayIso` (both `YYYY-MM-DD`). */
+export const ageInDays = (dateIso: string, todayIso: string): number => {
+  const a = Date.parse(`${dateIso}T00:00:00Z`);
+  const b = Date.parse(`${todayIso}T00:00:00Z`);
+  return Math.round((b - a) / 86_400_000);
+};
+
+/**
+ * Determine where the latest price came from. `ledger` carries no provenance,
+ * so we correlate the (symbol, quote, date) key against the manual- and
+ * fetched-price sets built from the database. Manual wins when both match.
+ */
+export const deriveSource = (args: {
+  symbolNormalized: string | null;
+  quoteNormalized: string | null;
+  date: string | null;
+  base: string;
+  manualKeys: Set<string>;
+  fetchedKeys: Set<string>;
+}): PriceSource => {
+  const {
+    symbolNormalized,
+    quoteNormalized,
+    date,
+    base,
+    manualKeys,
+    fetchedKeys,
+  } = args;
+  if (symbolNormalized && symbolNormalized === base) return 'base';
+  if (!date || !symbolNormalized || !quoteNormalized) return 'none';
+  const key = priceKey(symbolNormalized, quoteNormalized, date);
+  if (manualKeys.has(key)) return 'manual';
+  if (fetchedKeys.has(key)) return 'fetched';
+  return 'journal';
+};
+
+/** Re-exported so the service normalizes symbols the same way. */
+export { normalizeCommoditySymbol };

--- a/lib/prices/knownPrices.ts
+++ b/lib/prices/knownPrices.ts
@@ -50,11 +50,34 @@ export const parsePriceHistory = (stdout: string): PricePoint[] => {
   return points;
 };
 
-/** Whole UTC days from `dateIso` to `todayIso` (both `YYYY-MM-DD`). */
+/**
+ * Whole UTC days from `dateIso` to `todayIso` (both `YYYY-MM-DD`). Returns a
+ * negative number when `dateIso` is in the future relative to `todayIso`.
+ */
 export const ageInDays = (dateIso: string, todayIso: string): number => {
   const a = Date.parse(`${dateIso}T00:00:00Z`);
   const b = Date.parse(`${todayIso}T00:00:00Z`);
   return Math.round((b - a) / 86_400_000);
+};
+
+/**
+ * The current price and the date it last changed. `ledger prices` forward-
+ * carries the prevailing price onto every posting date, so the final row's
+ * date can be a transaction date rather than when the price was actually set.
+ * Returns the last point's price/quote paired with the date the price value
+ * last changed (the start of the final constant-price run), so staleness
+ * reflects how long the current price has stood. Returns null for empty input.
+ */
+export const latestGenuinePrice = (points: PricePoint[]): PricePoint | null => {
+  if (points.length === 0) return null;
+  const last = points[points.length - 1];
+  let changeDate = points[0].date;
+  for (let index = 1; index < points.length; index += 1) {
+    if (points[index].price !== points[index - 1].price) {
+      changeDate = points[index].date;
+    }
+  }
+  return { date: changeDate, price: last.price, quote: last.quote };
 };
 
 /**
@@ -79,7 +102,8 @@ export const deriveSource = (args: {
     fetchedKeys,
   } = args;
   if (symbolNormalized && symbolNormalized === base) return 'base';
-  if (!date || !symbolNormalized || !quoteNormalized) return 'none';
+  if (!date) return 'none';
+  if (!symbolNormalized || !quoteNormalized) return 'journal';
   const key = priceKey(symbolNormalized, quoteNormalized, date);
   if (manualKeys.has(key)) return 'manual';
   if (fetchedKeys.has(key)) return 'fetched';

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -698,4 +698,30 @@ describe('PriceService.listKnownPrices', () => {
     expect(widget?.price).toBeNull();
     expect(widget?.source).toBe('none');
   });
+
+  it('dates staleness from when the price was set, not a later posting', async () => {
+    await seedUser(
+      ctx,
+      'u-stale',
+      [
+        // BTC's only genuine price is set 2026-01-01. A later 2026-07-01 posting
+        // transacts BTC at the same (forward-carried) price — it must NOT be
+        // read as the "latest" price date.
+        'P 2026-01-01 BTC $40000',
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '2026-07-01 buy more',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const rows = await service.listKnownPrices('u-stale');
+    const btc = rows.find((row) => row.symbol === 'BTC');
+    expect(btc?.date).toBe('2026-01-01');
+    expect(btc?.price).toBe(40000);
+    expect(btc?.stale).toBe(true);
+  });
 });

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -567,3 +567,85 @@ describe('PriceService known-price reads', () => {
     expect(points).toEqual([]);
   });
 });
+
+describe('PriceService.listKnownPrices', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('prices-list-');
+    service = new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+      mappingRepo: new CommodityMappingRepository(ctx.db),
+    });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('reports latest price, base row, and journal source', async () => {
+    await seedUser(
+      ctx,
+      'u-known',
+      [
+        'P 2026-01-01 BTC $40000',
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto        1 BTC @ $40000',
+        '    Assets:Metal         2 GOLD @ $10',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const rows = await service.listKnownPrices('u-known');
+    const bySymbol = Object.fromEntries(rows.map((r) => [r.symbol, r]));
+
+    // BTC: latest journal price, denominated in $.
+    expect(bySymbol.BTC.price).toBe(50000);
+    expect(bySymbol.BTC.date).toBe('2026-06-15');
+    expect(bySymbol.BTC.source).toBe('journal');
+    expect(bySymbol.BTC.stale).toBe(true); // 2026-06-15 is well over 7 days old
+
+    // GOLD held with a cost → has a price row.
+    expect(bySymbol.GOLD.price).toBe(10);
+
+    // Base currency row synthesized.
+    expect(bySymbol['$'].source).toBe('base');
+    expect(bySymbol['$'].price).toBe(1);
+    expect(bySymbol['$'].stale).toBe(false);
+  });
+
+  it('labels a fetched price as fetched', async () => {
+    await seedUser(
+      ctx,
+      'u-fetch',
+      [
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    // Record a fetched price on the same day/value as the latest known price.
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'BTC',
+        quote: 'USD',
+        price: 50000,
+        fetchedAt: new Date('2026-06-15T00:00:00Z'),
+        fetchedDate: '2026-06-15',
+      },
+    ]);
+    const rows = await service.listKnownPrices('u-fetch');
+    const btc = rows.find((r) => r.symbol === 'BTC');
+    expect(btc?.source).toBe('fetched');
+  });
+});

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -549,4 +549,21 @@ describe('PriceService known-price reads', () => {
       quote: '$',
     });
   });
+
+  it('treats a flag-like symbol as an inert query, not a ledger flag', async () => {
+    await seedUser(
+      ctx,
+      'u-inject',
+      [
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const points = await service.listPriceHistory('u-inject', '--version');
+    expect(points).toEqual([]);
+  });
 });

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -489,3 +489,64 @@ describe('PriceService manual prices', () => {
     expect(await service.deleteManualPrice('alice', 999999)).toBe(false);
   });
 });
+
+describe('PriceService known-price reads', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('prices-known-');
+    service = new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+      mappingRepo: new CommodityMappingRepository(ctx.db),
+    });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('lists held commodities including the base symbol', async () => {
+    await seedUser(
+      ctx,
+      'u-comm',
+      [
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const held = await service.listHeldCommodities('u-comm');
+    expect(held).toContain('BTC');
+    expect(held).toContain('$');
+  });
+
+  it('returns ascending price points for a held commodity', async () => {
+    await seedUser(
+      ctx,
+      'u-hist',
+      [
+        'P 2026-01-01 BTC $40000',
+        'P 2026-06-15 BTC $50000',
+        '2026-01-02 buy',
+        '    Assets:Crypto   1 BTC @ $40000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const points = await service.listPriceHistory('u-hist', 'BTC');
+    expect(points.length).toBeGreaterThanOrEqual(2);
+    expect(points.at(-1)).toEqual({
+      date: '2026-06-15',
+      price: 50000,
+      quote: '$',
+    });
+  });
+});

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -648,4 +648,54 @@ describe('PriceService.listKnownPrices', () => {
     const btc = rows.find((r) => r.symbol === 'BTC');
     expect(btc?.source).toBe('fetched');
   });
+
+  it('labels a manual price as manual', async () => {
+    // Posting and P directive on the same date so latestGenuinePrice returns
+    // that date, which then matches the manual key (BTC|USD|2026-06-15).
+    await seedUser(
+      ctx,
+      'u-manual',
+      [
+        'P 2026-06-15 BTC $50000',
+        '2026-06-15 buy',
+        '    Assets:Crypto   1 BTC @ $50000',
+        '    Assets:Cash',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    await new ManualPriceRepository(ctx.db).upsertMany([
+      {
+        userId: 'u-manual',
+        symbol: 'BTC',
+        quote: 'USD',
+        price: 50000,
+        pricedAt: new Date('2026-06-15T00:00:00Z'),
+      },
+    ]);
+    const rows = await service.listKnownPrices('u-manual');
+    const btc = rows.find((r) => r.symbol === 'BTC');
+    expect(btc?.source).toBe('manual');
+  });
+
+  it('returns a gap row for a held commodity with no price', async () => {
+    // WIDGET appears in commodities but has no P directive, so ledger prices
+    // WIDGET returns nothing → the service emits a gap row.
+    await seedUser(
+      ctx,
+      'u-gap',
+      [
+        '2026-01-02 open',
+        '    Assets:Stuff   5 WIDGET',
+        '    Assets:Stuff  -5 WIDGET',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const rows = await service.listKnownPrices('u-gap');
+    const widget = rows.find((r) => r.symbol === 'WIDGET');
+    expect(widget).toBeDefined();
+    expect(widget?.price).toBeNull();
+    expect(widget?.source).toBe('none');
+  });
 });

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -7,7 +7,12 @@ import { renderPriceDb, hasGeneratedBanner } from './formatter';
 import type { CommodityPriceRow } from './formatter';
 import {
   PRICES_FORMAT,
+  STALE_THRESHOLD_DAYS,
+  ageInDays,
+  deriveSource,
   parsePriceHistory,
+  priceKey,
+  type KnownPrice,
   type PricePoint,
 } from './knownPrices';
 import { withPriceLock } from './lock';
@@ -362,6 +367,82 @@ export class PriceService {
       }
       // kind === 'manual' → skipped: user supplies the price.
     }
+  }
+
+  /** Latest known price for every held commodity, with provenance and staleness. */
+  async listKnownPrices(userId: string): Promise<KnownPrice[]> {
+    const base = await this.resolveBaseCurrency(userId);
+    const [held, manual, fetched] = await Promise.all([
+      this.listHeldCommodities(userId),
+      this.deps.manualRepo.listForUser(userId),
+      this.deps.commodityRepo.listForQuote(base),
+    ]);
+
+    const manualKeys = new Set(
+      manual.map((row) =>
+        priceKey(row.symbol, row.quote, utcDate(row.pricedAt))
+      )
+    );
+    const fetchedKeys = new Set(
+      fetched.map((row) => priceKey(row.symbol, row.quote, row.fetchedDate))
+    );
+
+    const today = utcDate(new Date());
+
+    const rows = await Promise.all(
+      held.map(async (symbol): Promise<KnownPrice> => {
+        const symbolNormalized = normalizeCommoditySymbol(symbol);
+
+        if (symbolNormalized && symbolNormalized === base) {
+          return {
+            symbol,
+            price: 1,
+            quote: base,
+            date: null,
+            ageDays: null,
+            stale: false,
+            source: 'base',
+          };
+        }
+
+        const history = await this.listPriceHistory(userId, symbol);
+        const latest: PricePoint | undefined = history.at(-1);
+
+        if (!latest) {
+          return {
+            symbol,
+            price: null,
+            quote: null,
+            date: null,
+            ageDays: null,
+            stale: false,
+            source: 'none',
+          };
+        }
+
+        const quoteNormalized =
+          normalizeCommoditySymbol(latest.quote) ?? latest.quote;
+        const ageDays = ageInDays(latest.date, today);
+        return {
+          symbol,
+          price: latest.price,
+          quote: latest.quote,
+          date: latest.date,
+          ageDays,
+          stale: ageDays > STALE_THRESHOLD_DAYS,
+          source: deriveSource({
+            symbolNormalized,
+            quoteNormalized,
+            date: latest.date,
+            base,
+            manualKeys,
+            fetchedKeys,
+          }),
+        };
+      })
+    );
+
+    return rows.sort((a, b) => a.symbol.localeCompare(b.symbol));
   }
 
   private async maybeMigrateLegacyFiles(users: string[]): Promise<void> {

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -261,22 +261,38 @@ export class PriceService {
       .filter((line) => line.length > 0);
   }
 
-  /** Full known price history for one commodity, ascending by date. */
+  /**
+   * Full known price history for one commodity, ascending by date.
+   *
+   * Side effect: when no price-db.ledger exists yet this method creates an
+   * empty one so that `ledger prices` can surface P directives. The file is
+   * created with an exclusive open (`wx`) so a concurrent regeneration is never
+   * clobbered.
+   */
   async listPriceHistory(
     userId: string,
     symbol: string
   ): Promise<PricePoint[]> {
+    if (!symbol.trim() || /[\n\r]/.test(symbol)) return [];
     let stdout: string;
     try {
       // ledger prices only surfaces P directives when --price-db is present,
       // even if the file is empty. Ensure one exists before shelling out.
       const layout = await this.deps.journalRepo.ensureLayout(userId);
       if (!layout.priceDbPath) {
-        await fs.writeFile(path.join(layout.dir, PRICE_DB_NAME), '', 'utf-8');
+        await fs
+          .writeFile(path.join(layout.dir, PRICE_DB_NAME), '', {
+            encoding: 'utf-8',
+            flag: 'wx',
+          })
+          .catch(() => {
+            // File already exists (a prior call or a concurrent regeneration created
+            // it). Either way --price-db will be passed by runLedgerForUser.
+          });
       }
       stdout = await runLedgerForUser(
         userId,
-        ['prices', symbol, '--prices-format', PRICES_FORMAT],
+        ['prices', '--prices-format', PRICES_FORMAT, '--', symbol],
         this.deps.journalRepo
       );
     } catch {

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -5,6 +5,11 @@ import { classifyCommodity } from './classify';
 import { getCoinSymbolMap } from './coingecko/coinCache';
 import { renderPriceDb, hasGeneratedBanner } from './formatter';
 import type { CommodityPriceRow } from './formatter';
+import {
+  PRICES_FORMAT,
+  parsePriceHistory,
+  type PricePoint,
+} from './knownPrices';
 import { withPriceLock } from './lock';
 import type { ManualPriceRepository } from './manualRepository';
 import { buildPricedAt, type ManualPriceDraft } from './manualSchema';
@@ -236,6 +241,48 @@ export class PriceService {
   // (price-DB regeneration, prices UI) share one source of truth.
   async resolveBaseCurrency(_userId: string): Promise<string> {
     return 'USD';
+  }
+
+  /** Raw commodity symbols the user holds, as `ledger commodities` prints them. */
+  async listHeldCommodities(userId: string): Promise<string[]> {
+    let stdout: string;
+    try {
+      stdout = await runLedgerForUser(
+        userId,
+        ['commodities'],
+        this.deps.journalRepo
+      );
+    } catch {
+      return [];
+    }
+    return stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  /** Full known price history for one commodity, ascending by date. */
+  async listPriceHistory(
+    userId: string,
+    symbol: string
+  ): Promise<PricePoint[]> {
+    let stdout: string;
+    try {
+      // ledger prices only surfaces P directives when --price-db is present,
+      // even if the file is empty. Ensure one exists before shelling out.
+      const layout = await this.deps.journalRepo.ensureLayout(userId);
+      if (!layout.priceDbPath) {
+        await fs.writeFile(path.join(layout.dir, PRICE_DB_NAME), '', 'utf-8');
+      }
+      stdout = await runLedgerForUser(
+        userId,
+        ['prices', symbol, '--prices-format', PRICES_FORMAT],
+        this.deps.journalRepo
+      );
+    } catch {
+      return [];
+    }
+    return parsePriceHistory(stdout);
   }
 
   async listNormalizedSymbolsForUser(userId: string): Promise<string[]> {

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -32,11 +32,17 @@ import type { DbInstance } from '@/lib/db/connection';
 import { PRICE_DB_NAME, getJournalCacheTag } from '@/lib/journal/layout';
 import type { JournalRepository } from '@/lib/journal/repository';
 import { createLogger } from '@/lib/log';
+import { mapWithConcurrency } from '@/utils/mapWithConcurrency';
 import { runLedgerForUser } from '@/utils/runLedgerForUser';
 import { user as userTable } from '@naeemba/next-starter/schema';
 import { revalidateTag } from 'next/cache';
 
 const log = createLogger('prices');
+
+// listKnownPrices shells out to `ledger prices` once per held commodity. Cap the
+// fan-out so a user holding many commodities cannot spawn an unbounded number of
+// subprocesses at once.
+const PRICE_HISTORY_CONCURRENCY = 8;
 
 export type RefreshResult =
   | { status: 'success'; fetched: number }
@@ -391,8 +397,10 @@ export class PriceService {
 
     const today = utcDate(new Date());
 
-    const rows = await Promise.all(
-      held.map(async (symbol): Promise<KnownPrice> => {
+    const rows = await mapWithConcurrency(
+      held,
+      PRICE_HISTORY_CONCURRENCY,
+      async (symbol): Promise<KnownPrice> => {
         const symbolNormalized = normalizeCommoditySymbol(symbol);
 
         if (symbolNormalized && symbolNormalized === base) {
@@ -441,7 +449,7 @@ export class PriceService {
             fetchedKeys,
           }),
         };
-      })
+      }
     );
 
     return rows.sort((a, b) =>

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -10,6 +10,7 @@ import {
   STALE_THRESHOLD_DAYS,
   ageInDays,
   deriveSource,
+  latestGenuinePrice,
   parsePriceHistory,
   priceKey,
   type KnownPrice,
@@ -290,7 +291,8 @@ export class PriceService {
             encoding: 'utf-8',
             flag: 'wx',
           })
-          .catch(() => {
+          .catch((error: NodeJS.ErrnoException) => {
+            if (error.code !== 'EEXIST') throw error;
             // File already exists (a prior call or a concurrent regeneration created
             // it). Either way --price-db will be passed by runLedgerForUser.
           });
@@ -406,7 +408,7 @@ export class PriceService {
         }
 
         const history = await this.listPriceHistory(userId, symbol);
-        const latest: PricePoint | undefined = history.at(-1);
+        const latest = latestGenuinePrice(history);
 
         if (!latest) {
           return {
@@ -426,7 +428,7 @@ export class PriceService {
         return {
           symbol,
           price: latest.price,
-          quote: latest.quote,
+          quote: quoteNormalized,
           date: latest.date,
           ageDays,
           stale: ageDays > STALE_THRESHOLD_DAYS,
@@ -442,7 +444,9 @@ export class PriceService {
       })
     );
 
-    return rows.sort((a, b) => a.symbol.localeCompare(b.symbol));
+    return rows.sort((a, b) =>
+      a.symbol.localeCompare(b.symbol, undefined, { sensitivity: 'base' })
+    );
   }
 
   private async maybeMigrateLegacyFiles(users: string[]): Promise<void> {

--- a/utils/mapWithConcurrency.test.ts
+++ b/utils/mapWithConcurrency.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { mapWithConcurrency } from './mapWithConcurrency';
+
+describe('mapWithConcurrency', () => {
+  it('preserves input order in the result', async () => {
+    const result = await mapWithConcurrency(
+      [1, 2, 3, 4],
+      2,
+      async (n) => n * 10
+    );
+    expect(result).toEqual([10, 20, 30, 40]);
+  });
+
+  it('never runs more than `limit` tasks at once', async () => {
+    let active = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    await mapWithConcurrency(items, 3, async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active--;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it('passes the index to the task', async () => {
+    const result = await mapWithConcurrency(
+      ['a', 'b', 'c'],
+      2,
+      async (item, index) => `${item}${index}`
+    );
+    expect(result).toEqual(['a0', 'b1', 'c2']);
+  });
+
+  it('handles an empty input without spawning workers', async () => {
+    const result = await mapWithConcurrency([], 4, async (n) => n);
+    expect(result).toEqual([]);
+  });
+
+  it('runs sequentially when limit is 1', async () => {
+    const order: number[] = [];
+    await mapWithConcurrency([5, 4, 3], 1, async (n) => {
+      await new Promise((resolve) => setTimeout(resolve, n));
+      order.push(n);
+    });
+    expect(order).toEqual([5, 4, 3]);
+  });
+});

--- a/utils/mapWithConcurrency.ts
+++ b/utils/mapWithConcurrency.ts
@@ -1,0 +1,23 @@
+/**
+ * Map over `items` running at most `limit` async tasks at once, preserving
+ * input order in the result. Use instead of `Promise.all(items.map(...))` when
+ * each task holds a scarce resource — e.g. shelling out to a subprocess — so a
+ * large input cannot spawn an unbounded number of them simultaneously.
+ */
+export const mapWithConcurrency = async <T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>
+): Promise<R[]> => {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await task(items[index]!, index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+};


### PR DESCRIPTION
## What

Adds a read-only view of the latest price `ledger` knows for every commodity you hold, plus a per-commodity price-history page.

- **`/prices` is now tabbed:**
  - **Known prices** (default): a table of every held commodity with its latest known price, the date that price is from, its age (with a stale marker past 7 days), and the source of the price (`fetched` / `manual` / `journal` / `base` / no price).
  - **Manual entry**: the existing manual-price form, unchanged.
- **`/prices/[symbol]`**: a price-history detail page — a line chart over time plus a dated table.

## How

- Prices come straight from `ledger prices`, which merges the journal's own `P`/`@` prices with the fetched + manual price database (via `--file` + `--price-db`), so the view reflects exactly what ledger values each commodity at.
- Only commodities you actually hold are listed (`ledger commodities`), including the base currency (USD), shown as `base` at 1.00. Held-but-unpriced commodities show a "no price" gap row.
- Provenance (the Source column) is derived by correlating the latest price against the manual- and fetched-price tables, since ledger output carries no source.

## Notable correctness points

- **Staleness dates from when the price last changed, not the newest data row.** `ledger prices` forward-carries the prevailing price onto every date a commodity is transacted, so a naive "last row" read would show a recent posting date and make a stale price look fresh. A dedicated helper (`latestGenuinePrice`) tracks the last actual price change; a regression test guards it.
- **Input hardening:** the per-commodity ledger call uses a `--` end-of-options separator plus an empty/newline guard so a crafted commodity symbol cannot smuggle a ledger flag.
- Prices render with thousands separators; quotes display normalized (USD).

## Testing

- 931 tests passing; `tsc`, `eslint`, and `next build` all clean (both routes emit as dynamic).
- New coverage: parser + provenance unit tests, and integration tests for base/journal/fetched/manual sources, gap rows, and the forward-carry staleness scenario.

## Deferred (backlog)

- `listKnownPrices` fans out one `ledger` process per held commodity; fine at personal scale, worth a concurrency limiter if portfolios grow large.
- Stale shown as text rather than a styled badge.

Design + plan: `docs/superpowers/specs/2026-07-08-known-prices-page-design.md`, `docs/superpowers/plans/2026-07-08-known-prices-page.md`.
