### PR TITLE
fix(prices): make relocated `format` directives journal-valid

### DIFF
--- a/lib/prices/definitions.test.ts
+++ b/lib/prices/definitions.test.ts
@@ -51,6 +51,40 @@ describe('extractDefinitions', () => {
     const text = 'P 2026/07/06 BTC 64000 USD\nP 2026/07/06 ETH 3000 USD\n';
     expect(extractDefinitions(text)).toBe('');
   });
+
+  it('gives a symbol-less `format` sample its commodity (journal-valid)', () => {
+    const text = [
+      'commodity KIRT',
+      '\talias Kirt',
+      '\tformat 1,000',
+      '\tnomarket',
+      'commodity $',
+      '\tformat 1,000.00',
+    ].join('\n');
+    expect(extractDefinitions(text)).toBe(
+      [
+        'commodity KIRT',
+        '\talias Kirt',
+        '\tformat 1,000 "KIRT"',
+        '\tnomarket',
+        'commodity $',
+        '\tformat 1,000.00 "$"',
+      ].join('\n')
+    );
+  });
+
+  it('quotes a symbol containing a separator (e.g. د.إ) when injecting', () => {
+    const text = 'commodity د.إ\n\tformat 1,000.00';
+    expect(extractDefinitions(text)).toBe(
+      'commodity د.إ\n\tformat 1,000.00 "د.إ"'
+    );
+  });
+
+  it('leaves a `format` sample that already carries its commodity', () => {
+    const text =
+      'commodity KIRT\n\tformat KIRT 1,000.000\ncommodity $\n\tformat $1,000.00';
+    expect(extractDefinitions(text)).toBe(text);
+  });
 });
 
 describe('hasDefinitions', () => {

--- a/lib/prices/definitions.ts
+++ b/lib/prices/definitions.ts
@@ -22,11 +22,43 @@ const PRICE_LINE =
  */
 export const extractDefinitions = (text: string): string => {
   const kept: string[] = [];
+  let currentCommodity: string | null = null;
   for (const raw of text.split('\n')) {
     const line = raw.replace(/\s+$/, '');
     const trimmed = line.trim();
     if (PRICE_LINE.test(trimmed)) continue;
     if (trimmed.includes(BANNER_MARKER)) continue;
+
+    // Track the enclosing `commodity <symbol>` block. A non-indented, non-blank
+    // line closes it; blank lines and comments leave it open.
+    const commodityMatch = /^commodity\s+(.+)$/.exec(trimmed);
+    if (commodityMatch) {
+      // Store unquoted so we can re-quote consistently in the format below.
+      currentCommodity = commodityMatch[1].trim().replace(/^"(.*)"$/, '$1');
+      kept.push(line);
+      continue;
+    }
+    if (trimmed && !/^\s/.test(line)) currentCommodity = null;
+
+    // ledger tolerates a symbol-less `format` sample (e.g. `format 1,000`) in a
+    // --price-db but rejects it in a journal include ("commodity directive
+    // symbol X and format directive symbol '' should be the same"). Give a
+    // numeric-only sample its commodity — quoted, so a symbol containing a `.`
+    // or other separator (e.g. `د.إ`) isn't mis-tokenized. A sample that
+    // already carries a symbol (`format KIRT 1,000` / `format $1,000.00`) is
+    // left untouched.
+    const formatMatch = /^format\s+(.+)$/.exec(trimmed);
+    if (
+      formatMatch &&
+      currentCommodity &&
+      /^[\d.,\s+-]+$/.test(formatMatch[1])
+    ) {
+      const indent = line.slice(0, line.length - trimmed.length);
+      kept.push(
+        `${indent}format ${formatMatch[1].trim()} "${currentCommodity}"`
+      );
+      continue;
+    }
     kept.push(line);
   }
   return kept.join('\n').replace(/^\n+/, '').replace(/\n+$/, '');

--- a/lib/prices/definitions.ts
+++ b/lib/prices/definitions.ts
@@ -30,7 +30,7 @@ export const extractDefinitions = (text: string): string => {
     if (trimmed.includes(BANNER_MARKER)) continue;
 
     // Track the enclosing `commodity <symbol>` block. A non-indented, non-blank
-    // line closes it; blank lines and comments leave it open.
+    // line closes it; blank lines and indented comments leave it open.
     const commodityMatch = /^commodity\s+(.+)$/.exec(trimmed);
     if (commodityMatch) {
       // Store unquoted so we can re-quote consistently in the format below.


### PR DESCRIPTION
Follow-up to #77.

## Problem

`relocateLegacyDefinitions` copied `commodity` blocks verbatim from the legacy price DB. A hand-maintained price DB commonly writes a **symbol-less `format` sample** (e.g. `format 1,000`). ledger accepts that inside a `--price-db` but **rejects it in a journal include**:

```
commodity directive symbol KIRT and format directive symbol '' should be the same
```

So the post-relocation `verifyJournalParseable` failed, the relocation rolled back, and the repair could never complete — `POST /api/maintenance/relocate-definitions` returned `failed`. (The rollback worked correctly; no journal was damaged.)

## Fix

`extractDefinitions` now gives a numeric-only `format` sample its enclosing commodity, **quoted** so a symbol containing a separator (e.g. `د.إ`, whose `.` would otherwise be mis-tokenized) matches its `commodity` directive:

```
format 1,000        →  format 1,000 "KIRT"
format 1,000.00     →  format 1,000.00 "د.إ"
```

A sample that already carries its symbol (`format KIRT 1,000` / `format $1,000.00`) is left untouched.

## Verification

Reproduced against the **real** 211-line `price-db_old.ledger` from prod: after the fix the relocated `definitions.ledger` passes `ledger stats` (exit 0) and values cleanly, where before every `format` line failed. Unit tests cover symbol injection, the separator-quoting case, and the already-symboled no-op.