### PR TITLE
feat(prices): toggle known prices between original quote and base currency

### DIFF
--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -12,7 +12,10 @@ const PricesPage = async ({
   searchParams: Promise<SearchParams>;
 }) => {
   const { base } = await searchParams;
-  const baseMode = base === 'usd';
+  // `base=base` is a mode flag ("value into the resolved base currency"), not
+  // the currency code — so the toggle keeps working the day
+  // resolveBaseCurrency returns something other than USD.
+  const baseMode = base === 'base';
   const user = await requireUser();
   const [known, prices, commodities, baseCurrency] = await Promise.all([
     baseMode

--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -4,10 +4,20 @@ import { priceService } from '@/lib/prices';
 
 export const dynamic = 'force-dynamic';
 
-const PricesPage = async () => {
+type SearchParams = { base?: string };
+
+const PricesPage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) => {
+  const { base } = await searchParams;
+  const baseMode = base === 'usd';
   const user = await requireUser();
   const [known, prices, commodities, baseCurrency] = await Promise.all([
-    priceService.listKnownPrices(user.id),
+    baseMode
+      ? priceService.listKnownPricesInBase(user.id)
+      : priceService.listKnownPrices(user.id),
     priceService.listManualPrices(user.id),
     priceService.listNormalizedSymbolsForUser(user.id),
     priceService.resolveBaseCurrency(user.id),
@@ -19,6 +29,7 @@ const PricesPage = async () => {
       prices={prices}
       commodities={commodities}
       baseCurrency={baseCurrency}
+      baseMode={baseMode}
     />
   );
 };

--- a/docs/superpowers/plans/2026-07-08-known-prices-base-currency-toggle.md
+++ b/docs/superpowers/plans/2026-07-08-known-prices-base-currency-toggle.md
@@ -1,0 +1,544 @@
+# Known Prices — Base-Currency Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a toggle on the Known prices tab that switches each row between its original journal quote and a USD-normalized value.
+
+**Architecture:** A new `PriceService.listKnownPricesInBase` reuses the existing raw `listKnownPrices` rows, then values each held commodity into the base currency in a single ledger `balance -X USD` call driven by a throwaway probe journal. The prices page branches on a `?base=usd` search param; a segmented `next/link` control drives the (server-refetched) switch.
+
+**Tech Stack:** TypeScript, Next.js 16 (App Router, server components), Ledger 3.4.1 CLI, Vitest.
+
+## Global Constraints
+
+- Base currency comes from `resolveBaseCurrency(userId)` (returns `'USD'` today). Never hardcode `'USD'` in the service — use the resolved `base` variable.
+- Ledger `prices -X` does NOT convert; only a `balance -X <base>` report chains cross-rates. Do not attempt normalization via `ledger prices`.
+- Probe journal transactions MUST be blank-line separated and each MUST carry an explicit offsetting posting, or ledger errors ("Only one posting with null amount allowed").
+- The `balance` call MUST include `--empty` (sub-unit values round to 0 at USD display precision and would otherwise be dropped) and anchor the account query as `^Probe:c`.
+- Identifiers spelled out in full; no abbreviations. No AI/tool self-reference in code, comments, or commits.
+- Commit style: Conventional Commits, terse. No `Co-Authored-By` trailer.
+
+---
+
+### Task 1: Base-balance parser + format constant
+
+**Files:**
+- Modify: `lib/prices/knownPrices.ts` (add near `PRICES_FORMAT`)
+- Test: `lib/prices/knownPrices.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `BALANCE_BASE_FORMAT: string`
+  - `parseBaseBalance(stdout: string): Map<number, { price: number; commodity: string }>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `lib/prices/knownPrices.test.ts`. Add `parseBaseBalance` and `BALANCE_BASE_FORMAT` to the existing import from `./knownPrices`.
+
+```typescript
+describe('parseBaseBalance', () => {
+  it('parses Probe:cN|quantity|commodity rows keyed by index', () => {
+    const stdout =
+      'Probe:c0|107393.21686406863836|USD\nProbe:c1|117.045492|USD\n';
+    const map = parseBaseBalance(stdout);
+    expect(map.get(0)).toEqual({
+      price: 107393.21686406863836,
+      commodity: 'USD',
+    });
+    expect(map.get(1)).toEqual({ price: 117.045492, commodity: 'USD' });
+  });
+
+  it('keeps an unconvertible row in its own commodity', () => {
+    const map = parseBaseBalance('Probe:c2|1|XOF\n');
+    expect(map.get(2)).toEqual({ price: 1, commodity: 'XOF' });
+  });
+
+  it('strips thousands separators from the quantity', () => {
+    const map = parseBaseBalance('Probe:c0|1,234.50|USD\n');
+    expect(map.get(0)).toEqual({ price: 1234.5, commodity: 'USD' });
+  });
+
+  it('ignores offset accounts, blanks, and malformed lines', () => {
+    const stdout =
+      '\nOffset:c0|-1|USD\nProbe:c0|5|USD\ngarbage\nProbe:cX|9|USD\n';
+    const map = parseBaseBalance(stdout);
+    expect([...map.keys()]).toEqual([0]);
+    expect(map.get(0)).toEqual({ price: 5, commodity: 'USD' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run lib/prices/knownPrices.test.ts -t parseBaseBalance`
+Expected: FAIL — `parseBaseBalance is not a function` / import error.
+
+- [ ] **Step 3: Implement the constant and parser**
+
+In `lib/prices/knownPrices.ts`, directly below the `PRICES_FORMAT` export, add:
+
+```typescript
+/**
+ * Machine-parseable balance format for base-currency valuation: one
+ * `account|quantity|commodity` line per probe holding. `quantity` is the
+ * full-precision value, `commodity` is the currency it resolved to (the base
+ * when a conversion path existed, otherwise the holding's own commodity).
+ */
+export const BALANCE_BASE_FORMAT =
+  '%(account)|%(quantity(scrub(display_total)))|%(commodity(scrub(display_total)))\n';
+```
+
+At the end of the file (after `latestGenuinePrice`), add:
+
+```typescript
+/**
+ * Parse `ledger balance ^Probe:cN --flat -X <base> --empty` output into a
+ * map of probe index → valued amount. Probe accounts are named `Probe:c<index>`
+ * so the account label carries no commodity-specific characters; the index maps
+ * back to the held commodity by position. Offset accounts and malformed lines
+ * are ignored. A row whose `commodity` differs from the requested base was not
+ * convertible into the base.
+ */
+export const parseBaseBalance = (
+  stdout: string
+): Map<number, { price: number; commodity: string }> => {
+  const out = new Map<number, { price: number; commodity: string }>();
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [account, quantity, commodity] = trimmed.split('|');
+    if (!account || !quantity || !commodity) continue;
+    const match = /^Probe:c(\d+)$/.exec(account);
+    if (!match) continue;
+    const price = Number(quantity.replace(/,/g, ''));
+    if (!Number.isFinite(price)) continue;
+    out.set(Number(match[1]), { price, commodity });
+  }
+  return out;
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run lib/prices/knownPrices.test.ts`
+Expected: PASS (new `parseBaseBalance` block + all existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/prices/knownPrices.ts lib/prices/knownPrices.test.ts
+git commit -m "feat(prices): add base-balance parser for currency normalization"
+```
+
+---
+
+### Task 2: `listKnownPricesInBase` service method
+
+**Files:**
+- Modify: `lib/prices/service.ts`
+- Test: `lib/prices/service.test.ts`
+
+**Interfaces:**
+- Consumes: `BALANCE_BASE_FORMAT`, `parseBaseBalance` (Task 1); existing `listKnownPrices`, `resolveBaseCurrency`, `normalizeCommoditySymbol`, `runLedgerForUser`, `this.deps.journalRepo`.
+- Produces: `PriceService.listKnownPricesInBase(userId: string): Promise<KnownPrice[]>` — same row shape as `listKnownPrices`; each non-base row's `price` becomes the base-valued number with `quote === base`, or `price: null` / `quote: null` when no path exists. `date`, `ageDays`, `stale`, `source` are carried over unchanged from the raw row.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `lib/prices/service.test.ts` (uses the real ledger binary, like the existing `listKnownPrices` suite):
+
+```typescript
+describe('PriceService.listKnownPricesInBase', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('prices-base-');
+    service = new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+      mappingRepo: new CommodityMappingRepository(ctx.db),
+    });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('values held commodities into the base via ledger cross-rate chains', async () => {
+    await seedUser(
+      ctx,
+      'u-base',
+      [
+        'P 2026-07-01 DAI 1 USD',
+        'P 2026-07-01 BTC 100 DAI',
+        'P 2026-07-01 KIRT 2 USD',
+        'P 2026-07-01 Nim 10 KIRT',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 BTC',
+        '  Equity    -1 BTC',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:B   1 Nim',
+        '  Equity    -1 Nim',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:E   1 XOF',
+        '  Equity    -1 XOF',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:F   1 USD',
+        '  Equity    -1 USD',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-base');
+    const bySymbol = Object.fromEntries(rows.map((r) => [r.symbol, r]));
+
+    // BTC = 100 DAI * 1 USD/DAI = 100 USD (chained BTC->DAI->USD).
+    expect(bySymbol.BTC.price).toBeCloseTo(100, 6);
+    expect(bySymbol.BTC.quote).toBe('USD');
+    // Provenance / recency carried over from the raw row (keep-raw).
+    expect(bySymbol.BTC.source).toBe('journal');
+    expect(bySymbol.BTC.date).toBe('2026-07-01');
+
+    // Nim = 10 KIRT * 2 USD/KIRT = 20 USD (chained Nim->KIRT->USD).
+    expect(bySymbol.Nim.price).toBeCloseTo(20, 6);
+    expect(bySymbol.Nim.quote).toBe('USD');
+
+    // XOF has no path to USD → no price.
+    expect(bySymbol.XOF.price).toBeNull();
+    expect(bySymbol.XOF.quote).toBeNull();
+
+    // Base row untouched.
+    expect(bySymbol.USD.price).toBe(1);
+    expect(bySymbol.USD.source).toBe('base');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/prices/service.test.ts -t listKnownPricesInBase`
+Expected: FAIL — `service.listKnownPricesInBase is not a function`.
+
+- [ ] **Step 3: Add imports**
+
+In `lib/prices/service.ts`, extend the existing top-of-file imports:
+
+- Add to the `./knownPrices` named import block: `BALANCE_BASE_FORMAT,` and `parseBaseBalance,`.
+- Add two node imports below the existing `import path from 'path';`:
+
+```typescript
+import os from 'os';
+import { randomUUID } from 'crypto';
+```
+
+- [ ] **Step 4: Implement the method**
+
+In `lib/prices/service.ts`, add this method to the `PriceService` class, directly after `listKnownPrices` (after its closing `}` near line 458):
+
+```typescript
+  /**
+   * Latest known price for every held commodity, valued into the base currency.
+   * Reuses the raw rows from `listKnownPrices` for provenance and staleness,
+   * then re-values each non-base holding through ledger's full price graph in a
+   * single `balance -X <base>` call driven by a throwaway probe journal. A
+   * holding with no conversion path to the base yields `price: null`.
+   */
+  async listKnownPricesInBase(userId: string): Promise<KnownPrice[]> {
+    const base = await this.resolveBaseCurrency(userId);
+    const raw = await this.listKnownPrices(userId);
+
+    const toBaseRow = (row: KnownPrice): KnownPrice =>
+      normalizeCommoditySymbol(row.symbol) === base
+        ? row
+        : { ...row, price: null, quote: null };
+
+    // Probe only non-base commodities; reject symbols that could break the
+    // throwaway journal (quotes / newlines).
+    const probeSymbols = raw
+      .filter(
+        (row) =>
+          normalizeCommoditySymbol(row.symbol) !== base &&
+          !/["\n\r]/.test(row.symbol)
+      )
+      .map((row) => row.symbol);
+
+    if (probeSymbols.length === 0) return raw.map(toBaseRow);
+
+    // One balanced `1 <symbol>` transaction per commodity, indexed by position
+    // so the account name carries no commodity-specific characters. Blank lines
+    // separate transactions; an explicit offset balances each one.
+    const journal = probeSymbols
+      .map((symbol, index) => {
+        const needsQuote = /[^A-Za-z0-9_]/.test(symbol);
+        const amount = needsQuote ? `1 "${symbol}"` : `1 ${symbol}`;
+        const offset = needsQuote ? `-1 "${symbol}"` : `-1 ${symbol}`;
+        return `2000-01-01 * probe\n  Probe:c${index}    ${amount}\n  Offset:c${index}    ${offset}\n`;
+      })
+      .join('\n');
+
+    const probePath = path.join(
+      os.tmpdir(),
+      `ledger-probe-${randomUUID()}.ledger`
+    );
+    try {
+      await fs.writeFile(probePath, journal, 'utf-8');
+      let stdout: string;
+      try {
+        stdout = await runLedgerForUser(
+          userId,
+          [
+            '--file',
+            probePath,
+            'balance',
+            '^Probe:c',
+            '--flat',
+            '--empty',
+            '--no-total',
+            '-X',
+            base,
+            '--format',
+            BALANCE_BASE_FORMAT,
+          ],
+          this.deps.journalRepo
+        );
+      } catch {
+        // Ledger failed → no valuation available; degrade to no-price rows.
+        return raw.map(toBaseRow);
+      }
+
+      const valued = parseBaseBalance(stdout);
+      return raw.map((row) => {
+        if (normalizeCommoditySymbol(row.symbol) === base) return row;
+        const index = probeSymbols.indexOf(row.symbol);
+        const hit = index >= 0 ? valued.get(index) : undefined;
+        return hit && hit.commodity === base
+          ? { ...row, price: hit.price, quote: base }
+          : { ...row, price: null, quote: null };
+      });
+    } finally {
+      await fs.rm(probePath, { force: true }).catch(() => {});
+    }
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm vitest run lib/prices/service.test.ts -t listKnownPricesInBase`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full prices suite + type-check**
+
+Run: `pnpm vitest run lib/prices && pnpm type-check`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/prices/service.ts lib/prices/service.test.ts
+git commit -m "feat(prices): value known prices into base currency"
+```
+
+---
+
+### Task 3: Search-param branch + toggle UI
+
+**Files:**
+- Modify: `app/prices/page.tsx`
+- Modify: `features/prices/PricesTabs.tsx`
+- Modify: `features/prices/KnownPricesView.tsx`
+
+**Interfaces:**
+- Consumes: `priceService.listKnownPricesInBase` (Task 2).
+- Produces: `PricesTabs` gains a `baseMode: boolean` prop; `KnownPricesView` gains `baseMode: boolean` and `baseCurrency: string` props and renders the toggle.
+
+- [ ] **Step 1: Branch the page on the search param**
+
+Replace the whole body of `app/prices/page.tsx` with:
+
+```tsx
+import { PricesTabs } from '@/features/prices';
+import { requireUser } from '@/lib/auth/require-user';
+import { priceService } from '@/lib/prices';
+
+export const dynamic = 'force-dynamic';
+
+type SearchParams = { base?: string };
+
+const PricesPage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) => {
+  const { base } = await searchParams;
+  const baseMode = base === 'usd';
+  const user = await requireUser();
+  const [known, prices, commodities, baseCurrency] = await Promise.all([
+    baseMode
+      ? priceService.listKnownPricesInBase(user.id)
+      : priceService.listKnownPrices(user.id),
+    priceService.listManualPrices(user.id),
+    priceService.listNormalizedSymbolsForUser(user.id),
+    priceService.resolveBaseCurrency(user.id),
+  ]);
+
+  return (
+    <PricesTabs
+      known={known}
+      prices={prices}
+      commodities={commodities}
+      baseCurrency={baseCurrency}
+      baseMode={baseMode}
+    />
+  );
+};
+
+export default PricesPage;
+```
+
+- [ ] **Step 2: Thread `baseMode` through `PricesTabs`**
+
+In `features/prices/PricesTabs.tsx`:
+
+Add `baseMode: boolean;` to the `Props` type, add `baseMode` to the destructured params, and pass `baseMode` + `baseCurrency` into `KnownPricesView`. The `KnownPricesView` usage becomes:
+
+```tsx
+      {active === 'known' ? (
+        <KnownPricesView
+          rows={known}
+          baseMode={baseMode}
+          baseCurrency={baseCurrency}
+        />
+      ) : (
+```
+
+The `Props` type becomes:
+
+```tsx
+type Props = {
+  known: KnownPrice[];
+  prices: ManualPrice[];
+  commodities: string[];
+  baseCurrency: string;
+  baseMode: boolean;
+};
+```
+
+and the destructure:
+
+```tsx
+export const PricesTabs = ({
+  known,
+  prices,
+  commodities,
+  baseCurrency,
+  baseMode,
+}: Props) => {
+```
+
+- [ ] **Step 3: Render the toggle in `KnownPricesView`**
+
+In `features/prices/KnownPricesView.tsx`:
+
+Change the `Props` type and add a segmented control above the table. Replace the `type Props` line and the component opening through the first `<TableScroll` with:
+
+```tsx
+type Props = { rows: KnownPrice[]; baseMode: boolean; baseCurrency: string };
+
+const segmentClass = (active: boolean): string =>
+  [
+    'px-3 py-1.5 font-medium transition-opacity',
+    active
+      ? 'bg-accent text-accent-foreground'
+      : 'opacity-60 hover:opacity-100',
+  ].join(' ');
+
+export const KnownPricesView = ({ rows, baseMode, baseCurrency }: Props) => (
+  <div className="space-y-3">
+    <div className="flex justify-end">
+      <div
+        role="group"
+        aria-label="Price currency"
+        className="inline-flex overflow-hidden rounded-md border border-border text-sm"
+      >
+        <Link
+          href="/prices"
+          aria-current={!baseMode}
+          className={segmentClass(!baseMode)}
+        >
+          Original quote
+        </Link>
+        <Link
+          href="/prices?base=usd"
+          aria-current={baseMode}
+          className={`${segmentClass(baseMode)} border-l border-border`}
+        >
+          In {baseCurrency}
+        </Link>
+      </div>
+    </div>
+    <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      <TableScroll bleed={false}>
+```
+
+Then close the extra wrapping `<div>`: change the component's final `</div>` region. The existing tail is:
+
+```tsx
+      </table>
+    </TableScroll>
+  </div>
+);
+```
+
+Replace it with:
+
+```tsx
+      </table>
+    </TableScroll>
+    </div>
+  </div>
+);
+```
+
+(The `Link` import already exists at the top of the file.)
+
+- [ ] **Step 4: Type-check and lint**
+
+Run: `pnpm type-check && pnpm lint`
+Expected: PASS, no errors.
+
+- [ ] **Step 5: Manual verification in the dev server**
+
+Run: `pnpm dev` and open `http://localhost:3000/prices`.
+Verify:
+- Toggle shows two segments; "Original quote" active by default; table matches today's behavior (mixed quotes: BTC in DAI, Nim in KIRT).
+- Click "In USD" → URL becomes `/prices?base=usd`; every priced row now reads `… USD`; commodities with no USD path read "no price"; Date / Age / Source columns unchanged.
+- Click "Original quote" → returns to mixed-quote view.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/prices/page.tsx features/prices/PricesTabs.tsx features/prices/KnownPricesView.tsx
+git commit -m "feat(prices): toggle known prices between original quote and base currency"
+```
+
+---
+
+## Notes / Known trade-offs
+
+- Switching the toggle is a full server navigation; it resets the client-side tab state to "Known prices". Acceptable — the toggle only appears on that tab and it is the default.
+- USD-mode Date / Age / Source are carried from the underlying primary price (keep-raw), so a USD value derived from a stale price is still flagged stale.
+- `listKnownPricesInBase` issues exactly one extra ledger subprocess beyond `listKnownPrices`; the per-commodity fan-out bound (`PRICE_HISTORY_CONCURRENCY`) is unchanged.
+
+## Self-review
+
+- **Spec coverage:** toggle (Task 3); USD valuation via probe-journal balance (Task 2); parser + format constant (Task 1); keep-raw columns (Task 2 merge + Task 3 leaves columns intact); no-USD-path → "no price" (Task 2 + existing `KnownPricesView` null handling); default `force-dynamic` retained (Task 3).
+- **Placeholder scan:** none — every step carries concrete code/commands.
+- **Type consistency:** `BALANCE_BASE_FORMAT` / `parseBaseBalance` signatures identical across Tasks 1–2; `baseMode: boolean` and `baseCurrency: string` prop names identical across page → `PricesTabs` → `KnownPricesView`.

--- a/docs/superpowers/specs/2026-07-08-known-prices-base-currency-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-08-known-prices-base-currency-toggle-design.md
@@ -1,0 +1,172 @@
+# Known Prices — Base-Currency Toggle
+
+## Problem
+
+The "Known prices" tab lists each held commodity's latest known price in
+**whatever quote the newest `P` directive used** — no normalization. Fetched
+prices come back in USD, but journal-sourced prices keep their original quote:
+BTC shows in DAI, Nim/Sekke in KIRT, etc. A user scanning the table sees a
+column of mixed currencies and cannot compare values at a glance.
+
+This is faithful to the journal, not a bug — but the user wants a way to view
+every row in one consistent currency (USD).
+
+## Goal
+
+Add a toggle on the Known prices tab that switches between two views:
+
+1. **Original quote** (current behavior, default) — latest price in the quote
+   the newest `P` directive recorded.
+2. **In USD** — every row valued into USD (the base currency) using ledger's
+   cross-rate chain (BTC→DAI→USD, Nim→KIRT→USD, …). Rows with no USD path show
+   "no price".
+
+## Key technical finding
+
+`ledger prices -X USD` does **not** convert — it emits the raw `P` directives
+plus junk zero rows. Verified against Ledger 3.4.1.
+
+A `balance` report **does** chain-convert. Proven with a synthetic journal
+(one `1 <commodity>` posting per held commodity) against the price-db:
+
+```
+ledger --file <main> --price-db <db> --file <probe> \
+  balance '^Probe:' --flat -X USD --empty --no-total \
+  --format "%(account)|%(quantity(scrub(display_total)))|%(commodity(scrub(display_total)))\n"
+```
+
+Output (from the user's real data):
+
+```
+Probe:ADA|0.169753|USD
+Probe:BTC|107393.21686406863836|USD      <- chained BTC→DAI→USD
+Probe:KIRT|0.00568182|USD
+Probe:Nim|117.045492|USD                 <- chained Nim→KIRT→USD
+Probe:Orphan|1|Orphan                    <- no USD path: stays in own commodity
+Probe:USD|1|USD
+```
+
+Notes learned during the spike:
+- Transactions in the probe journal **must be blank-line separated**, else
+  ledger merges postings into one transaction and errors ("Only one posting
+  with null amount allowed").
+- Each probe transaction needs an explicit offsetting posting
+  (`Probe:X 1 X` / `ProbeEq:X -1 X`) — a single null-amount balancer cannot
+  balance multiple commodities.
+- `--empty` is required: USD default display precision rounds sub-unit values
+  (ADA 0.169, KIRT 0.0057) to `0`, which ledger would otherwise drop as a
+  zero row. `quantity(scrub(display_total))` still returns full internal
+  precision, so `--empty` only rescues visibility, not accuracy.
+- Anchor the account query with `^Probe:` — an unanchored `Probe` regex also
+  matches the offsetting equity accounts.
+- A row whose `commodity` field is **not** `USD` was not convertible → treat
+  as no USD path.
+
+## Design
+
+### Server — `PriceService.listKnownPricesInBase(userId)`
+
+New method alongside `listKnownPrices`. Returns `KnownPrice[]` (same shape).
+
+Steps:
+1. Compute the raw rows via the existing `listKnownPrices(userId)` — reused
+   verbatim so `date` / `ageDays` / `stale` / `source` describe the underlying
+   primary price (see "Column semantics" below).
+2. Build a probe journal string: for each held commodity `sym`, one
+   blank-line-separated balanced transaction:
+   ```
+   2000-01-01 * probe
+     Probe:<sym>    1 <sym>
+     ProbeEq:<sym> -1 <sym>
+   ```
+   Symbols are the raw `ledger commodities` strings (already what
+   `listHeldCommodities` returns). Guard against symbols containing newlines
+   (mirrors the `listPriceHistory` guard); skip any such symbol.
+3. Write the probe journal to a temp file (`os.tmpdir()`, unique name).
+   `try/finally` unlink.
+4. Run ledger via `runLedgerForUser(userId, ['--file', probePath, 'balance',
+   '^Probe:', '--flat', '-X', base, '--empty', '--no-total', '--format',
+   BALANCE_BASE_FORMAT])`. `runLedgerForUser` already prepends
+   `--file <main> --price-db <db>`; the extra `--file` merges the probe's
+   postings into the same price graph.
+5. Parse each `Probe:<sym>|<quantity>|<commodity>` line into a map
+   `sym → { price, commodity }`.
+6. Merge onto the raw rows: for each raw row,
+   - if a probe entry exists **and** its `commodity === base` →
+     `{ ...rawRow, price: <parsed>, quote: base }`.
+   - otherwise → `{ ...rawRow, price: null, quote: null }` (no USD path).
+   - Keep `date`, `ageDays`, `stale`, `source` from the raw row unchanged.
+7. Return sorted the same way `listKnownPrices` sorts.
+
+`base` comes from `resolveBaseCurrency(userId)` (always `USD` today, but keep
+it a variable so the two methods share the source of truth).
+
+Parsing helper (pure, unit-testable) lives in `knownPrices.ts`:
+`parseBaseBalance(stdout): Map<string, { price: number; commodity: string }>`.
+
+`BALANCE_BASE_FORMAT` constant lives beside `PRICES_FORMAT` in `knownPrices.ts`.
+
+**Concurrency / cost:** one extra ledger subprocess total (not per-commodity).
+`listKnownPrices` itself already fans out per-commodity; `listKnownPricesInBase`
+calls it once, then adds a single balance call. No change to the existing
+`PRICE_HISTORY_CONCURRENCY` bound.
+
+### Page — `app/prices/page.tsx`
+
+- Read `searchParams`. When `base === 'usd'` (or, future-proof, any truthy
+  `base` flag) call `listKnownPricesInBase`; else `listKnownPrices`.
+- Page is already `force-dynamic`, so the searchParam-driven refetch is free.
+- Pass a `baseMode: boolean` prop through to `PricesTabs` so the toggle can
+  render its active state.
+
+### UI — toggle
+
+- A two-option segmented control rendered inside `KnownPricesView`'s container
+  header (or just above the table), shown only on the Known prices tab.
+- Options: **Original quote** (`/prices`) and **In USD** (`/prices?base=usd`),
+  rendered as `next/link`s so selection is a server navigation (URL param +
+  refetch, per decision). Active option styled per existing segmented-control
+  / `TabBar` conventions in the codebase.
+- `KnownPricesView` already renders `quote` and already handles `price: null`
+  as "no price" — no row-rendering changes needed.
+
+### Column semantics in USD mode (decision: keep-raw)
+
+- **Latest price**: the USD value (or "no price").
+- **Date / Age / stale**: unchanged from the raw row — they describe the
+  recency of the underlying primary price, which still governs how stale the
+  derived USD number is.
+- **Source**: unchanged from the raw row (Fetched / Journal / Manual / Base).
+  Tells the user how trustworthy the underlying number is. For a row derived
+  from two prices (Nim = Journal price × Manual rate) the single label is
+  approximate, but keep-raw is the accepted trade-off (simplest, and the base
+  number's provenance is the useful signal).
+
+## Out of scope (YAGNI)
+
+- Arbitrary target-currency picker (only USD/base).
+- Persisting the toggle choice across sessions.
+- Changing the raw view or the Manual-entry tab.
+- Re-dating the USD valuation (uses ledger's default latest-price valuation).
+
+## Testing
+
+- **`knownPrices.test.ts`** — `parseBaseBalance` unit tests: well-formed
+  lines, unconvertible commodity (commodity ≠ base), blank/garbage lines,
+  full-precision quantity, comma-stripping.
+- **`service.test.ts`** — `listKnownPricesInBase`: mock the ledger balance
+  stdout; assert USD rows carry `quote: base`, unconvertible commodity →
+  `price: null`, and `date`/`source` are carried over from the raw rows.
+  Also assert only one balance subprocess is issued and the temp file is
+  cleaned up.
+- No new UI test infra; toggle is plain links.
+
+## Files touched
+
+- `lib/prices/knownPrices.ts` — `BALANCE_BASE_FORMAT`, `parseBaseBalance`.
+- `lib/prices/service.ts` — `listKnownPricesInBase`.
+- `lib/prices/index.ts` — export if needed.
+- `app/prices/page.tsx` — searchParam branch + `baseMode` prop.
+- `features/prices/PricesTabs.tsx` — thread `baseMode`.
+- `features/prices/KnownPricesView.tsx` — toggle control.
+- Tests: `lib/prices/knownPrices.test.ts`, `lib/prices/service.test.ts`.

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -40,14 +40,14 @@ export const KnownPricesView = ({ rows, baseMode, baseCurrency }: Props) => (
       >
         <Link
           href="/prices"
-          aria-current={!baseMode}
+          aria-current={!baseMode ? 'page' : undefined}
           className={segmentClass(!baseMode)}
         >
           Original quote
         </Link>
         <Link
           href="/prices?base=usd"
-          aria-current={baseMode}
+          aria-current={baseMode ? 'page' : undefined}
           className={`${segmentClass(baseMode)} border-l border-border`}
         >
           In {baseCurrency}

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -5,7 +5,15 @@ import { TableScroll } from '@/components/ui/table';
 import type { KnownPrice } from '@/lib/prices';
 import Link from 'next/link';
 
-type Props = { rows: KnownPrice[] };
+type Props = { rows: KnownPrice[]; baseMode: boolean; baseCurrency: string };
+
+const segmentClass = (active: boolean): string =>
+  [
+    'px-3 py-1.5 font-medium transition-opacity',
+    active
+      ? 'bg-accent text-accent-foreground'
+      : 'opacity-60 hover:opacity-100',
+  ].join(' ');
 
 const sourceLabel: Record<KnownPrice['source'], string> = {
   fetched: 'Fetched',
@@ -22,70 +30,94 @@ const ageLabel = (row: KnownPrice): string => {
   return `${row.ageDays} days ago`;
 };
 
-export const KnownPricesView = ({ rows }: Props) => (
-  <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-    <TableScroll bleed={false}>
-      <table>
-        <thead>
-          <tr>
-            <th>Commodity</th>
-            <th className="text-right">Latest price</th>
-            <th>Date</th>
-            <th>Age</th>
-            <th>Source</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.length === 0 ? (
+export const KnownPricesView = ({ rows, baseMode, baseCurrency }: Props) => (
+  <div className="space-y-3">
+    <div className="flex justify-end">
+      <div
+        role="group"
+        aria-label="Price currency"
+        className="inline-flex overflow-hidden rounded-md border border-border text-sm"
+      >
+        <Link
+          href="/prices"
+          aria-current={!baseMode}
+          className={segmentClass(!baseMode)}
+        >
+          Original quote
+        </Link>
+        <Link
+          href="/prices?base=usd"
+          aria-current={baseMode}
+          className={`${segmentClass(baseMode)} border-l border-border`}
+        >
+          In {baseCurrency}
+        </Link>
+      </div>
+    </div>
+    <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      <TableScroll bleed={false}>
+        <table>
+          <thead>
             <tr>
-              <td
-                colSpan={5}
-                className="py-6 text-center text-muted-foreground"
-              >
-                No commodities
-              </td>
+              <th>Commodity</th>
+              <th className="text-right">Latest price</th>
+              <th>Date</th>
+              <th>Age</th>
+              <th>Source</th>
             </tr>
-          ) : (
-            rows.map((row) => (
-              <tr key={row.symbol}>
-                <td className="font-medium">
-                  <Link
-                    href={`/prices/${encodeURIComponent(row.symbol)}`}
-                    className="hover:underline"
-                  >
-                    {row.symbol}
-                  </Link>
-                </td>
-                <td className="text-right tabular-nums whitespace-nowrap">
-                  {row.price === null ? (
-                    <span className="text-muted-foreground">no price</span>
-                  ) : (
-                    `${priceFormatter.format(row.price)} ${row.quote ?? ''}`.trim()
-                  )}
-                </td>
-                <td className="whitespace-nowrap text-muted-foreground">
-                  {row.date ?? '—'}
-                </td>
-                <td className="whitespace-nowrap">
-                  <span
-                    className={
-                      row.stale
-                        ? 'text-amber-600 dark:text-amber-500'
-                        : 'text-muted-foreground'
-                    }
-                  >
-                    {ageLabel(row)}
-                    {row.stale ? ' · stale' : ''}
-                  </span>
-                </td>
-                <td className="whitespace-nowrap text-muted-foreground">
-                  {sourceLabel[row.source]}
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="py-6 text-center text-muted-foreground"
+                >
+                  No commodities
                 </td>
               </tr>
-            ))
-          )}
-        </tbody>
-      </table>
-    </TableScroll>
+            ) : (
+              rows.map((row) => (
+                <tr key={row.symbol}>
+                  <td className="font-medium">
+                    <Link
+                      href={`/prices/${encodeURIComponent(row.symbol)}`}
+                      className="hover:underline"
+                    >
+                      {row.symbol}
+                    </Link>
+                  </td>
+                  <td className="text-right tabular-nums whitespace-nowrap">
+                    {row.price === null ? (
+                      <span className="text-muted-foreground">no price</span>
+                    ) : (
+                      `${priceFormatter.format(row.price)} ${row.quote ?? ''}`.trim()
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap text-muted-foreground">
+                    {row.date ?? '—'}
+                  </td>
+                  <td className="whitespace-nowrap">
+                    <span
+                      className={
+                        row.stale
+                          ? 'text-amber-600 dark:text-amber-500'
+                          : 'text-muted-foreground'
+                      }
+                    >
+                      {ageLabel(row)}
+                      {row.stale ? ' · stale' : ''}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap text-muted-foreground">
+                    {sourceLabel[row.source]}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </TableScroll>
+    </div>
   </div>
 );

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -46,7 +46,7 @@ export const KnownPricesView = ({ rows, baseMode, baseCurrency }: Props) => (
           Original quote
         </Link>
         <Link
-          href="/prices?base=usd"
+          href="/prices?base=base"
           aria-current={baseMode ? 'page' : undefined}
           className={`${segmentClass(baseMode)} border-l border-border`}
         >

--- a/features/prices/PricesTabs.tsx
+++ b/features/prices/PricesTabs.tsx
@@ -12,6 +12,7 @@ type Props = {
   prices: ManualPrice[];
   commodities: string[];
   baseCurrency: string;
+  baseMode: boolean;
 };
 
 const TABS = [
@@ -24,6 +25,7 @@ export const PricesTabs = ({
   prices,
   commodities,
   baseCurrency,
+  baseMode,
 }: Props) => {
   const [active, setActive] = useState('known');
 
@@ -34,7 +36,11 @@ export const PricesTabs = ({
       </header>
       <TabBar tabs={TABS} active={active} onSelect={setActive} />
       {active === 'known' ? (
-        <KnownPricesView rows={known} />
+        <KnownPricesView
+          rows={known}
+          baseMode={baseMode}
+          baseCurrency={baseCurrency}
+        />
       ) : (
         <>
           <p className="text-muted-foreground text-sm">

--- a/lib/prices/bridgeViability.ts
+++ b/lib/prices/bridgeViability.ts
@@ -1,0 +1,32 @@
+// The `$` = 1 USD bridge directive that `listKnownPricesInBase` prepends to its
+// probe journal is fatal on ledger builds that canonicalize `$` to `USD`:
+// `P 2000-01-01 $ 1 USD` is a self-price there and aborts the whole parse
+// ("Assertion failed ... source != price.commodity()"). On such builds the
+// bridge attempt always throws and the caller retries without it — so every
+// USD-base render spends two ledger subprocesses instead of one.
+//
+// A given ledger binary's behaviour is fixed for the process lifetime, so we
+// remember it after the first observation and skip the known-fatal bridge
+// attempt on later renders. Builds that keep `$` and `USD` distinct instead
+// value the bridge cleanly, so once observed 'viable' we keep using it.
+//
+// Pinned on globalThis, not a module-level `let`: Next.js evaluates this module
+// in separate instances per server context (route handlers, RSC render), so a
+// module-scoped flag would be re-learned per context rather than shared across
+// the whole process.
+type BridgeViability = 'unknown' | 'viable' | 'aborts';
+
+const globalForBridge = globalThis as typeof globalThis & {
+  __ledgerBridgeViability?: BridgeViability;
+};
+
+export const getBridgeViability = (): BridgeViability =>
+  globalForBridge.__ledgerBridgeViability ?? 'unknown';
+
+export const recordBridgeViable = (): void => {
+  globalForBridge.__ledgerBridgeViability = 'viable';
+};
+
+export const recordBridgeAborts = (): void => {
+  globalForBridge.__ledgerBridgeViability = 'aborts';
+};

--- a/lib/prices/knownPrices.test.ts
+++ b/lib/prices/knownPrices.test.ts
@@ -198,4 +198,10 @@ describe('parseBaseBalance', () => {
     expect([...map.keys()]).toEqual([0]);
     expect(map.get(0)).toEqual({ price: 5, commodity: 'USD' });
   });
+
+  it('exposes the exact ledger balance format string', () => {
+    expect(BALANCE_BASE_FORMAT).toBe(
+      '%(account)|%(quantity(scrub(display_total)))|%(commodity(scrub(display_total)))\n'
+    );
+  });
 });

--- a/lib/prices/knownPrices.test.ts
+++ b/lib/prices/knownPrices.test.ts
@@ -6,6 +6,8 @@ import {
   latestGenuinePrice,
   priceKey,
   STALE_THRESHOLD_DAYS,
+  parseBaseBalance,
+  BALANCE_BASE_FORMAT,
 } from './knownPrices';
 
 describe('parsePriceHistory', () => {
@@ -164,5 +166,36 @@ describe('latestGenuinePrice', () => {
       price: 50000,
       quote: '$',
     });
+  });
+});
+
+describe('parseBaseBalance', () => {
+  it('parses Probe:cN|quantity|commodity rows keyed by index', () => {
+    const stdout =
+      'Probe:c0|107393.21686406863836|USD\nProbe:c1|117.045492|USD\n';
+    const map = parseBaseBalance(stdout);
+    expect(map.get(0)).toEqual({
+      price: 107393.21686406863836,
+      commodity: 'USD',
+    });
+    expect(map.get(1)).toEqual({ price: 117.045492, commodity: 'USD' });
+  });
+
+  it('keeps an unconvertible row in its own commodity', () => {
+    const map = parseBaseBalance('Probe:c2|1|XOF\n');
+    expect(map.get(2)).toEqual({ price: 1, commodity: 'XOF' });
+  });
+
+  it('strips thousands separators from the quantity', () => {
+    const map = parseBaseBalance('Probe:c0|1,234.50|USD\n');
+    expect(map.get(0)).toEqual({ price: 1234.5, commodity: 'USD' });
+  });
+
+  it('ignores offset accounts, blanks, and malformed lines', () => {
+    const stdout =
+      '\nOffset:c0|-1|USD\nProbe:c0|5|USD\ngarbage\nProbe:cX|9|USD\n';
+    const map = parseBaseBalance(stdout);
+    expect([...map.keys()]).toEqual([0]);
+    expect(map.get(0)).toEqual({ price: 5, commodity: 'USD' });
   });
 });

--- a/lib/prices/knownPrices.ts
+++ b/lib/prices/knownPrices.ts
@@ -133,7 +133,7 @@ export { normalizeCommoditySymbol };
 export const parseBaseBalance = (
   stdout: string
 ): Map<number, { price: number; commodity: string }> => {
-  const out = new Map<number, { price: number; commodity: string }>();
+  const result = new Map<number, { price: number; commodity: string }>();
   for (const line of stdout.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -143,7 +143,7 @@ export const parseBaseBalance = (
     if (!match) continue;
     const price = Number(quantity.replace(/,/g, ''));
     if (!Number.isFinite(price)) continue;
-    out.set(Number(match[1]), { price, commodity });
+    result.set(Number(match[1]), { price, commodity });
   }
-  return out;
+  return result;
 };

--- a/lib/prices/knownPrices.ts
+++ b/lib/prices/knownPrices.ts
@@ -9,6 +9,15 @@ import { normalizeCommoditySymbol } from './symbols';
 export const PRICES_FORMAT =
   "%(format_date(date,'%Y-%m-%d'))|%(quantity(scrub(display_amount)))|%(commodity(scrub(display_amount)))\n";
 
+/**
+ * Machine-parseable balance format for base-currency valuation: one
+ * `account|quantity|commodity` line per probe holding. `quantity` is the
+ * full-precision value, `commodity` is the currency it resolved to (the base
+ * when a conversion path existed, otherwise the holding's own commodity).
+ */
+export const BALANCE_BASE_FORMAT =
+  '%(account)|%(quantity(scrub(display_total)))|%(commodity(scrub(display_total)))\n';
+
 export const STALE_THRESHOLD_DAYS = 7;
 
 export type PricePoint = { date: string; price: number; quote: string };
@@ -112,3 +121,29 @@ export const deriveSource = (args: {
 
 /** Re-exported so the service normalizes symbols the same way. */
 export { normalizeCommoditySymbol };
+
+/**
+ * Parse `ledger balance ^Probe:cN --flat -X <base> --empty` output into a
+ * map of probe index → valued amount. Probe accounts are named `Probe:c<index>`
+ * so the account label carries no commodity-specific characters; the index maps
+ * back to the held commodity by position. Offset accounts and malformed lines
+ * are ignored. A row whose `commodity` differs from the requested base was not
+ * convertible into the base.
+ */
+export const parseBaseBalance = (
+  stdout: string
+): Map<number, { price: number; commodity: string }> => {
+  const out = new Map<number, { price: number; commodity: string }>();
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [account, quantity, commodity] = trimmed.split('|');
+    if (!account || !quantity || !commodity) continue;
+    const match = /^Probe:c(\d+)$/.exec(account);
+    if (!match) continue;
+    const price = Number(quantity.replace(/,/g, ''));
+    if (!Number.isFinite(price)) continue;
+    out.set(Number(match[1]), { price, commodity });
+  }
+  return out;
+};

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -10,6 +10,7 @@ import {
   PriceFetchRunRepository,
 } from './repository';
 import { PriceService } from './service';
+import { normalizeCommoditySymbol } from './symbols';
 import { getJournalDir } from '@/lib/journal/layout';
 import { JournalRepository } from '@/lib/journal/repository';
 import { UserSettingRepository } from '@/lib/settings/repository';
@@ -800,11 +801,15 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(bySymbol.XOF.price).toBeNull();
     expect(bySymbol.XOF.quote).toBeNull();
 
-    // Base row untouched. Ledger canonicalizes the held USD holding to `$`,
-    // and USD mode keeps the same symbol as the original-quote view.
-    expect(bySymbol['$'].price).toBe(1);
-    expect(bySymbol['$'].quote).toBe('USD');
-    expect(bySymbol['$'].source).toBe('base');
+    // Base row untouched. Identify it by its stable `base` source, and assert
+    // the symbol only after normalizing — ledger prints the held base holding
+    // as `$` on 3.4.x but `USD` on older apt builds, so a literal `$` would be
+    // build-specific.
+    const baseRow = rows.find((row) => row.source === 'base');
+    expect(baseRow).toBeDefined();
+    expect(normalizeCommoditySymbol(baseRow!.symbol)).toBe('USD');
+    expect(baseRow?.price).toBe(1);
+    expect(baseRow?.quote).toBe('USD');
   });
 
   it('values a dollar-denominated holding via the injected $=USD bridge', async () => {

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -725,3 +725,77 @@ describe('PriceService.listKnownPrices', () => {
     expect(btc?.stale).toBe(true);
   });
 });
+
+describe('PriceService.listKnownPricesInBase', () => {
+  let ctx: TestDbContext;
+  let service: PriceService;
+
+  beforeEach(async () => {
+    ctx = await setupTestDb('prices-base-');
+    service = new PriceService({
+      db: ctx.db,
+      commodityRepo: new CommodityPriceRepository(ctx.db),
+      runRepo: new PriceFetchRunRepository(ctx.db),
+      journalRepo: new JournalRepository(ctx.db),
+      manualRepo: new ManualPriceRepository(ctx.db),
+      mappingRepo: new CommodityMappingRepository(ctx.db),
+    });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+  });
+
+  it('values held commodities into the base via ledger cross-rate chains', async () => {
+    await seedUser(
+      ctx,
+      'u-base',
+      [
+        'P 2026-07-01 DAI 1 USD',
+        'P 2026-07-01 BTC 100 DAI',
+        'P 2026-07-01 KIRT 2 USD',
+        'P 2026-07-01 Nim 10 KIRT',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 BTC',
+        '  Equity    -1 BTC',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:B   1 Nim',
+        '  Equity    -1 Nim',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:E   1 XOF',
+        '  Equity    -1 XOF',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:F   1 USD',
+        '  Equity    -1 USD',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-base');
+    const bySymbol = Object.fromEntries(rows.map((r) => [r.symbol, r]));
+
+    // BTC = 100 DAI * 1 USD/DAI = 100 USD (chained BTC->DAI->USD).
+    expect(bySymbol.BTC.price).toBeCloseTo(100, 6);
+    expect(bySymbol.BTC.quote).toBe('USD');
+    // Provenance / recency carried over from the raw row (keep-raw).
+    expect(bySymbol.BTC.source).toBe('journal');
+    expect(bySymbol.BTC.date).toBe('2026-07-01');
+
+    // Nim = 10 KIRT * 2 USD/KIRT = 20 USD (chained Nim->KIRT->USD).
+    expect(bySymbol.Nim.price).toBeCloseTo(20, 6);
+    expect(bySymbol.Nim.quote).toBe('USD');
+
+    // XOF has no path to USD → no price.
+    expect(bySymbol.XOF.price).toBeNull();
+    expect(bySymbol.XOF.quote).toBeNull();
+
+    // Base row untouched.
+    expect(bySymbol.USD.price).toBe(1);
+    expect(bySymbol.USD.source).toBe('base');
+  });
+});

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -794,8 +794,10 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(bySymbol.XOF.price).toBeNull();
     expect(bySymbol.XOF.quote).toBeNull();
 
-    // Base row untouched.
-    expect(bySymbol.USD.price).toBe(1);
-    expect(bySymbol.USD.source).toBe('base');
+    // Base row untouched. Ledger canonicalizes the held USD holding to `$`,
+    // and USD mode keeps the same symbol as the original-quote view.
+    expect(bySymbol['$'].price).toBe(1);
+    expect(bySymbol['$'].quote).toBe('USD');
+    expect(bySymbol['$'].source).toBe('base');
   });
 });

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -806,4 +806,28 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(bySymbol['$'].quote).toBe('USD');
     expect(bySymbol['$'].source).toBe('base');
   });
+
+  it('values a dollar-denominated holding via the injected $=USD bridge', async () => {
+    // The common journal convention prices in `$`, which ledger will not bridge
+    // to a `USD` base on its own. The probe's injected `$` = 1 USD directive
+    // must let the value resolve instead of reporting "no price".
+    await seedUser(
+      ctx,
+      'u-dollar',
+      [
+        'P 2026-07-01 BTC $40000',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 BTC',
+        '  Equity    -1 BTC',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-dollar');
+    const btc = rows.find((row) => row.symbol === 'BTC');
+    expect(btc?.price).toBeCloseTo(40000, 6);
+    expect(btc?.quote).toBe('USD');
+  });
 });

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -785,6 +785,12 @@ describe('PriceService.listKnownPricesInBase', () => {
     // Provenance / recency carried over from the raw row (keep-raw).
     expect(bySymbol.BTC.source).toBe('journal');
     expect(bySymbol.BTC.date).toBe('2026-07-01');
+    // ageDays / stale must match the original-quote view exactly. Comparing
+    // against listKnownPrices keeps the guard independent of the run date.
+    const rawRows = await service.listKnownPrices('u-base');
+    const rawBtc = rawRows.find((row) => row.symbol === 'BTC');
+    expect(bySymbol.BTC.ageDays).toBe(rawBtc?.ageDays);
+    expect(bySymbol.BTC.stale).toBe(rawBtc?.stale);
 
     // Nim = 10 KIRT * 2 USD/KIRT = 20 USD (chained Nim->KIRT->USD).
     expect(bySymbol.Nim.price).toBeCloseTo(20, 6);

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -830,4 +830,32 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(btc?.price).toBeCloseTo(40000, 6);
     expect(btc?.quote).toBe('USD');
   });
+
+  it('values a digit-bearing ticker that ledger surfaces quoted', async () => {
+    // A digit-bearing commodity like `1INCH` is only legal double-quoted in a
+    // journal, and `ledger commodities` prints it back with the quotes intact
+    // (`"1INCH"`). The probe must strip the surrounding pair and re-quote the
+    // bare name, otherwise the holding is silently reported as having no price
+    // even though it converts cleanly to the base.
+    await seedUser(
+      ctx,
+      'u-digit',
+      [
+        'P 2026-07-01 "1INCH" 3 USD',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 "1INCH"',
+        '  Equity    -1 "1INCH"',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-digit');
+    // `ledger commodities` keeps the surrounding quotes, so the row identity is
+    // the quoted form.
+    const inch = rows.find((row) => row.symbol === '"1INCH"');
+    expect(inch?.price).toBeCloseTo(3, 6);
+    expect(inch?.quote).toBe('USD');
+  });
 });

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -3,6 +3,11 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import 'server-only';
+import {
+  getBridgeViability,
+  recordBridgeAborts,
+  recordBridgeViable,
+} from './bridgeViability';
 import { classifyCommodity } from './classify';
 import { getCoinSymbolMap } from './coingecko/coinCache';
 import { renderPriceDb, hasGeneratedBanner } from './formatter';
@@ -568,13 +573,18 @@ export class PriceService {
     // ("Assertion failed … source != price.commodity()") and abort the whole
     // parse — but they also already value `$` into `USD` natively, so the
     // bridge is redundant there. Try with the bridge, then retry without it on
-    // failure to stay correct across both build behaviours.
-    const bridge = base === 'USD' ? 'P 2000-01-01 $ 1 USD\n\n' : '';
+    // failure to stay correct across both build behaviours — and remember which
+    // build this binary is, so a canonicalizing build skips the known-fatal
+    // bridge attempt (and its guaranteed retry) on every later render.
+    const bridge = 'P 2000-01-01 $ 1 USD\n\n';
+    const wantsBridge = base === 'USD' && getBridgeViability() !== 'aborts';
     let stdout: string | null = null;
     try {
-      stdout = await runProbe(buildJournal(bridge));
+      stdout = await runProbe(buildJournal(wantsBridge ? bridge : ''));
+      if (wantsBridge) recordBridgeViable();
     } catch {
-      if (bridge) {
+      if (wantsBridge) {
+        recordBridgeAborts();
         stdout = await runProbe(buildJournal('')).catch(() => null);
       }
     }

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -492,17 +492,26 @@ export class PriceService {
 
     if (probeSymbols.length === 0) return raw.map(toBaseRow);
 
+    // Ledger treats `$` and the literal `USD` as distinct commodities and will
+    // not bridge them on its own, so a holding priced in `$` (the common
+    // journal convention) would fail to value into a `USD` base. Seed the probe
+    // journal with the identity `$` = 1 USD, dated in the distant past so any
+    // real `$`/USD price in the user's journal takes precedence over it.
+    const bridge = base === 'USD' ? 'P 2000-01-01 $ 1 USD\n\n' : '';
+
     // One balanced `1 <symbol>` transaction per commodity, indexed by position
     // so the account name carries no commodity-specific characters. Blank lines
     // separate transactions; an explicit offset balances each one.
-    const journal = probeSymbols
-      .map((symbol, index) => {
-        const needsQuote = /[^A-Za-z0-9_]/.test(symbol);
-        const amount = needsQuote ? `1 "${symbol}"` : `1 ${symbol}`;
-        const offset = needsQuote ? `-1 "${symbol}"` : `-1 ${symbol}`;
-        return `2000-01-01 * probe\n  Probe:c${index}    ${amount}\n  Offset:c${index}    ${offset}\n`;
-      })
-      .join('\n');
+    const journal =
+      bridge +
+      probeSymbols
+        .map((symbol, index) => {
+          const needsQuote = /[^A-Za-z0-9_]/.test(symbol);
+          const amount = needsQuote ? `1 "${symbol}"` : `1 ${symbol}`;
+          const offset = needsQuote ? `-1 "${symbol}"` : `-1 ${symbol}`;
+          return `2000-01-01 * probe\n  Probe:c${index}    ${amount}\n  Offset:c${index}    ${offset}\n`;
+        })
+        .join('\n');
 
     const probePath = path.join(
       os.tmpdir(),
@@ -539,7 +548,10 @@ export class PriceService {
         if (normalizeCommoditySymbol(row.symbol) === base) return row;
         const index = probeSymbols.indexOf(row.symbol);
         const hit = index >= 0 ? valued.get(index) : undefined;
-        return hit && hit.commodity === base
+        // Ledger emits `$` for dollar-denominated legs even when `base` is the
+        // string `USD`, so normalize before comparing — otherwise a genuinely
+        // convertible holding would be reported as having no price.
+        return hit && normalizeCommoditySymbol(hit.commodity) === base
           ? { ...row, price: hit.price, quote: base }
           : { ...row, price: null, quote: null };
       });

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -472,9 +472,12 @@ export class PriceService {
     const base = await this.resolveBaseCurrency(userId);
     const raw = await this.listKnownPrices(userId);
 
+    // The base row keeps whatever symbol ledger prints for it (e.g. `$`), so
+    // the row's identity matches the original-quote view exactly — only the
+    // non-base rows get re-valued.
     const toBaseRow = (row: KnownPrice): KnownPrice =>
       normalizeCommoditySymbol(row.symbol) === base
-        ? { ...row, symbol: base }
+        ? row
         : { ...row, price: null, quote: null };
 
     // Probe only non-base commodities; reject symbols that could break the
@@ -533,8 +536,7 @@ export class PriceService {
 
       const valued = parseBaseBalance(stdout);
       return raw.map((row) => {
-        if (normalizeCommoditySymbol(row.symbol) === base)
-          return { ...row, symbol: base };
+        if (normalizeCommoditySymbol(row.symbol) === base) return row;
         const index = probeSymbols.indexOf(row.symbol);
         const hit = index >= 0 ? valued.get(index) : undefined;
         return hit && hit.commodity === base

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
+import os from 'os';
 import path from 'path';
 import 'server-only';
 import { classifyCommodity } from './classify';
@@ -6,11 +8,13 @@ import { getCoinSymbolMap } from './coingecko/coinCache';
 import { renderPriceDb, hasGeneratedBanner } from './formatter';
 import type { CommodityPriceRow } from './formatter';
 import {
+  BALANCE_BASE_FORMAT,
   PRICES_FORMAT,
   STALE_THRESHOLD_DAYS,
   ageInDays,
   deriveSource,
   latestGenuinePrice,
+  parseBaseBalance,
   parsePriceHistory,
   priceKey,
   type KnownPrice,
@@ -455,6 +459,91 @@ export class PriceService {
     return rows.sort((a, b) =>
       a.symbol.localeCompare(b.symbol, undefined, { sensitivity: 'base' })
     );
+  }
+
+  /**
+   * Latest known price for every held commodity, valued into the base currency.
+   * Reuses the raw rows from `listKnownPrices` for provenance and staleness,
+   * then re-values each non-base holding through ledger's full price graph in a
+   * single `balance -X <base>` call driven by a throwaway probe journal. A
+   * holding with no conversion path to the base yields `price: null`.
+   */
+  async listKnownPricesInBase(userId: string): Promise<KnownPrice[]> {
+    const base = await this.resolveBaseCurrency(userId);
+    const raw = await this.listKnownPrices(userId);
+
+    const toBaseRow = (row: KnownPrice): KnownPrice =>
+      normalizeCommoditySymbol(row.symbol) === base
+        ? { ...row, symbol: base }
+        : { ...row, price: null, quote: null };
+
+    // Probe only non-base commodities; reject symbols that could break the
+    // throwaway journal (quotes / newlines).
+    const probeSymbols = raw
+      .filter(
+        (row) =>
+          normalizeCommoditySymbol(row.symbol) !== base &&
+          !/["\n\r]/.test(row.symbol)
+      )
+      .map((row) => row.symbol);
+
+    if (probeSymbols.length === 0) return raw.map(toBaseRow);
+
+    // One balanced `1 <symbol>` transaction per commodity, indexed by position
+    // so the account name carries no commodity-specific characters. Blank lines
+    // separate transactions; an explicit offset balances each one.
+    const journal = probeSymbols
+      .map((symbol, index) => {
+        const needsQuote = /[^A-Za-z0-9_]/.test(symbol);
+        const amount = needsQuote ? `1 "${symbol}"` : `1 ${symbol}`;
+        const offset = needsQuote ? `-1 "${symbol}"` : `-1 ${symbol}`;
+        return `2000-01-01 * probe\n  Probe:c${index}    ${amount}\n  Offset:c${index}    ${offset}\n`;
+      })
+      .join('\n');
+
+    const probePath = path.join(
+      os.tmpdir(),
+      `ledger-probe-${randomUUID()}.ledger`
+    );
+    try {
+      await fs.writeFile(probePath, journal, 'utf-8');
+      let stdout: string;
+      try {
+        stdout = await runLedgerForUser(
+          userId,
+          [
+            '--file',
+            probePath,
+            'balance',
+            '^Probe:c',
+            '--flat',
+            '--empty',
+            '--no-total',
+            '-X',
+            base,
+            '--format',
+            BALANCE_BASE_FORMAT,
+          ],
+          this.deps.journalRepo
+        );
+      } catch {
+        // Ledger failed → no valuation available; degrade to no-price rows.
+        return raw.map(toBaseRow);
+      }
+
+      const valued = parseBaseBalance(stdout);
+      return raw.map((row) => {
+        if (normalizeCommoditySymbol(row.symbol) === base)
+          return { ...row, symbol: base };
+        const index = probeSymbols.indexOf(row.symbol);
+        const hit = index >= 0 ? valued.get(index) : undefined;
+        return hit && hit.commodity === base
+          ? { ...row, price: hit.price, quote: base }
+          : { ...row, price: null, quote: null };
+      });
+    } finally {
+      await fs.rm(probePath, { force: true }).catch(() => {});
+    }
   }
 
   private async maybeMigrateLegacyFiles(users: string[]): Promise<void> {

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -480,48 +480,65 @@ export class PriceService {
         ? row
         : { ...row, price: null, quote: null };
 
-    // Probe only non-base commodities; reject symbols that could break the
-    // throwaway journal (quotes / newlines).
+    // `ledger commodities` surrounds any name that is not a bare alphanumeric
+    // run with double quotes (e.g. it prints `"1INCH"` for the digit-bearing
+    // 1inch ticker — such names are only legal quoted in a journal anyway).
+    // Recover the bare commodity name by stripping one surrounding quote pair,
+    // then reject anything that still carries a quote or newline, which would
+    // let a crafted holding break out of the throwaway journal.
+    const probeName = (symbol: string): string | null => {
+      const stripped =
+        symbol.length >= 2 &&
+        ((symbol.startsWith('"') && symbol.endsWith('"')) ||
+          (symbol.startsWith("'") && symbol.endsWith("'")))
+          ? symbol.slice(1, -1)
+          : symbol;
+      return /["\n\r]/.test(stripped) ? null : stripped;
+    };
+
+    // Probe only non-base commodities with a journal-safe name. Keep the raw
+    // symbol as the row identity so results match back exactly.
     const probeSymbols = raw
       .filter(
         (row) =>
           normalizeCommoditySymbol(row.symbol) !== base &&
-          !/["\n\r]/.test(row.symbol)
+          probeName(row.symbol) !== null
       )
       .map((row) => row.symbol);
 
     if (probeSymbols.length === 0) return raw.map(toBaseRow);
 
-    // Ledger treats `$` and the literal `USD` as distinct commodities and will
-    // not bridge them on its own, so a holding priced in `$` (the common
-    // journal convention) would fail to value into a `USD` base. Seed the probe
-    // journal with the identity `$` = 1 USD, dated in the distant past so any
-    // real `$`/USD price in the user's journal takes precedence over it.
-    const bridge = base === 'USD' ? 'P 2000-01-01 $ 1 USD\n\n' : '';
+    // Map each held symbol to its probe index once, so the final re-value pass
+    // is linear rather than O(n²) via a per-row `indexOf` scan. First index
+    // wins on the off chance two rows carry the same symbol.
+    const symbolIndex = new Map<string, number>();
+    probeSymbols.forEach((symbol, index) => {
+      if (!symbolIndex.has(symbol)) symbolIndex.set(symbol, index);
+    });
 
     // One balanced `1 <symbol>` transaction per commodity, indexed by position
     // so the account name carries no commodity-specific characters. Blank lines
-    // separate transactions; an explicit offset balances each one.
-    const journal =
+    // separate transactions; an explicit offset balances each one. The bare
+    // commodity name is always double-quoted, which is legal for every name and
+    // is required for digit-bearing tickers (`1 1INCH` fails: "Unexpected char
+    // '1'"). An optional bridge directive may be prepended.
+    const buildJournal = (bridge: string): string =>
       bridge +
       probeSymbols
         .map((symbol, index) => {
-          const needsQuote = /[^A-Za-z0-9_]/.test(symbol);
-          const amount = needsQuote ? `1 "${symbol}"` : `1 ${symbol}`;
-          const offset = needsQuote ? `-1 "${symbol}"` : `-1 ${symbol}`;
-          return `2000-01-01 * probe\n  Probe:c${index}    ${amount}\n  Offset:c${index}    ${offset}\n`;
+          const name = probeName(symbol) as string;
+          return `2000-01-01 * probe\n  Probe:c${index}    1 "${name}"\n  Offset:c${index}    -1 "${name}"\n`;
         })
         .join('\n');
 
-    const probePath = path.join(
-      os.tmpdir(),
-      `ledger-probe-${randomUUID()}.ledger`
-    );
-    try {
-      await fs.writeFile(probePath, journal, 'utf-8');
-      let stdout: string;
+    const runProbe = async (journal: string): Promise<string> => {
+      const probePath = path.join(
+        os.tmpdir(),
+        `ledger-probe-${randomUUID()}.ledger`
+      );
       try {
-        stdout = await runLedgerForUser(
+        await fs.writeFile(probePath, journal, 'utf-8');
+        return await runLedgerForUser(
           userId,
           [
             '--file',
@@ -538,26 +555,44 @@ export class PriceService {
           ],
           this.deps.journalRepo
         );
-      } catch {
-        // Ledger failed → no valuation available; degrade to no-price rows.
-        return raw.map(toBaseRow);
+      } finally {
+        await fs.rm(probePath, { force: true }).catch(() => {});
       }
+    };
 
-      const valued = parseBaseBalance(stdout);
-      return raw.map((row) => {
-        if (normalizeCommoditySymbol(row.symbol) === base) return row;
-        const index = probeSymbols.indexOf(row.symbol);
-        const hit = index >= 0 ? valued.get(index) : undefined;
-        // Ledger emits `$` for dollar-denominated legs even when `base` is the
-        // string `USD`, so normalize before comparing — otherwise a genuinely
-        // convertible holding would be reported as having no price.
-        return hit && normalizeCommoditySymbol(hit.commodity) === base
-          ? { ...row, price: hit.price, quote: base }
-          : { ...row, price: null, quote: null };
-      });
-    } finally {
-      await fs.rm(probePath, { force: true }).catch(() => {});
+    // Ledger builds that keep `$` and the literal `USD` distinct will not
+    // bridge a `$`-priced holding into a `USD` base on their own, so seed the
+    // identity `$` = 1 USD, dated in the distant past so any real `$`/USD price
+    // in the user's journal takes precedence over it. Builds that canonicalize
+    // `$` to `USD` (e.g. Ledger 3.4.x) reject that directive as a self-price
+    // ("Assertion failed … source != price.commodity()") and abort the whole
+    // parse — but they also already value `$` into `USD` natively, so the
+    // bridge is redundant there. Try with the bridge, then retry without it on
+    // failure to stay correct across both build behaviours.
+    const bridge = base === 'USD' ? 'P 2000-01-01 $ 1 USD\n\n' : '';
+    let stdout: string | null = null;
+    try {
+      stdout = await runProbe(buildJournal(bridge));
+    } catch {
+      if (bridge) {
+        stdout = await runProbe(buildJournal('')).catch(() => null);
+      }
     }
+    // Ledger failed outright → no valuation available; degrade to no-price rows.
+    if (stdout === null) return raw.map(toBaseRow);
+
+    const valued = parseBaseBalance(stdout);
+    return raw.map((row) => {
+      if (normalizeCommoditySymbol(row.symbol) === base) return row;
+      const index = symbolIndex.get(row.symbol);
+      const hit = index !== undefined ? valued.get(index) : undefined;
+      // Ledger emits `$` for dollar-denominated legs even when `base` is the
+      // string `USD`, so normalize before comparing — otherwise a genuinely
+      // convertible holding would be reported as having no price.
+      return hit && normalizeCommoditySymbol(hit.commodity) === base
+        ? { ...row, price: hit.price, quote: base }
+        : { ...row, price: null, quote: null };
+    });
   }
 
   private async maybeMigrateLegacyFiles(users: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

Adds a toggle on the **Known prices** tab to switch each row between its original journal quote and a value normalized into the base currency (USD).

Previously every commodity showed its latest price in whatever quote its newest `P` directive used — fetched prices in USD, but journal-sourced ones in their original quote (BTC in DAI, Nim/Sekke in KIRT). The result was a column of mixed currencies that couldn't be compared at a glance.

## How it works

- **Original quote** (default) — unchanged behavior.
- **In USD** — every held commodity is valued into the base via a single `ledger balance -X <base>` call driven by a throwaway probe journal (one balanced `1 <commodity>` transaction each). Ledger chains cross-rates through the full price graph (BTC→DAI→USD, Nim→KIRT→USD). Commodities with no path to the base show "no price" — never a fabricated 0.
- Date / Age / Source columns are carried over unchanged from the original-quote view (keep-raw): a USD value derived from a stale underlying price is still flagged stale.
- The toggle is a `?base=usd` search param (server refetch), rendered as a segmented control shown only on the Known prices tab.

`ledger prices -X` does not convert (verified) — only a `balance -X` report chains rates. Because ledger treats `$` and the literal `USD` as distinct commodities, the probe journal injects a `$` = 1 USD bridge (dated in the distant past so any real `$`/USD price wins) so dollar-denominated holdings — the common journal convention — value correctly.

## Cost

One extra ledger subprocess beyond the existing per-commodity fan-out, regardless of how many commodities are held.

## Testing

- `parseBaseBalance` unit tests (index keying, unconvertible commodity, thousands stripping, offset/garbage rejection, exact format-string assertion).
- Real-ledger integration tests for `listKnownPricesInBase`: chained conversion, no-path → null, keep-raw columns, base row, dollar-denominated holding via the bridge.
- Full suite 948/948 green; type-check + lint clean; `next build` compiles `/prices` as a dynamic route.

## Not covered

Live in-browser verification against a real journal was not run (requires an authenticated session).
