### PR TITLE
feat(prices): value known-prices toggle into the selected display currency

### DIFF
--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -1,6 +1,7 @@
 import { PricesTabs } from '@/features/prices';
 import { requireUser } from '@/lib/auth/require-user';
 import { priceService } from '@/lib/prices';
+import { getBaseCurrency } from '@/lib/settings';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,18 +13,20 @@ const PricesPage = async ({
   searchParams: Promise<SearchParams>;
 }) => {
   const { base } = await searchParams;
-  // `base=base` is a mode flag ("value into the resolved base currency"), not
-  // the currency code — so the toggle keeps working the day
-  // resolveBaseCurrency returns something other than USD.
+  // `base=base` is a mode flag ("value into the display currency"), not the
+  // currency code itself — the label and target both come from getBaseCurrency.
   const baseMode = base === 'base';
   const user = await requireUser();
-  const [known, prices, commodities, baseCurrency] = await Promise.all([
+  // The display currency the user picked (session cookie → saved setting →
+  // default), the same resolver every report page uses. Distinct from the USD
+  // pricing base that prices are stored and fetched in.
+  const displayCurrency = await getBaseCurrency();
+  const [known, prices, commodities] = await Promise.all([
     baseMode
-      ? priceService.listKnownPricesInBase(user.id)
+      ? priceService.listKnownPricesInBase(user.id, displayCurrency)
       : priceService.listKnownPrices(user.id),
     priceService.listManualPrices(user.id),
     priceService.listNormalizedSymbolsForUser(user.id),
-    priceService.resolveBaseCurrency(user.id),
   ]);
 
   return (
@@ -31,7 +34,7 @@ const PricesPage = async ({
       known={known}
       prices={prices}
       commodities={commodities}
-      baseCurrency={baseCurrency}
+      baseCurrency={displayCurrency}
       baseMode={baseMode}
     />
   );

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -863,4 +863,28 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(inch?.price).toBeCloseTo(3, 6);
     expect(inch?.quote).toBe('USD');
   });
+
+  it('values into a non-USD target currency (respects the selector)', async () => {
+    // BTC is priced in USD and EUR itself is priced in USD; `-X EUR` inverts the
+    // EUR/USD leg to reach the target. 1 BTC = 40000 USD / 1.10 USD-per-EUR.
+    await seedUser(
+      ctx,
+      'u-eur',
+      [
+        'P 2026-07-01 BTC 40000 USD',
+        'P 2026-07-01 EUR 1.10 USD',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 BTC',
+        '  Equity    -1 BTC',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-eur', 'EUR');
+    const btc = rows.find((row) => row.symbol === 'BTC');
+    expect(btc?.price).toBeCloseTo(40000 / 1.1, 1);
+    expect(btc?.quote).toBe('EUR');
+  });
 });

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -887,4 +887,31 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(btc?.price).toBeCloseTo(40000 / 1.1, 1);
     expect(btc?.quote).toBe('EUR');
   });
+
+  it('values a dollar-denominated holding into a non-USD target via the bridge', async () => {
+    // The exact interaction the removed `base === 'USD'` gate unlocks: a `$`
+    // -priced holding reaching a non-USD target. BTC is priced in `$` (not the
+    // `USD` literal), so it only reaches the `USD` pricing base through the
+    // injected `$` = 1 USD bridge; EUR is then priced in USD, so `-X EUR`
+    // inverts that leg. 1 BTC = 40000 $ -> 40000 USD / 1.10 USD-per-EUR.
+    await seedUser(
+      ctx,
+      'u-dollar-eur',
+      [
+        'P 2026-07-01 BTC $40000',
+        'P 2026-07-01 EUR 1.10 USD',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 BTC',
+        '  Equity    -1 BTC',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-dollar-eur', 'EUR');
+    const btc = rows.find((row) => row.symbol === 'BTC');
+    expect(btc?.price).toBeCloseTo(40000 / 1.1, 1);
+    expect(btc?.quote).toBe('EUR');
+  });
 });

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -467,14 +467,21 @@ export class PriceService {
   }
 
   /**
-   * Latest known price for every held commodity, valued into the base currency.
+   * Latest known price for every held commodity, valued into a target currency.
    * Reuses the raw rows from `listKnownPrices` for provenance and staleness,
-   * then re-values each non-base holding through ledger's full price graph in a
-   * single `balance -X <base>` call driven by a throwaway probe journal. A
-   * holding with no conversion path to the base yields `price: null`.
+   * then re-values each non-target holding through ledger's full price graph in
+   * a single `balance -X <target>` call driven by a throwaway probe journal. A
+   * holding with no conversion path to the target yields `price: null`.
+   *
+   * `targetCurrency` is the user-facing display currency (their selector) — NOT
+   * the USD pricing base that `resolveBaseCurrency` returns for storage. It
+   * defaults to that pricing base only so existing callers stay valid.
    */
-  async listKnownPricesInBase(userId: string): Promise<KnownPrice[]> {
-    const base = await this.resolveBaseCurrency(userId);
+  async listKnownPricesInBase(
+    userId: string,
+    targetCurrency?: string
+  ): Promise<KnownPrice[]> {
+    const base = targetCurrency ?? (await this.resolveBaseCurrency(userId));
     const raw = await this.listKnownPrices(userId);
 
     // The base row keeps whatever symbol ledger prints for it (e.g. `$`), so
@@ -576,8 +583,12 @@ export class PriceService {
     // failure to stay correct across both build behaviours — and remember which
     // build this binary is, so a canonicalizing build skips the known-fatal
     // bridge attempt (and its guaranteed retry) on every later render.
+    // The bridge states `$` = 1 USD, a universal identity (the pricing base is
+    // always USD), so it is valid for any target: a dollar-priced holding
+    // reaches a non-USD target as `$`->USD->target. Only the ledger-build
+    // viability gates it, not the target currency.
     const bridge = 'P 2000-01-01 $ 1 USD\n\n';
-    const wantsBridge = base === 'USD' && getBridgeViability() !== 'aborts';
+    const wantsBridge = getBridgeViability() !== 'aborts';
     let stdout: string | null = null;
     try {
       stdout = await runProbe(buildJournal(wantsBridge ? bridge : ''));

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -484,12 +484,15 @@ export class PriceService {
     const base = targetCurrency ?? (await this.resolveBaseCurrency(userId));
     const raw = await this.listKnownPrices(userId);
 
-    // The base row keeps whatever symbol ledger prints for it (e.g. `$`), so
-    // the row's identity matches the original-quote view exactly — only the
-    // non-base rows get re-valued.
+    // The base row is the target currency valued in itself, so represent it as
+    // the identity `1 <target>` rather than its raw quote. For the USD default
+    // the raw row is already `1 USD`, so this is a no-op there; for a non-USD
+    // target it stops the held target currency from rendering at its raw
+    // USD-quoted price (e.g. `1.10 USD`) among rows all valued in the target.
+    // Its symbol (e.g. `$`), date, staleness and provenance are preserved.
     const toBaseRow = (row: KnownPrice): KnownPrice =>
       normalizeCommoditySymbol(row.symbol) === base
-        ? row
+        ? { ...row, price: 1, quote: base }
         : { ...row, price: null, quote: null };
 
     // `ledger commodities` surrounds any name that is not a bare alphanumeric
@@ -604,7 +607,9 @@ export class PriceService {
 
     const valued = parseBaseBalance(stdout);
     return raw.map((row) => {
-      if (normalizeCommoditySymbol(row.symbol) === base) return row;
+      // The target valued in itself is the identity `1 <target>` (see toBaseRow).
+      if (normalizeCommoditySymbol(row.symbol) === base)
+        return { ...row, price: 1, quote: base };
       const index = symbolIndex.get(row.symbol);
       const hit = index !== undefined ? valued.get(index) : undefined;
       // Ledger emits `$` for dollar-denominated legs even when `base` is the


### PR DESCRIPTION
## Summary

Follow-up to #73. The Known-prices "In …" toggle valued every row into the hardcoded USD **pricing** base (`resolveBaseCurrency`), ignoring the user's currency selector — so it always read "In USD" no matter what currency was chosen.

This wires the toggle to the **display** currency (`getBaseCurrency()` — session cookie → saved setting → default, the same resolver the balance/net-worth pages use). The USD pricing base is untouched: prices are still fetched and stored in USD; only the on-screen valuation target changes.

## Changes

- `listKnownPricesInBase(userId, targetCurrency?)` — new optional target; values via `balance -X <target>`. Ledger inverts a fetched `EUR-in-USD` leg to reach a non-USD target (e.g. BTC → USD → EUR).
- The `$` = 1 USD bridge is no longer gated on a USD target — it is a universal identity, so dollar-priced holdings reach any target as `$` → USD → target. Ledger-build viability still gates it.
- `app/prices/page.tsx` resolves `getBaseCurrency()` and passes it as both the valuation target and the toggle label; the label now reads "In <selected currency>".

## Testing

- New integration test: values BTC into EUR (40000 USD / 1.10 = 36363.64 EUR).
- Full `lib/prices` suite 107/107; type-check + lint clean.

## Note

Commodities with no price path to the selected currency still show "no price" (honest — no fabricated value).
