### PR TITLE
fix(settings): match reporting base case-insensitively for rates and currency list

### DIFF
--- a/lib/settings/parseCommodityList.test.ts
+++ b/lib/settings/parseCommodityList.test.ts
@@ -48,4 +48,13 @@ describe('parseCommodityList', () => {
   it('appends the base even when absent from the input', () => {
     expect(parseCommodityList('EUR\n', 'USD')).toEqual(['USD', 'EUR']);
   });
+
+  it('does not offer a case-variant of the base as a separate currency', () => {
+    // Journal holds both `KIRT` and `Kirt`; with `Kirt` chosen as the base,
+    // only the pinned base appears — not a duplicate `KIRT` option.
+    expect(parseCommodityList('KIRT\nEUR\nKirt\n', 'Kirt')).toEqual([
+      'Kirt',
+      'EUR',
+    ]);
+  });
 });

--- a/lib/settings/parseCommodityList.ts
+++ b/lib/settings/parseCommodityList.ts
@@ -20,6 +20,11 @@ export const parseCommodityList = (stdout: string, base: string): string[] => {
     out.push(line);
   }
 
-  const rest = out.filter((c) => c !== base).sort(collator.compare);
+  // Filter the base case-insensitively so a case-variant of the base (e.g.
+  // `Kirt` when the base is `KIRT`) is not offered as a second, distinct
+  // currency alongside the pinned base.
+  const rest = out
+    .filter((c) => collator.compare(c, base) !== 0)
+    .sort(collator.compare);
   return [base, ...rest];
 };

--- a/lib/settings/parseUnconverted.test.ts
+++ b/lib/settings/parseUnconverted.test.ts
@@ -48,4 +48,11 @@ describe('parseUnconverted', () => {
     `;
     expect(parseUnconverted(stdout, 'USD')).toEqual(['EUR', 'JPY']);
   });
+
+  it('treats a case-variant of the base as the base, not unconverted', () => {
+    const stdout = ['20 Kirt  Assets:A', '5 EUR  Assets:B'].join('\n');
+    // Base is `KIRT`; the `Kirt` row is the same currency, so only EUR needs
+    // a rate.
+    expect(parseUnconverted(stdout, 'KIRT')).toEqual(['EUR']);
+  });
 });

--- a/lib/settings/parseUnconverted.ts
+++ b/lib/settings/parseUnconverted.ts
@@ -33,7 +33,9 @@ export const parseUnconverted = (stdout: string, base: string): string[] => {
     if (!line) continue;
 
     const commodity = extractCommodity(line);
-    if (commodity && commodity !== base) {
+    // Match the base case-insensitively: a case-variant of the base (e.g. `Kirt`
+    // when the base is `KIRT`) is the same currency, not an unconverted holding.
+    if (commodity && collator.compare(commodity, base) !== 0) {
       found.add(commodity);
     }
   }


### PR DESCRIPTION
## Summary

App-wide robustness for mixed-case commodity/currency names (e.g. a journal that holds both `KIRT` and `Kirt`). Ledger treats case-variants as distinct commodities; the app compared the reporting **base** case-sensitively in two shared spots, so a case-variant of the base was mishandled for every user, not just one.

Bounded principle: the **reporting base is matched case-insensitively** — its own case-variants are the same currency. Arbitrary commodities are left untouched (blindly folding all names would mangle legitimately mixed-case tickers and hide real journal state).

## Changes

- `parseUnconverted` (missing-rate detection) — a case-variant of the base (e.g. `Kirt` when base is `KIRT`) is no longer flagged as an unconverted holding needing a rate. Kills a spurious "missing rate" warning.
- `parseCommodityList` (currency selector) — a case-variant of the base is no longer offered as a second, distinct currency option alongside the pinned base.

Both reuse the `Intl.Collator(sensitivity:'base')` already present in each file.

## Context

The known-prices "In <currency>" toggle nulling every row on a mixed-case base was already fixed app-wide in the display-currency-normalization work; this closes the remaining base-comparison spots.

## Testing

- New cases in both parser suites; full `lib/settings` 43/43; type-check + lint clean.
