### PR TITLE
fix(prices): make relocated definitions layout parse under the read path

### DIFF
--- a/app/api/maintenance/repair-price-db/route.ts
+++ b/app/api/maintenance/repair-price-db/route.ts
@@ -1,0 +1,31 @@
+import { requireUser } from '@/lib/auth/require-user';
+import { createLogger } from '@/lib/log';
+import { priceService } from '@/lib/prices';
+import { NextResponse } from 'next/server';
+
+const log = createLogger('repair-price-db');
+
+/**
+ * Regenerate the caller's price DB and push it to canonical. Repairs a price DB
+ * written before render-time canonicalization existed — one that quoted a
+ * commodity the journal also aliases (e.g. `USD` under `commodity $ / alias
+ * USD`), which made ledger abort every read with a pool.cc assertion. Operates
+ * only on the caller's own journal. Idempotent — safe to hit more than once.
+ *
+ * The service takes the per-user lock and pulls fresh under it, so this handler
+ * does not pull first. A regeneration that leaves the journal unparseable does
+ * not push and returns `failed` rather than an opaque 500.
+ */
+export async function POST(): Promise<NextResponse> {
+  const user = await requireUser();
+  try {
+    const result = await priceService.repairUserPriceDb(user.id);
+    return NextResponse.json({ result });
+  } catch (error) {
+    log.error({ err: error }, 'price db repair failed');
+    return NextResponse.json(
+      { result: 'failed', message: 'Could not repair your price database' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/journal/verify.ts
+++ b/lib/journal/verify.ts
@@ -54,31 +54,35 @@ const sanitize = (stderr: string): string => {
  * diverges from ledger's grammar, we catch it before the user has to find
  * out via a broken report page.
  *
+ * Pass `priceDbPath` to load a `--price-db` alongside the journal, exactly as
+ * the real read paths do. This matters because some parse errors only surface
+ * with the price DB present: ledger auto-vivifies a commodity from a `P` line's
+ * symbol/quote, so a price DB that names an alias (e.g. `BTC`) collides with the
+ * journal's `alias BTC` directive and aborts (pool.cc assertion). Verifying the
+ * journal alone would miss it and let a broken layout through.
+ *
  * On failure, returns the actual ledger diagnostic with absolute paths
  * redacted so the message is safe to surface to the client.
  */
 export const verifyJournalParseable = async (
-  mainPath: string
+  mainPath: string,
+  priceDbPath?: string
 ): Promise<VerifyResult> => {
   try {
     // Run hermetically: ignore the server's `~/.ledgerrc` (--init-file) and its
     // ambient LEDGER_* env (a personal LEDGER_PRICE_DB can declare commodities
     // that collide with the journal's own, failing an otherwise valid parse).
-    // The real read paths pass an explicit --price-db, which already overrides
-    // the env; verify only checks the journal, so it needs no price DB at all.
+    // An explicit --price-db still overrides the env, so passing one is safe.
     const {
       LEDGER_PRICE_DB: _priceDb,
       LEDGER_FILE: _file,
       LEDGER_INIT: _init,
       ...env
     } = process.env;
-    await execFileP(
-      'ledger',
-      ['--init-file', '/dev/null', '-f', mainPath, 'stats'],
-      {
-        env,
-      }
-    );
+    const args = ['--init-file', '/dev/null', '-f', mainPath];
+    if (priceDbPath) args.push('--price-db', priceDbPath);
+    args.push('stats');
+    await execFileP('ledger', args, { env });
     return { ok: true };
   } catch (e) {
     const err = e as { stderr?: string; message?: string };

--- a/lib/prices/definitions.test.ts
+++ b/lib/prices/definitions.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { extractDefinitions, hasDefinitions } from './definitions';
+import {
+  extractDefinitions,
+  hasDefinitions,
+  parseAliasMap,
+} from './definitions';
 import { renderPriceDb } from './formatter';
 
 describe('extractDefinitions', () => {
@@ -84,6 +88,49 @@ describe('extractDefinitions', () => {
     const text =
       'commodity KIRT\n\tformat KIRT 1,000.000\ncommodity $\n\tformat $1,000.00';
     expect(extractDefinitions(text)).toBe(text);
+  });
+});
+
+describe('parseAliasMap', () => {
+  it('maps each commodity-block alias to its canonical symbol', () => {
+    const text = [
+      'commodity BITCOIN',
+      '\talias BTC',
+      '\talias XBT',
+      '\tnomarket',
+      'commodity KIRT',
+      '\talias Kirt',
+    ].join('\n');
+    const map = parseAliasMap(text);
+    expect(map.get('BTC')).toBe('BITCOIN');
+    expect(map.get('XBT')).toBe('BITCOIN');
+    expect(map.get('Kirt')).toBe('KIRT');
+    expect(map.size).toBe(3);
+  });
+
+  it('unquotes both the commodity and the alias symbol', () => {
+    const text = 'commodity "د.إ"\n\talias "AED"';
+    expect(parseAliasMap(text).get('AED')).toBe('د.إ');
+  });
+
+  it('ignores a non-indented (block-closing) alias and account aliases', () => {
+    // A top-level `alias Old=New` is an account alias, not a commodity alias,
+    // and a non-indented line closes the commodity block.
+    const text = [
+      'commodity KIRT',
+      '\talias Kirt',
+      'alias Expenses=Ex',
+      'alias Bogus',
+    ].join('\n');
+    const map = parseAliasMap(text);
+    expect(map.get('Kirt')).toBe('KIRT');
+    expect(map.has('Expenses=Ex')).toBe(false);
+    expect(map.has('Bogus')).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  it('returns an empty map when there are no aliases', () => {
+    expect(parseAliasMap('commodity BTC\n\tnomarket').size).toBe(0);
   });
 });
 

--- a/lib/prices/definitions.ts
+++ b/lib/prices/definitions.ts
@@ -65,6 +65,45 @@ export const extractDefinitions = (text: string): string => {
 };
 
 /**
+ * Map every commodity-block `alias` to its canonical `commodity` symbol, e.g.
+ * `commodity BITCOIN` / `alias BTC` yields `BTC -> BITCOIN`. Used to canonicalize
+ * price rows so the generated price DB never references an alias as a bare
+ * commodity: ledger auto-vivifies a commodity from a `P` line's symbol/quote, so
+ * a later `alias BTC` in the journal would collide with that auto-created `BTC`
+ * and abort the parse (pool.cc assertion).
+ *
+ * Only picks up `alias` directives indented inside a `commodity` block — a
+ * non-indented line closes the block, and a top-level `alias Old=New` is an
+ * account alias, not a commodity one.
+ */
+export const parseAliasMap = (text: string): Map<string, string> => {
+  const map = new Map<string, string>();
+  let currentCommodity: string | null = null;
+  const unquote = (value: string): string =>
+    value.trim().replace(/^"(.*)"$/, '$1');
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    const trimmed = line.trim();
+
+    const commodityMatch = /^commodity\s+(.+)$/.exec(trimmed);
+    if (commodityMatch) {
+      currentCommodity = unquote(commodityMatch[1]);
+      continue;
+    }
+
+    const aliasMatch = /^alias\s+(.+)$/.exec(trimmed);
+    // Only an indented alias belongs to the enclosing commodity block.
+    if (aliasMatch && currentCommodity && /^\s/.test(line)) {
+      map.set(unquote(aliasMatch[1]), currentCommodity);
+      continue;
+    }
+
+    if (trimmed && !/^\s/.test(line)) currentCommodity = null;
+  }
+  return map;
+};
+
+/**
  * True when the file carries at least one real definition — a non-blank,
  * non-comment line that survives {@link extractDefinitions}. A file that is
  * only prices, blanks, and comments has nothing worth relocating.

--- a/lib/prices/formatter.test.ts
+++ b/lib/prices/formatter.test.ts
@@ -43,6 +43,32 @@ describe('renderPriceDb', () => {
     expect(out).toContain(BANNER_MARKER);
     expect(out).not.toMatch(/^P /m);
   });
+
+  it('double-quotes a symbol or quote that ledger cannot read bare', () => {
+    const out = renderPriceDb([
+      {
+        symbol: 'Real Estate',
+        quote: 'د.إ',
+        price: 100,
+        fetchedAt: new Date('2026-05-25T06:00:00.000Z'),
+        fetchedDate: '2026-05-25',
+      },
+    ]);
+    expect(out).toContain('P 2026/05/25 06:00:00 "Real Estate" 100 "د.إ"');
+  });
+
+  it('leaves bare-safe tickers unquoted', () => {
+    const out = renderPriceDb([
+      {
+        symbol: '$',
+        quote: 'USD',
+        price: 1,
+        fetchedAt: new Date('2026-05-25T06:00:00.000Z'),
+        fetchedDate: '2026-05-25',
+      },
+    ]);
+    expect(out).toContain('P 2026/05/25 06:00:00 $ 1 USD');
+  });
 });
 
 describe('hasGeneratedBanner', () => {

--- a/lib/prices/formatter.ts
+++ b/lib/prices/formatter.ts
@@ -17,11 +17,22 @@ const BANNER = [
   '; Manual price overrides belong in your main journal.',
 ].join('\n');
 
+// Ledger reads a bare commodity symbol as a run of characters that excludes
+// whitespace, digits, and the punctuation it reserves for amount syntax. A name
+// outside that set (e.g. `Real Estate`, `1INCH`, `د.إ`) is only legal
+// double-quoted. Fetched/manual tickers (`$`, `BTC`, `USD`) contain none of
+// these and stay bare, but a canonical substitution can pull in a `commodity`
+// target that does — `parseAliasMap` unquotes those targets, so re-quote here.
+const RESERVED_COMMODITY_CHARS = /[\s\d.,;:?!+\-*/^&|=<>[\]{}()@"]/;
+
+const renderCommodity = (symbol: string): string =>
+  RESERVED_COMMODITY_CHARS.test(symbol) ? `"${symbol}"` : symbol;
+
 export const renderPriceDb = (rows: CommodityPriceRow[]): string => {
   const generatedAt = `; Last regenerated: ${new Date().toISOString()}`;
   const lines = rows.map(
     (r) =>
-      `P ${formatLedgerDateTime(r.fetchedAt)} ${r.symbol} ${r.price} ${r.quote}`
+      `P ${formatLedgerDateTime(r.fetchedAt)} ${renderCommodity(r.symbol)} ${r.price} ${renderCommodity(r.quote)}`
   );
   return [BANNER, generatedAt, '', ...lines, ''].join('\n');
 };

--- a/lib/prices/service-definitions.test.ts
+++ b/lib/prices/service-definitions.test.ts
@@ -245,6 +245,119 @@ describe('PriceService.relocateLegacyDefinitions', () => {
     expect(defs).toContain('alias Kirt');
   });
 
+  it('canonicalizes a legacy price that quotes an alias so the price DB parses', async () => {
+    // Regression: the legacy price DB priced BITCOIN under its alias `BTC`.
+    // Relocating `commodity BITCOIN / alias BTC` while regenerating a price DB
+    // that still says `P ... BTC ... USD` makes ledger auto-create a commodity
+    // `BTC` from the price line, colliding with the `alias BTC` directive and
+    // aborting every read (pool.cc assertion) — but only when the price DB is
+    // loaded, which the dashboard does and the old verify did not. Canonicalizing
+    // the price to the real commodity is what keeps the new layout parseable.
+    await ctx.insertUser('gina', 'gina', 'gina@example.com');
+    await new UserSettingRepository(ctx.db).upsertBaseCurrency('gina', 'USD');
+    await new JournalRepository(ctx.db).setMainFile('gina', 'ledger.ledger');
+    const dir = getJournalDir('gina');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'ledger.ledger'),
+      'include ./2025.ledger\n',
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(dir, '2025.ledger'),
+      '2025/01/01 x\n  Assets:Wallet  1 BITCOIN\n  Income\n',
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(dir, 'price-db_old.ledger'),
+      [
+        'commodity BITCOIN',
+        '\talias BTC',
+        '\tnomarket',
+        'P 2024/06/30 12:00:00 BTC 50000 USD',
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(dir, 'price-db.ledger'),
+      GENERATED_PRICE_DB,
+      'utf-8'
+    );
+    await push('gina');
+
+    // Relocation must SUCCEED (not roll back): the canonicalized price DB and
+    // the definitions no longer collide, so the verify-with-price-db passes.
+    expect(await service.relocateLegacyDefinitions('gina')).toBe('relocated');
+
+    const generated = await fs.readFile(
+      path.join(dir, 'generated-prices.ledger'),
+      'utf-8'
+    );
+    // The regenerated price references the canonical commodity, never the alias.
+    expect(generated).toMatch(/^P .* BITCOIN 50000 USD$/m);
+    expect(generated).not.toMatch(/\bBTC\b/);
+  });
+
+  it('repairs a price DB that quotes an aliased base currency', async () => {
+    // The real prod break: the journal declares `commodity $ / alias USD`, and
+    // the price DB quoted the base as `USD`. Loading `--price-db` auto-creates a
+    // commodity `USD`, then `alias USD` in the journal collides → pool.cc
+    // assertion on every read. repairUserPriceDb must regenerate the price DB
+    // quoting the canonical `$`, so it parses.
+    await ctx.insertUser('hank', 'hank', 'hank@example.com');
+    await new UserSettingRepository(ctx.db).upsertBaseCurrency('hank', 'USD');
+    await new JournalRepository(ctx.db).setMainFile('hank', 'ledger.ledger');
+    const dir = getJournalDir('hank');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'ledger.ledger'),
+      'include ./definitions.ledger\ninclude ./2025.ledger\n',
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(dir, 'definitions.ledger'),
+      [
+        'commodity KIRT',
+        '\talias Kirt',
+        '\tnomarket',
+        'commodity $',
+        '\tnote US Dollar',
+        '\talias USD',
+        '\tnomarket',
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(dir, '2025.ledger'),
+      '2025/01/01 x\n  Assets:Cash  1000 KIRT\n  Income\n',
+      'utf-8'
+    );
+    // A fetched price, stored quoting the base as the DB always does.
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'KIRT',
+        quote: 'USD',
+        price: 0.0056818184,
+        fetchedAt: new Date('2026-07-07T23:59:59Z'),
+        fetchedDate: '2026-07-07',
+      },
+    ]);
+    await push('hank');
+
+    expect(await service.repairUserPriceDb('hank')).toBe('repaired');
+
+    const generated = await fs.readFile(
+      path.join(dir, 'generated-prices.ledger'),
+      'utf-8'
+    );
+    // Quotes the canonical commodity, never the alias — otherwise it would not
+    // have parsed and repair would have returned 'failed'.
+    expect(generated).toMatch(/^P .* KIRT 0\.0056818184 \$$/m);
+    expect(generated).not.toMatch(/\bUSD\b/);
+  });
+
   it('skips a user with no dropped definitions', async () => {
     await ctx.insertUser('carol', 'carol', 'carol@example.com');
     await new UserSettingRepository(ctx.db).upsertBaseCurrency('carol', 'USD');

--- a/lib/prices/service-definitions.test.ts
+++ b/lib/prices/service-definitions.test.ts
@@ -358,6 +358,60 @@ describe('PriceService.relocateLegacyDefinitions', () => {
     expect(generated).not.toMatch(/\bUSD\b/);
   });
 
+  it('keeps a row whose canonical commodity is mixed-case when regenerating', async () => {
+    // Regression for the membership test in regenerateUserPriceDb. A stored row
+    // names the alias (`BTC`); the journal declares `commodity Bitcoin / alias
+    // BTC`, so canonical('BTC') = 'Bitcoin' — the journal's raw, mixed case.
+    // `userSymbols` comes from `ledger commodities`, which is upper-cased
+    // ('BITCOIN'). Without normalizing the canonical name before the lookup,
+    // `has('Bitcoin')` is false, the row is silently dropped, and Bitcoin gets
+    // no price line. Both the gina and hank cases use already-uppercase
+    // canonicals, so only this one exercises the normalize wrapper.
+    await ctx.insertUser('ivy', 'ivy', 'ivy@example.com');
+    await new UserSettingRepository(ctx.db).upsertBaseCurrency('ivy', 'USD');
+    await new JournalRepository(ctx.db).setMainFile('ivy', 'ledger.ledger');
+    const dir = getJournalDir('ivy');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'ledger.ledger'),
+      [
+        'commodity Bitcoin',
+        '\talias BTC',
+        '\tnomarket',
+        'include ./2025.ledger',
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(dir, '2025.ledger'),
+      '2025/01/01 x\n  Assets:Wallet  1 Bitcoin\n  Income\n',
+      'utf-8'
+    );
+    // A fetched row stored under the alias, quoting the base as the DB always does.
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'BTC',
+        quote: 'USD',
+        price: 50000,
+        fetchedAt: new Date('2026-07-07T23:59:59Z'),
+        fetchedDate: '2026-07-07',
+      },
+    ]);
+    await push('ivy');
+
+    await service.regenerateUserPriceDb('ivy');
+
+    const generated = await fs.readFile(
+      path.join(dir, 'generated-prices.ledger'),
+      'utf-8'
+    );
+    // The row survived the mixed-case membership test and renders under the
+    // canonical commodity, never the alias.
+    expect(generated).toMatch(/^P .* Bitcoin 50000 USD$/m);
+    expect(generated).not.toMatch(/\bBTC\b/);
+  });
+
   it('skips a user with no dropped definitions', async () => {
     await ctx.insertUser('carol', 'carol', 'carol@example.com');
     await new UserSettingRepository(ctx.db).upsertBaseCurrency('carol', 'USD');

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -140,8 +140,15 @@ export class PriceService {
       await this.listNormalizedSymbolsForUser(userId)
     );
     // Match on the canonical symbol: a stored alias-symbol row still belongs to
-    // a journal that only ever names the canonical commodity.
-    const fetched = all.filter((r) => userSymbols.has(canonical(r.symbol)));
+    // a journal that only ever names the canonical commodity. Normalize the
+    // canonical name before the membership test — `userSymbols` is upper-cased
+    // (listNormalizedSymbolsForUser), while canonical() preserves the journal's
+    // raw case, so a lower/mixed-case declaration (`commodity Bitcoin` / `alias
+    // BTC`) would otherwise never match and drop the row silently.
+    const fetched = all.filter((r) => {
+      const canonicalSymbol = normalizeCommoditySymbol(canonical(r.symbol));
+      return canonicalSymbol !== null && userSymbols.has(canonicalSymbol);
+    });
     const manual = await this.deps.manualRepo.listForUser(userId);
     const manualRows: CommodityPriceRow[] = manual.map((m) => ({
       symbol: m.symbol,

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -53,8 +53,12 @@ import {
   PRICE_DB_NAME,
   getJournalCacheTag,
 } from '@/lib/journal/layout';
+import { resolveIncludes } from '@/lib/journal/loader';
 import { withUserLock } from '@/lib/journal/mutex';
-import type { JournalRepository } from '@/lib/journal/repository';
+import type {
+  JournalLayout,
+  JournalRepository,
+} from '@/lib/journal/repository';
 import { verifyJournalParseable } from '@/lib/journal/verify';
 import { createLogger } from '@/lib/log';
 import { pull, push } from '@/lib/storage';
@@ -128,7 +132,7 @@ export class PriceService {
     // canonicalize at render, not at insert, so the base-currency quote stays
     // intact for listForQuote's filter above and cron-fetched rows are covered
     // too. See parseAliasMap and lib/journal/verify.ts.
-    const aliasMap = await this.readCommodityAliasMap(layout.dir);
+    const aliasMap = await this.readCommodityAliasMap(layout);
     const canonical = (symbol: string): string =>
       aliasMap.get(symbol) ?? symbol;
 
@@ -168,19 +172,44 @@ export class PriceService {
   }
 
   /**
-   * Alias→canonical-commodity map declared in the user's `definitions.ledger`
-   * (empty when there is none). This is where the relocation puts recovered
-   * `commodity`/`alias` declarations, so it is the authoritative source for
-   * canonicalizing generated prices. Aliases declared elsewhere in the journal
-   * are not consulted; move them into definitions.ledger if they must apply.
+   * Alias→canonical-commodity map for the whole journal (empty when it declares
+   * none). ledger honors `commodity`/`alias` blocks wherever they appear — a
+   * common layout declares `commodity $` / `alias USD` directly in the main
+   * journal, never in `definitions.ledger` — so consulting only the relocated
+   * definitions file would miss them and let a generated `P … USD` collide with
+   * the journal's `alias USD` (the pool.cc assertion this canonicalization
+   * exists to prevent). We therefore parse every file reachable from the main
+   * journal via its `include` directives, the same set ledger loads.
+   *
+   * `definitions.ledger` is read explicitly as well so the map still resolves if
+   * include-resolution fails (an include cycle or a missing include, which would
+   * make ledger itself fail to parse anyway). Later files win on a duplicate
+   * alias, but a genuine duplicate `alias` would abort ledger regardless.
    */
   private async readCommodityAliasMap(
-    dir: string
+    layout: JournalLayout
   ): Promise<Map<string, string>> {
-    const text = await this.deps.journalRepo
-      .readFile(path.join(dir, DEFINITIONS_NAME))
-      .catch(() => '');
-    return parseAliasMap(text);
+    const defsPath = path.join(layout.dir, DEFINITIONS_NAME);
+    const files = [defsPath];
+    try {
+      for (const file of await resolveIncludes(layout.mainPath)) {
+        // definitions.ledger is already first in the list; skip the duplicate.
+        if (path.resolve(file) !== path.resolve(defsPath)) files.push(file);
+      }
+    } catch {
+      // Include cycle or missing include — ledger would fail to parse too. Fall
+      // back to the definitions.ledger declarations collected above.
+    }
+
+    const map = new Map<string, string>();
+    for (const file of files) {
+      const text = await this.deps.journalRepo.readFile(file).catch(() => '');
+      if (!text) continue;
+      for (const [alias, commodity] of parseAliasMap(text)) {
+        map.set(alias, commodity);
+      }
+    }
+    return map;
   }
 
   /**

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -10,7 +10,11 @@ import {
 } from './bridgeViability';
 import { classifyCommodity } from './classify';
 import { getCoinSymbolMap } from './coingecko/coinCache';
-import { extractDefinitions, hasDefinitions } from './definitions';
+import {
+  extractDefinitions,
+  hasDefinitions,
+  parseAliasMap,
+} from './definitions';
 import {
   renderPriceDb,
   hasGeneratedBanner,
@@ -115,10 +119,25 @@ export class PriceService {
     const layout = await this.deps.journalRepo.ensureLayout(userId);
     const base = await this.resolveBaseCurrency(userId);
     const all = await this.deps.commodityRepo.listForQuote(base);
+
+    // Canonicalize every price symbol/quote through the aliases the journal
+    // declares. ledger auto-creates a commodity from a `P` line's symbol/quote,
+    // so a price that names an alias — quote `USD` when the journal declares
+    // `commodity $ / alias USD`, or symbol `BTC` aliased to `BITCOIN` — collides
+    // with the `alias` directive and aborts every read (pool.cc assertion). We
+    // canonicalize at render, not at insert, so the base-currency quote stays
+    // intact for listForQuote's filter above and cron-fetched rows are covered
+    // too. See parseAliasMap and lib/journal/verify.ts.
+    const aliasMap = await this.readCommodityAliasMap(layout.dir);
+    const canonical = (symbol: string): string =>
+      aliasMap.get(symbol) ?? symbol;
+
     const userSymbols = new Set(
       await this.listNormalizedSymbolsForUser(userId)
     );
-    const fetched = all.filter((r) => userSymbols.has(r.symbol));
+    // Match on the canonical symbol: a stored alias-symbol row still belongs to
+    // a journal that only ever names the canonical commodity.
+    const fetched = all.filter((r) => userSymbols.has(canonical(r.symbol)));
     const manual = await this.deps.manualRepo.listForUser(userId);
     const manualRows: CommodityPriceRow[] = manual.map((m) => ({
       symbol: m.symbol,
@@ -132,7 +151,12 @@ export class PriceService {
     const merged = [...fetched, ...manualRows].sort(
       (a, b) => a.fetchedAt.getTime() - b.fetchedAt.getTime()
     );
-    const body = renderPriceDb(merged);
+    const canonicalized = merged.map((r) => ({
+      ...r,
+      symbol: canonical(r.symbol),
+      quote: canonical(r.quote),
+    }));
+    const body = renderPriceDb(canonicalized);
     const target = path.join(layout.dir, GENERATED_PRICE_DB_NAME);
     await this.deps.journalRepo.writeFileAtomic(target, body);
     try {
@@ -141,6 +165,58 @@ export class PriceService {
       // revalidateTag throws outside a Next.js request context (cron, tests).
       // Acceptable — the cache invalidates on the next request.
     }
+  }
+
+  /**
+   * Alias→canonical-commodity map declared in the user's `definitions.ledger`
+   * (empty when there is none). This is where the relocation puts recovered
+   * `commodity`/`alias` declarations, so it is the authoritative source for
+   * canonicalizing generated prices. Aliases declared elsewhere in the journal
+   * are not consulted; move them into definitions.ledger if they must apply.
+   */
+  private async readCommodityAliasMap(
+    dir: string
+  ): Promise<Map<string, string>> {
+    const text = await this.deps.journalRepo
+      .readFile(path.join(dir, DEFINITIONS_NAME))
+      .catch(() => '');
+    return parseAliasMap(text);
+  }
+
+  /**
+   * Regenerate the user's price DB from the database and push it to canonical.
+   * Repairs a price DB written before render-time canonicalization existed —
+   * e.g. one that quoted an alias (`USD` for a journal declaring `alias USD`)
+   * and aborted every read with a pool.cc assertion. Idempotent; safe to call
+   * repeatedly.
+   *
+   * Takes the per-user lock, pulls fresh under it, regenerates, verifies the new
+   * layout parses WITH the price DB (the collision only surfaces when both are
+   * loaded), and pushes only on success. Runs in request context so an
+   * encryption-enabled user's DEK is available for the push; a locked or
+   * undecryptable journal bails before writing (`skipped`) so plaintext never
+   * overwrites ciphertext.
+   */
+  async repairUserPriceDb(
+    userId: string
+  ): Promise<'repaired' | 'skipped' | 'failed'> {
+    return withUserLock(userId, async () => {
+      try {
+        await pull(userId);
+      } catch {
+        return 'skipped';
+      }
+      const layout = await this.deps.journalRepo.ensureLayout(userId);
+      await this.regenerateUserPriceDb(userId);
+      const verify = await verifyJournalParseable(
+        layout.mainPath,
+        path.join(layout.dir, GENERATED_PRICE_DB_NAME)
+      );
+      // Never push a price DB that still can't be parsed alongside the journal.
+      if (!verify.ok) return 'failed';
+      await push(userId);
+      return 'repaired';
+    });
   }
 
   async addManualPrices(
@@ -288,7 +364,10 @@ export class PriceService {
       stdout = await runLedgerForUser(
         userId,
         ['commodities'],
-        this.deps.journalRepo
+        this.deps.journalRepo,
+        {
+          includePriceDb: false,
+        }
       );
     } catch {
       return [];
@@ -346,7 +425,10 @@ export class PriceService {
       stdout = await runLedgerForUser(
         userId,
         ['commodities'],
-        this.deps.journalRepo
+        this.deps.journalRepo,
+        {
+          includePriceDb: false,
+        }
       );
     } catch {
       return [];
@@ -719,6 +801,10 @@ export class PriceService {
         .catch(() => null);
 
       // Preserve any prices the legacy file still carried (idempotent upsert).
+      // Rows are stored verbatim; the alias→commodity canonicalization that keeps
+      // the generated price DB parseable happens at render time in
+      // regenerateUserPriceDb (so it also covers rows the cron fetcher adds, and
+      // so the base-currency quote stays intact for listForQuote's filter).
       const rows = parseLegacyPriceDb(source);
       if (rows.length > 0) await this.deps.commodityRepo.insert(rows);
 
@@ -730,6 +816,7 @@ export class PriceService {
         existingDefs !== null && existingDefs.trim()
           ? `${existingDefs.replace(/\n+$/, '')}\n\n${relocated}\n`
           : `${DEFINITIONS_BANNER}\n${relocated}\n`;
+
       await this.deps.journalRepo.writeFileAtomic(defsPath, body);
       await this.prependInclude(layout.mainPath, defsPath);
 
@@ -738,8 +825,13 @@ export class PriceService {
       await this.regenerateUserPriceDb(userId);
 
       // Verify the NEW layout parses BEFORE deleting the legacy files, so a
-      // failure is fully reversible.
-      const verify = await verifyJournalParseable(layout.mainPath);
+      // failure is fully reversible. Load the generated price DB too, mirroring
+      // the real read path: a commodity/alias collision between definitions and
+      // the price DB only surfaces when both are parsed together.
+      const verify = await verifyJournalParseable(
+        layout.mainPath,
+        path.join(layout.dir, GENERATED_PRICE_DB_NAME)
+      );
       if (!verify.ok) {
         if (existingDefs === null) {
           await fs.rm(defsPath, { force: true });

--- a/utils/runLedgerForUser.ts
+++ b/utils/runLedgerForUser.ts
@@ -14,16 +14,33 @@ const execFilePromise = promisify(execFile);
  * No caching — callers should be infrequent (daily cron). Pass `--sort -date`
  * yourself if needed.
  *
- * An optional `repo` may be injected for testing.
+ * An optional `repo` may be injected for testing. Set `includePriceDb: false`
+ * for commands that don't read prices (e.g. `commodities`): a malformed price
+ * DB would otherwise abort the parse, and listing held commodities must stay
+ * usable precisely so a broken price DB can be regenerated from it.
  */
 export const runLedgerForUser = async (
   userId: string,
   args: string[],
-  repo: JournalRepository = journalRepository
+  repo: JournalRepository = journalRepository,
+  { includePriceDb = true }: { includePriceDb?: boolean } = {}
 ): Promise<string> => {
   const { mainPath, priceDbPath } = await repo.ensureLayout(userId);
-  const baseArgs: string[] = ['--file', mainPath];
-  if (priceDbPath) baseArgs.push('--price-db', priceDbPath);
-  const { stdout } = await execFilePromise('ledger', [...baseArgs, ...args]);
+  // Run hermetically: ignore any `~/.ledgerrc` (--init-file /dev/null) and the
+  // ambient LEDGER_* env. A stray LEDGER_PRICE_DB would otherwise be loaded on
+  // top of the journal — declaring commodities that collide with the journal's
+  // own and aborting an otherwise valid parse (e.g. when `includePriceDb` is
+  // false precisely to avoid a broken price DB). Mirrors lib/journal/verify.ts.
+  const {
+    LEDGER_PRICE_DB: _priceDb,
+    LEDGER_FILE: _file,
+    LEDGER_INIT: _init,
+    ...env
+  } = process.env;
+  const baseArgs: string[] = ['--init-file', '/dev/null', '--file', mainPath];
+  if (priceDbPath && includePriceDb) baseArgs.push('--price-db', priceDbPath);
+  const { stdout } = await execFilePromise('ledger', [...baseArgs, ...args], {
+    env,
+  });
   return stdout;
 };


### PR DESCRIPTION
## Summary

The definition-relocation feature (#77) could leave a journal that `verifyJournalParseable` accepted but the dashboard couldn't read, returning a 500 with a ledger `pool.cc:110` assertion. This branch makes the relocated layout valid under the actual read path.

## The bug

ledger parses `--price-db` **before** the main journal and auto-creates a commodity from each `P` line's symbol/quote. When the generated price DB named a commodity the journal also **aliases**, the later `alias` directive collided with that auto-created commodity and aborted every read:

- base currency: price quotes `USD` while the journal declares `commodity $` / `alias USD`
- symbol alias: price symbol `BTC` while the journal declares `commodity BITCOIN` / `alias BTC`

It only surfaced with the price DB loaded. `verifyJournalParseable` ran `ledger stats` **without** `--price-db`, so it never reproduced the collision and pushed the broken layout.

## Changes

- **Canonicalize generated prices** — `regenerateUserPriceDb` maps every price symbol/quote through the aliases declared in `definitions.ledger` (new `parseAliasMap`), at render time, so the price DB always names the canonical commodity. Covers both cron-fetched and relocated rows; the base-currency quote stays intact for `listForQuote`'s filter.
- **Verify like the read path** — `verifyJournalParseable(mainPath, priceDbPath?)` loads the price DB, so a definitions/price-db collision fails the verify before any push.
- **Hermetic ledger invocation** — `runLedgerForUser` now passes `--init-file /dev/null` and strips ambient `LEDGER_*`; adds an `includePriceDb` option so commodity listing skips the price DB (a broken one can no longer zero the symbol set during a repair).
- **Repair vehicle** — `repairUserPriceDb` + `POST /api/maintenance/repair-price-db` regenerate, verify, and push a corrected price DB for the caller, encrypting with the session DEK. Repairs journals written before this fix (idempotent).
- Earlier commits on the branch: relocated `format` directives made journal-valid, and a commodity-block comment correction.

## Repair for an already-broken journal

After deploy, the affected user (authenticated) hits `POST /api/maintenance/repair-price-db` once → `{result:"repaired"}`. Works for encryption-enabled accounts because it runs in the user's session.

## Tests

- `parseAliasMap` unit coverage (indented block aliases, quoting, account-alias/block-close exclusion).
- Relocation with a symbol-alias legacy price (`BTC`→`BITCOIN`).
- The base-currency-alias case (`USD`→`$`) end-to-end via `repairUserPriceDb`.
- Full suite green (975 tests).