### PR TITLE
fix(prices): normalize display-currency target so mixed-case selections value

### DIFF
--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -914,4 +914,37 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(btc?.price).toBeCloseTo(40000 / 1.1, 1);
     expect(btc?.quote).toBe('EUR');
   });
+
+  it('normalizes a mixed-case target so it does not null every row', async () => {
+    // getBaseCurrency can return a currency in any case (e.g. `Kirt`). Held
+    // symbols and ledger output are normalized (uppercased), so the target must
+    // be too — otherwise `=== base` never matches and every row is "no price".
+    // ADA priced in USD, KIRT priced in USD → ADA = 0.169753 / 0.00568182 KIRT.
+    await seedUser(
+      ctx,
+      'u-kirt',
+      [
+        'P 2026-07-06 ADA 0.169753 USD',
+        'P 2026-07-07 KIRT 0.00568182 USD',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:A   1 ADA',
+        '  Equity    -1 ADA',
+        '',
+        '2026-07-02 * hold',
+        '  Assets:K   1 KIRT',
+        '  Equity    -1 KIRT',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+
+    const rows = await service.listKnownPricesInBase('u-kirt', 'Kirt');
+    const ada = rows.find((row) => row.symbol === 'ADA');
+    expect(ada?.price).toBeCloseTo(0.169753 / 0.00568182, 2);
+    expect(ada?.quote).toBe('KIRT');
+    // The target itself is the base row: valued in itself at 1.
+    const kirt = rows.find((row) => row.symbol === 'KIRT');
+    expect(kirt?.price).toBe(1);
+  });
 });

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -481,7 +481,13 @@ export class PriceService {
     userId: string,
     targetCurrency?: string
   ): Promise<KnownPrice[]> {
-    const base = targetCurrency ?? (await this.resolveBaseCurrency(userId));
+    // Normalize the target the same way held symbols are normalized (uppercased,
+    // `$`→USD). getBaseCurrency can hand back a currency in any case (e.g.
+    // `Kirt`), and every downstream `=== base` check compares against a
+    // normalized symbol — and `-X` must target the same canonical form ledger
+    // valued into — so an un-normalized base would null every row.
+    const rawBase = targetCurrency ?? (await this.resolveBaseCurrency(userId));
+    const base = normalizeCommoditySymbol(rawBase) ?? rawBase;
     const raw = await this.listKnownPrices(userId);
 
     // The base row is the target currency valued in itself, so represent it as


### PR DESCRIPTION
## Summary

Follow-up to #74. Selecting a display currency whose case differs from how it is stored/priced (e.g. **Kirt** vs the `KIRT` commodity) made every row show "no price".

Held symbols and ledger output are normalized (uppercased, `$`→USD) before every `=== base` comparison, but the target currency from `getBaseCurrency()` was passed through raw. So `normalize("KIRT") === "Kirt"` was always false — every valued row got nulled and the base row was never detected.

## Fix

Normalize the target once (`normalizeCommoditySymbol(rawBase) ?? rawBase`) and use that canonical form for both the `-X <target>` valuation and every comparison. `Kirt` → `KIRT` now values correctly (ADA = 0.169753 / 0.00568182 ≈ 29.88 KIRT; KIRT itself is the base row at 1).

## Testing

- New integration test: `listKnownPricesInBase(user, 'Kirt')` values ADA into `KIRT` and treats `KIRT` as the base row.
- Full `lib/prices` suite 109/109; type-check + lint clean.
