### PR TITLE
feat(entry): add extra items to guided transaction forms

### DIFF
--- a/docs/superpowers/plans/2026-07-09-extra-items-guided-forms.md
+++ b/docs/superpowers/plans/2026-07-09-extra-items-guided-forms.md
@@ -1,0 +1,1656 @@
+# Extra Items in Guided Transaction Forms — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user append an arbitrary number of extra postings (fees, tips, shipping, deductions) inside the Expense, Income, Transfer, and Exchange guided type forms.
+
+**Architecture:** Each affected adapter gains an `extraItems: ExtraItem[]` field. A shared helper (`extraItems.ts`) turns those rows into postings and computes the per-currency balancing postings for the form's absorbing account. `compile` appends the extras; `detect` recovers them by partitioning postings by account role. A shared `ExtraItemsField` component renders the dynamic row list in all four forms.
+
+**Tech Stack:** TypeScript, React (client components), Vitest, `renderToStaticMarkup` for component tests, existing `Combobox` / `AmountInput` / `CurrencyCombobox` widgets.
+
+## Global Constraints
+
+- Spell identifiers out in full — no abbreviations (project naming rule). Use `extraItems`, not `extras` in public field/type names (local variables named `extras` are acceptable).
+- Never mention AI tooling in code, comments, commits.
+- `MAX_POSTINGS = 50`, `MIN_POSTINGS = 2` (from `lib/transactions/schema.ts`) — the total posting count stays bounded by 50.
+- **Regression guarantee:** when `extraItems` is empty, every adapter's `compile` MUST produce byte-identical postings to today (same strings, same order). This is enforced by keeping the existing two-posting code path for the empty case.
+- FixBalance form is out of scope — do not touch `fixBalance.ts` or `FixBalanceForm.tsx`.
+- Computed absorbing postings use normalized numeric formatting (trailing zeros trimmed). Base and extra-item postings preserve the user's raw amount strings verbatim.
+
+---
+
+### Task 1: Shared extra-items helper
+
+**Files:**
+- Create: `features/transactions/entry/types/extraItems.ts`
+- Test: `features/transactions/entry/types/extraItems.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type ExtraItem = { account: string; amount: string; currency: string }`
+  - `formatAmount(n: number): string`
+  - `residualByCurrency(postings: readonly Posting[]): Map<string, number>`
+  - `balancingPostings(account: string, others: readonly Posting[]): Posting[]`
+  - `extraItemPostings(items: readonly ExtraItem[]): Posting[]`
+  - `toExtraItems(postings: readonly Posting[]): ExtraItem[]`
+  - `singleAccount(postings: readonly Posting[]): string | null`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// features/transactions/entry/types/extraItems.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  formatAmount,
+  residualByCurrency,
+  balancingPostings,
+  extraItemPostings,
+  toExtraItems,
+  singleAccount,
+} from './extraItems';
+
+describe('formatAmount', () => {
+  it('trims float noise and negative zero', () => {
+    expect(formatAmount(120)).toBe('120');
+    expect(formatAmount(-42.5)).toBe('-42.5');
+    expect(formatAmount(0.1 + 0.2)).toBe('0.3');
+    expect(formatAmount(-0)).toBe('0');
+  });
+});
+
+describe('residualByCurrency', () => {
+  it('sums plain postings per currency in first-seen order', () => {
+    const net = residualByCurrency([
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+    ]);
+    expect([...net]).toEqual([
+      ['USD', 120],
+      ['EUR', 2],
+    ]);
+  });
+
+  it('honors @@ cost annotations', () => {
+    const net = residualByCurrency([
+      {
+        account: 'Assets:BTC',
+        amount: '1',
+        currency: 'BTC',
+        cost: { amount: '100', currency: 'USD' },
+      },
+    ]);
+    expect(net.get('USD')).toBe(100);
+    expect(net.has('BTC')).toBe(false);
+  });
+});
+
+describe('balancingPostings', () => {
+  it('emits one negated posting per nonzero currency', () => {
+    const out = balancingPostings('Assets:Checking', [
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+    ]);
+    expect(out).toEqual([
+      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+    ]);
+  });
+
+  it('drops currencies that already net to zero', () => {
+    const out = balancingPostings('Assets:Checking', [
+      { account: 'A', amount: '5', currency: 'USD' },
+      { account: 'B', amount: '-5', currency: 'USD' },
+    ]);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('extraItemPostings', () => {
+  it('maps rows to postings and drops fully-blank rows', () => {
+    expect(
+      extraItemPostings([
+        { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+        { account: '', amount: '', currency: 'USD' },
+      ])
+    ).toEqual([{ account: 'Expenses:Tips', amount: '20', currency: 'USD' }]);
+  });
+});
+
+describe('toExtraItems', () => {
+  it('projects postings to plain item rows', () => {
+    expect(
+      toExtraItems([
+        { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      ])
+    ).toEqual([{ account: 'Expenses:Tips', amount: '20', currency: 'USD' }]);
+  });
+});
+
+describe('singleAccount', () => {
+  it('returns the account when all postings share one', () => {
+    expect(
+      singleAccount([
+        { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+      ])
+    ).toBe('Assets:Checking');
+  });
+  it('returns null for zero or multiple distinct accounts', () => {
+    expect(singleAccount([])).toBeNull();
+    expect(
+      singleAccount([
+        { account: 'Assets:A', amount: '1', currency: 'USD' },
+        { account: 'Assets:B', amount: '-1', currency: 'USD' },
+      ])
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/extraItems.test.ts`
+Expected: FAIL — cannot resolve `./extraItems`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// features/transactions/entry/types/extraItems.ts
+import type { Posting } from '@/lib/transactions/posting';
+
+export type ExtraItem = { account: string; amount: string; currency: string };
+
+/** Format a computed numeric amount to a compact string (trailing zeros trimmed, no -0). */
+export const formatAmount = (n: number): string => {
+  if (!Number.isFinite(n)) return '0';
+  const fixed = Number(n.toFixed(10));
+  return (Object.is(fixed, -0) ? 0 : fixed).toString();
+};
+
+/**
+ * Net amount per currency across postings, honoring `@@` cost annotations
+ * (a cost-bearing posting contributes its signed cost to the cost currency,
+ * exactly like {@link computeBalance}). Insertion order = first-seen currency.
+ */
+export const residualByCurrency = (
+  postings: readonly Posting[]
+): Map<string, number> => {
+  const net = new Map<string, number>();
+  for (const posting of postings) {
+    if (posting.cost) {
+      const amount = Number(posting.amount);
+      const cost = Number(posting.cost.amount);
+      if (!Number.isFinite(amount) || !Number.isFinite(cost)) continue;
+      const sign = amount < 0 ? -1 : 1;
+      net.set(
+        posting.cost.currency,
+        (net.get(posting.cost.currency) ?? 0) + sign * cost
+      );
+    } else {
+      const value = Number(posting.amount);
+      if (!Number.isFinite(value)) continue;
+      net.set(posting.currency, (net.get(posting.currency) ?? 0) + value);
+    }
+  }
+  return net;
+};
+
+/** Postings for `account` that zero the residual of `others`, one per nonzero currency. */
+export const balancingPostings = (
+  account: string,
+  others: readonly Posting[]
+): Posting[] => {
+  const net = residualByCurrency(others);
+  const out: Posting[] = [];
+  for (const [currency, total] of net) {
+    if (Math.abs(total) <= 1e-9) continue;
+    out.push({ account, amount: formatAmount(-total), currency });
+  }
+  return out;
+};
+
+/** Map extra-item rows to postings, dropping fully-blank rows. */
+export const extraItemPostings = (items: readonly ExtraItem[]): Posting[] =>
+  items
+    .filter((item) => item.account.trim() !== '' || item.amount.trim() !== '')
+    .map((item) => ({
+      account: item.account,
+      amount: item.amount,
+      currency: item.currency,
+    }));
+
+/** Project postings back to plain extra-item rows. */
+export const toExtraItems = (postings: readonly Posting[]): ExtraItem[] =>
+  postings.map((posting) => ({
+    account: posting.account,
+    amount: posting.amount,
+    currency: posting.currency,
+  }));
+
+/** The one account shared by every posting, or null if none / more than one. */
+export const singleAccount = (postings: readonly Posting[]): string | null => {
+  const accounts = new Set(postings.map((posting) => posting.account));
+  if (accounts.size !== 1) return null;
+  return [...accounts][0] ?? null;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/extraItems.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/types/extraItems.ts features/transactions/entry/types/extraItems.test.ts
+git commit -m "feat(entry): add extra-items posting helpers"
+```
+
+---
+
+### Task 2: Expense adapter extra items
+
+**Files:**
+- Modify: `features/transactions/entry/types/expense.ts`
+- Test: `features/transactions/entry/types/expense.test.ts` (update + extend)
+
+**Interfaces:**
+- Consumes: `ExtraItem`, `extraItemPostings`, `balancingPostings`, `toExtraItems`, `singleAccount` from Task 1; `computeBalance` from `@/lib/transactions/balance`.
+- Produces: `ExpenseFields` now includes `extraItems: ExtraItem[]`.
+
+- [ ] **Step 1: Update existing tests to expect `extraItems` and add extras coverage**
+
+Replace the whole body of `features/transactions/entry/types/expense.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { expenseAdapter, type ExpenseFields } from './expense';
+import { Transaction } from '@/lib/transactions/model';
+
+const ctx = { defaultCurrency: 'USD' };
+const header = {
+  date: '2026-06-29',
+  payee: 'Whole Foods',
+  status: 'none' as const,
+  note: '',
+};
+
+describe('expenseAdapter.compile', () => {
+  it('builds a +expense / -asset pair with no extras', () => {
+    const draft = expenseAdapter.compile(
+      {
+        ...header,
+        amount: '42.50',
+        currency: 'USD',
+        paidFrom: 'Assets:Checking',
+        spentOn: 'Expenses:Groceries',
+        extraItems: [],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+    ]);
+    expect(draft.payee).toBe('Whole Foods');
+  });
+
+  it('appends extra items and folds them into the paying posting', () => {
+    const draft = expenseAdapter.compile(
+      {
+        ...header,
+        amount: '100',
+        currency: 'USD',
+        paidFrom: 'Assets:Checking',
+        spentOn: 'Expenses:Dining',
+        extraItems: [
+          { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+          { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+    ]);
+  });
+});
+
+describe('expenseAdapter.detect', () => {
+  const clean = Transaction.of('2026-06-29', 'Whole Foods', 'none', '', [
+    { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+    { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+  ]);
+
+  it('recognizes a clean asset->expense pair with empty extras', () => {
+    expect(expenseAdapter.detect(clean)).toEqual({
+      date: '2026-06-29',
+      payee: 'Whole Foods',
+      status: 'none',
+      note: '',
+      uid: undefined,
+      amount: '42.50',
+      currency: 'USD',
+      paidFrom: 'Assets:Checking',
+      spentOn: 'Expenses:Groceries',
+      extraItems: [],
+    });
+  });
+
+  it('recovers extra items from a 3-posting split', () => {
+    const draft = Transaction.of('2026-06-29', 'Whole Foods', 'none', '', [
+      { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+      { account: 'Expenses:Tax', amount: '3', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-45.50', currency: 'USD' },
+    ]);
+    expect(expenseAdapter.detect(draft)).toMatchObject({
+      amount: '42.50',
+      paidFrom: 'Assets:Checking',
+      spentOn: 'Expenses:Groceries',
+      extraItems: [{ account: 'Expenses:Tax', amount: '3', currency: 'USD' }],
+    });
+  });
+
+  it('round-trips compile -> detect with extras', () => {
+    const fields: ExpenseFields = {
+      ...header,
+      uid: undefined,
+      amount: '100',
+      currency: 'USD',
+      paidFrom: 'Assets:Cash',
+      spentOn: 'Expenses:Coffee',
+      extraItems: [{ account: 'Expenses:Tips', amount: '5', currency: 'USD' }],
+    };
+    expect(expenseAdapter.detect(expenseAdapter.compile(fields, ctx))).toEqual(
+      fields
+    );
+  });
+
+  it('rejects two distinct paying accounts', () => {
+    expect(
+      expenseAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-20', currency: 'USD' },
+          { account: 'Assets:Cash', amount: '-22.50', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it('rejects an unbalanced draft', () => {
+    expect(
+      expenseAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-40', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it('rejects a cost-bearing posting', () => {
+    expect(
+      expenseAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          {
+            account: 'Expenses:Groceries',
+            amount: '42.50',
+            currency: 'USD',
+            cost: { amount: '1', currency: 'EUR' },
+          },
+          { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it('rejects an asset->asset transfer (no expense posting)', () => {
+    expect(
+      expenseAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/expense.test.ts`
+Expected: FAIL — `extraItems` missing from type / compile ignores extras.
+
+- [ ] **Step 3: Rewrite the adapter**
+
+Replace the whole body of `features/transactions/entry/types/expense.ts` with:
+
+```ts
+import type { DraftState } from '../draftReducer';
+import { classifyAccount } from './accountRole';
+import {
+  type HeaderFields,
+  type TransactionTypeAdapter,
+  type TypeContext,
+  headerOf,
+} from './adapter';
+import { absAmount, negateAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
+import { Transaction } from '@/lib/transactions/model';
+
+export type ExpenseFields = HeaderFields & {
+  amount: string;
+  currency: string;
+  paidFrom: string;
+  spentOn: string;
+  extraItems: ExtraItem[];
+};
+
+export const expenseAdapter: TransactionTypeAdapter<ExpenseFields> = {
+  id: 'expense',
+  label: 'Expense',
+  icon: '🛒',
+  emptyFields: (ctx: TypeContext): ExpenseFields => ({
+    date: '',
+    payee: '',
+    status: 'none',
+    note: '',
+    amount: '',
+    currency: ctx.defaultCurrency,
+    paidFrom: '',
+    spentOn: '',
+    extraItems: [],
+  }),
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const base = { account: f.spentOn, amount: f.amount, currency: f.currency };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        base,
+        {
+          account: f.paidFrom,
+          amount: negateAmount(f.amount),
+          currency: f.currency,
+        },
+      ]);
+    }
+    const items = [base, ...extras];
+    return Transaction.fromHeader(header, [
+      ...items,
+      ...balancingPostings(f.paidFrom, items),
+    ]);
+  },
+  detect: (draft): ExpenseFields | null => {
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.cost || p.assertion)) return null;
+    const expensePostings = postings.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    const payingPostings = postings.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    if (expensePostings.length + payingPostings.length !== postings.length)
+      return null;
+    if (expensePostings.length < 1 || payingPostings.length < 1) return null;
+    const paidFrom = singleAccount(payingPostings);
+    if (!paidFrom) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    const base = expensePostings[0];
+    if (base.amount === '' || !(Number(base.amount) > 0)) return null;
+    return {
+      ...headerOf(draft),
+      amount: absAmount(base.amount),
+      currency: base.currency,
+      paidFrom,
+      spentOn: base.account,
+      extraItems: toExtraItems(expensePostings.slice(1)),
+    };
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/expense.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/types/expense.ts features/transactions/entry/types/expense.test.ts
+git commit -m "feat(entry): support extra items in the expense adapter"
+```
+
+---
+
+### Task 3: Income adapter extra items
+
+**Files:**
+- Modify: `features/transactions/entry/types/income.ts`
+- Test: `features/transactions/entry/types/income.test.ts` (update + extend)
+
+**Interfaces:**
+- Consumes: Task 1 helpers, `computeBalance`.
+- Produces: `IncomeFields` now includes `extraItems: ExtraItem[]`. Absorbing account is `receivedInto`; the income source posting (`from`, negative) is the base.
+
+- [ ] **Step 1: Update tests**
+
+Replace the whole body of `features/transactions/entry/types/income.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { incomeAdapter, type IncomeFields } from './income';
+import { Transaction } from '@/lib/transactions/model';
+
+const ctx = { defaultCurrency: 'USD' };
+const header = {
+  date: '2026-06-29',
+  payee: 'Employer',
+  status: 'none' as const,
+  note: '',
+};
+
+describe('incomeAdapter.compile', () => {
+  it('builds a +asset / -income pair with no extras', () => {
+    const draft = incomeAdapter.compile(
+      {
+        ...header,
+        amount: '1000',
+        currency: 'USD',
+        receivedInto: 'Assets:Checking',
+        from: 'Income:Salary',
+        extraItems: [],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Assets:Checking', amount: '1000', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+    ]);
+  });
+
+  it('subtracts fee extras from the net received', () => {
+    const draft = incomeAdapter.compile(
+      {
+        ...header,
+        amount: '1000',
+        currency: 'USD',
+        receivedInto: 'Assets:Checking',
+        from: 'Income:Salary',
+        extraItems: [
+          { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Assets:Checking', amount: '970', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
+    ]);
+  });
+});
+
+describe('incomeAdapter.detect', () => {
+  it('recognizes a clean income pair with empty extras', () => {
+    const draft = Transaction.of('2026-06-29', 'Employer', 'none', '', [
+      { account: 'Assets:Checking', amount: '1000', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+    ]);
+    expect(incomeAdapter.detect(draft)).toEqual({
+      date: '2026-06-29',
+      payee: 'Employer',
+      status: 'none',
+      note: '',
+      uid: undefined,
+      amount: '1000',
+      currency: 'USD',
+      receivedInto: 'Assets:Checking',
+      from: 'Income:Salary',
+      extraItems: [],
+    });
+  });
+
+  it('round-trips compile -> detect with extras', () => {
+    const fields: IncomeFields = {
+      ...header,
+      uid: undefined,
+      amount: '1000',
+      currency: 'USD',
+      receivedInto: 'Assets:Checking',
+      from: 'Income:Salary',
+      extraItems: [
+        { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
+      ],
+    };
+    expect(incomeAdapter.detect(incomeAdapter.compile(fields, ctx))).toEqual(
+      fields
+    );
+  });
+
+  it('rejects a draft with two income sources', () => {
+    expect(
+      incomeAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Assets:Checking', amount: '1000', currency: 'USD' },
+          { account: 'Income:Salary', amount: '-600', currency: 'USD' },
+          { account: 'Income:Bonus', amount: '-400', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/income.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite the adapter**
+
+Replace the whole body of `features/transactions/entry/types/income.ts` with:
+
+```ts
+import type { DraftState } from '../draftReducer';
+import { classifyAccount } from './accountRole';
+import {
+  type HeaderFields,
+  type TransactionTypeAdapter,
+  type TypeContext,
+  headerOf,
+} from './adapter';
+import { absAmount, negateAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
+import { Transaction } from '@/lib/transactions/model';
+
+export type IncomeFields = HeaderFields & {
+  amount: string;
+  currency: string;
+  receivedInto: string;
+  from: string;
+  extraItems: ExtraItem[];
+};
+
+export const incomeAdapter: TransactionTypeAdapter<IncomeFields> = {
+  id: 'income',
+  label: 'Income',
+  icon: '💰',
+  emptyFields: (ctx: TypeContext): IncomeFields => ({
+    date: '',
+    payee: '',
+    status: 'none',
+    note: '',
+    amount: '',
+    currency: ctx.defaultCurrency,
+    receivedInto: '',
+    from: '',
+    extraItems: [],
+  }),
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const source = {
+      account: f.from,
+      amount: negateAmount(f.amount),
+      currency: f.currency,
+    };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        { account: f.receivedInto, amount: f.amount, currency: f.currency },
+        source,
+      ]);
+    }
+    const items = [source, ...extras];
+    return Transaction.fromHeader(header, [
+      ...balancingPostings(f.receivedInto, items),
+      ...items,
+    ]);
+  },
+  detect: (draft): IncomeFields | null => {
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.cost || p.assertion)) return null;
+    const incomePostings = postings.filter(
+      (p) => classifyAccount(p.account) === 'income'
+    );
+    const assetPostings = postings.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    const expensePostings = postings.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    if (
+      incomePostings.length + assetPostings.length + expensePostings.length !==
+      postings.length
+    )
+      return null;
+    if (incomePostings.length !== 1 || assetPostings.length < 1) return null;
+    const receivedInto = singleAccount(assetPostings);
+    if (!receivedInto) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    const base = incomePostings[0];
+    if (base.amount === '' || !(Number(base.amount) < 0)) return null;
+    return {
+      ...headerOf(draft),
+      amount: absAmount(base.amount),
+      currency: base.currency,
+      receivedInto,
+      from: base.account,
+      extraItems: toExtraItems(expensePostings),
+    };
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/income.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/types/income.ts features/transactions/entry/types/income.test.ts
+git commit -m "feat(entry): support extra items in the income adapter"
+```
+
+---
+
+### Task 4: Transfer adapter extra items
+
+**Files:**
+- Modify: `features/transactions/entry/types/transfer.ts`
+- Test: `features/transactions/entry/types/transfer.test.ts` (update + extend)
+
+**Interfaces:**
+- Consumes: Task 1 helpers, `computeBalance`.
+- Produces: `TransferFields` now includes `extraItems: ExtraItem[]`. Destination `to` (positive asset) is the base; `from` absorbs. Extra items are expense-role postings.
+
+- [ ] **Step 1: Update tests**
+
+Replace the whole body of `features/transactions/entry/types/transfer.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { transferAdapter, type TransferFields } from './transfer';
+import { Transaction } from '@/lib/transactions/model';
+
+const ctx = { defaultCurrency: 'USD' };
+const header = {
+  date: '2026-06-29',
+  payee: 'Transfer',
+  status: 'none' as const,
+  note: '',
+};
+
+describe('transferAdapter.compile', () => {
+  it('builds a to/from pair with no extras', () => {
+    const draft = transferAdapter.compile(
+      {
+        ...header,
+        amount: '500',
+        currency: 'USD',
+        from: 'Assets:Checking',
+        to: 'Assets:Savings',
+        extraItems: [],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
+    ]);
+  });
+
+  it('adds a transfer fee to the source outflow', () => {
+    const draft = transferAdapter.compile(
+      {
+        ...header,
+        amount: '500',
+        currency: 'USD',
+        from: 'Assets:Checking',
+        to: 'Assets:Savings',
+        extraItems: [
+          { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-515', currency: 'USD' },
+    ]);
+  });
+});
+
+describe('transferAdapter.detect', () => {
+  it('recognizes a clean transfer with empty extras', () => {
+    const draft = Transaction.of('2026-06-29', 'Transfer', 'none', '', [
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
+    ]);
+    expect(transferAdapter.detect(draft)).toEqual({
+      date: '2026-06-29',
+      payee: 'Transfer',
+      status: 'none',
+      note: '',
+      uid: undefined,
+      amount: '500',
+      currency: 'USD',
+      from: 'Assets:Checking',
+      to: 'Assets:Savings',
+      extraItems: [],
+    });
+  });
+
+  it('round-trips compile -> detect with a fee', () => {
+    const fields: TransferFields = {
+      ...header,
+      uid: undefined,
+      amount: '500',
+      currency: 'USD',
+      from: 'Assets:Checking',
+      to: 'Assets:Savings',
+      extraItems: [
+        { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+      ],
+    };
+    expect(transferAdapter.detect(transferAdapter.compile(fields, ctx))).toEqual(
+      fields
+    );
+  });
+
+  it('rejects two positive destinations', () => {
+    expect(
+      transferAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Assets:Savings', amount: '300', currency: 'USD' },
+          { account: 'Assets:Brokerage', amount: '200', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/transfer.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite the adapter**
+
+Replace the whole body of `features/transactions/entry/types/transfer.ts` with:
+
+```ts
+import type { DraftState } from '../draftReducer';
+import { classifyAccount } from './accountRole';
+import {
+  type HeaderFields,
+  type TransactionTypeAdapter,
+  type TypeContext,
+  headerOf,
+} from './adapter';
+import { absAmount, negateAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
+import { Transaction } from '@/lib/transactions/model';
+
+export type TransferFields = HeaderFields & {
+  amount: string;
+  currency: string;
+  from: string;
+  to: string;
+  extraItems: ExtraItem[];
+};
+
+export const transferAdapter: TransactionTypeAdapter<TransferFields> = {
+  id: 'transfer',
+  label: 'Transfer',
+  icon: '🔁',
+  emptyFields: (ctx: TypeContext): TransferFields => ({
+    date: '',
+    payee: 'Transfer',
+    status: 'none',
+    note: '',
+    amount: '',
+    currency: ctx.defaultCurrency,
+    from: '',
+    to: '',
+    extraItems: [],
+  }),
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const to = { account: f.to, amount: f.amount, currency: f.currency };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        to,
+        {
+          account: f.from,
+          amount: negateAmount(f.amount),
+          currency: f.currency,
+        },
+      ]);
+    }
+    const items = [to, ...extras];
+    return Transaction.fromHeader(header, [
+      ...items,
+      ...balancingPostings(f.from, items),
+    ]);
+  },
+  detect: (draft): TransferFields | null => {
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.cost || p.assertion)) return null;
+    const assetPostings = postings.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    const expensePostings = postings.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    if (assetPostings.length + expensePostings.length !== postings.length)
+      return null;
+    if (assetPostings.length < 2) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    const positives = assetPostings.filter((p) => Number(p.amount) > 0);
+    const negatives = assetPostings.filter((p) => Number(p.amount) < 0);
+    if (positives.length !== 1) return null;
+    const to = positives[0];
+    const from = singleAccount(negatives);
+    if (!from || from === to.account) return null;
+    return {
+      ...headerOf(draft),
+      amount: absAmount(to.amount),
+      currency: to.currency,
+      from,
+      to: to.account,
+      extraItems: toExtraItems(expensePostings),
+    };
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/transfer.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/types/transfer.ts features/transactions/entry/types/transfer.test.ts
+git commit -m "feat(entry): support extra items in the transfer adapter"
+```
+
+---
+
+### Task 5: Exchange adapter extra items
+
+**Files:**
+- Modify: `features/transactions/entry/types/exchange.ts`
+- Test: `features/transactions/entry/types/exchange.test.ts` (update + extend)
+
+**Interfaces:**
+- Consumes: Task 1 helpers, `computeBalance`.
+- Produces: `ExchangeFields` now includes `extraItems: ExtraItem[]`. The cost-bearing `got` posting is the base; `gaveFrom` absorbs (per currency). Extra items are expense-role postings (broker fee, etc.).
+
+- [ ] **Step 1: Read the current test to preserve its non-extras cases**
+
+Run: `cat features/transactions/entry/types/exchange.test.ts`
+
+Keep every existing case, adding `extraItems: []` to each expected `detect` result and each `compile` input's fields. Then append the two new cases below.
+
+New `compile` case:
+
+```ts
+it('routes a broker fee through the paying account', () => {
+  const draft = exchangeAdapter.compile(
+    {
+      ...header,
+      gaveAmount: '100',
+      gaveCurrency: 'USD',
+      gaveFrom: 'Assets:Bank',
+      gotAmount: '1',
+      gotCurrency: 'BTC',
+      gotInto: 'Assets:BTC',
+      extraItems: [
+        { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+      ],
+    },
+    ctx
+  );
+  expect(draft.postings).toEqual([
+    {
+      account: 'Assets:BTC',
+      amount: '1',
+      currency: 'BTC',
+      cost: { amount: '100', currency: 'USD' },
+    },
+    { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+    { account: 'Assets:Bank', amount: '-102', currency: 'USD' },
+  ]);
+});
+```
+
+New round-trip case:
+
+```ts
+it('round-trips compile -> detect with a broker fee', () => {
+  const fields: ExchangeFields = {
+    ...header,
+    uid: undefined,
+    gaveAmount: '100',
+    gaveCurrency: 'USD',
+    gaveFrom: 'Assets:Bank',
+    gotAmount: '1',
+    gotCurrency: 'BTC',
+    gotInto: 'Assets:BTC',
+    extraItems: [
+      { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+    ],
+  };
+  expect(exchangeAdapter.detect(exchangeAdapter.compile(fields, ctx))).toEqual(
+    fields
+  );
+});
+```
+
+Ensure the test file imports `type ExchangeFields`:
+
+```ts
+import { exchangeAdapter, type ExchangeFields } from './exchange';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/exchange.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite the adapter**
+
+Replace the whole body of `features/transactions/entry/types/exchange.ts` with:
+
+```ts
+// features/transactions/entry/types/exchange.ts
+import type { DraftState } from '../draftReducer';
+import { classifyAccount } from './accountRole';
+import {
+  type HeaderFields,
+  type TransactionTypeAdapter,
+  type TypeContext,
+  headerOf,
+} from './adapter';
+import { absAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
+import { Transaction } from '@/lib/transactions/model';
+
+export type ExchangeFields = HeaderFields & {
+  gaveAmount: string;
+  gaveCurrency: string;
+  gaveFrom: string;
+  gotAmount: string;
+  gotCurrency: string;
+  gotInto: string;
+  extraItems: ExtraItem[];
+};
+
+export const exchangeAdapter: TransactionTypeAdapter<ExchangeFields> = {
+  id: 'exchange',
+  label: 'Exchange',
+  icon: '💱',
+  emptyFields: (ctx: TypeContext): ExchangeFields => ({
+    date: '',
+    payee: 'Currency exchange',
+    status: 'none',
+    note: '',
+    gaveAmount: '',
+    gaveCurrency: ctx.defaultCurrency,
+    gaveFrom: '',
+    gotAmount: '',
+    gotCurrency: '',
+    gotInto: '',
+    extraItems: [],
+  }),
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const got = {
+      account: f.gotInto,
+      amount: f.gotAmount,
+      currency: f.gotCurrency,
+      cost: { amount: f.gaveAmount, currency: f.gaveCurrency },
+    };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        got,
+        {
+          account: f.gaveFrom,
+          amount: `-${absAmount(f.gaveAmount)}`,
+          currency: f.gaveCurrency,
+        },
+      ]);
+    }
+    const items = [got, ...extras];
+    return Transaction.fromHeader(header, [
+      ...items,
+      ...balancingPostings(f.gaveFrom, items),
+    ]);
+  },
+  detect: (draft): ExchangeFields | null => {
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.assertion)) return null;
+    const costPostings = postings.filter((p) => p.cost);
+    if (costPostings.length !== 1) return null;
+    const got = costPostings[0];
+    const cost = got.cost;
+    if (!cost) return null;
+    const rest = postings.filter((p) => p !== got);
+    const expensePostings = rest.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    const gavePostings = rest.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    if (expensePostings.length + gavePostings.length !== rest.length)
+      return null;
+    if (gavePostings.length < 1) return null;
+    const gaveFrom = singleAccount(gavePostings);
+    if (!gaveFrom) return null;
+    if (got.amount === '' || !(Number(got.amount) > 0)) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    return {
+      ...headerOf(draft),
+      gaveAmount: cost.amount,
+      gaveCurrency: cost.currency,
+      gaveFrom,
+      gotAmount: absAmount(got.amount),
+      gotCurrency: got.currency,
+      gotInto: got.account,
+      extraItems: toExtraItems(expensePostings),
+    };
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/exchange.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/types/exchange.ts features/transactions/entry/types/exchange.test.ts
+git commit -m "feat(entry): support extra items in the exchange adapter"
+```
+
+---
+
+### Task 6: Cross-type detection ordering
+
+**Files:**
+- Modify: `features/transactions/entry/types/registry.test.ts` (extend; do not weaken existing cases)
+
+**Interfaces:**
+- Consumes: `detectType` from `./registry` (unchanged).
+
+**Context:** `TYPE_ADAPTERS` order is `[expense, income, transfer, exchange, fixBalance]` and `detectType` returns the first non-null. These tests lock in that an extras-bearing draft resolves to the intended type and is not swallowed by an earlier adapter.
+
+- [ ] **Step 1: Read the current test file**
+
+Run: `cat features/transactions/entry/types/registry.test.ts`
+
+Keep all existing assertions. If any existing case asserts a full `fields` object (deep equality) for a detected type, add `extraItems: []` to that expected object so it still matches.
+
+- [ ] **Step 2: Append cross-type ordering tests**
+
+Add this block to `registry.test.ts` (adjust the import if the file already imports these):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { detectType } from './registry';
+import { Transaction } from '@/lib/transactions/model';
+
+describe('detectType with extra items', () => {
+  it('classifies an expense with a tip as expense', () => {
+    const draft = Transaction.of('2026-06-29', 'Diner', 'none', '', [
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+    ]);
+    expect(detectType(draft)?.id).toBe('expense');
+  });
+
+  it('classifies a transfer with a wire fee as transfer, not expense', () => {
+    const draft = Transaction.of('2026-06-29', 'Transfer', 'none', '', [
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-515', currency: 'USD' },
+    ]);
+    expect(detectType(draft)?.id).toBe('transfer');
+  });
+
+  it('classifies income with a processor fee as income, not expense', () => {
+    const draft = Transaction.of('2026-06-29', 'Employer', 'none', '', [
+      { account: 'Assets:Checking', amount: '970', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
+    ]);
+    expect(detectType(draft)?.id).toBe('income');
+  });
+
+  it('classifies an exchange with a broker fee as exchange', () => {
+    const draft = Transaction.of('2026-06-29', 'Currency exchange', 'none', '', [
+      {
+        account: 'Assets:BTC',
+        amount: '1',
+        currency: 'BTC',
+        cost: { amount: '100', currency: 'USD' },
+      },
+      { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+      { account: 'Assets:Bank', amount: '-102', currency: 'USD' },
+    ]);
+    expect(detectType(draft)?.id).toBe('exchange');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/types/registry.test.ts`
+Expected: PASS. If the transfer or income case resolves to `expense`, the corresponding adapter's `detect` guard is wrong — fix the adapter, not the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/transactions/entry/types/registry.test.ts
+git commit -m "test(entry): lock in type detection for drafts with extra items"
+```
+
+---
+
+### Task 7: ExtraItemsField component
+
+**Files:**
+- Create: `features/transactions/entry/typeForms/ExtraItemsField.tsx`
+- Test: `features/transactions/entry/typeForms/ExtraItemsField.test.tsx`
+
+**Interfaces:**
+- Consumes: `ExtraItem` (Task 1); existing `Combobox` (`@/components/Combobox`), `AmountInput` (`../../AmountInput`), `Button` (`@/components/ui/button`), `SectionLabel` + `CurrencyCombobox` (`./fields`).
+- Produces:
+  ```ts
+  function ExtraItemsField(props: {
+    items: ExtraItem[];
+    accounts: string[];
+    defaultCurrency: string;
+    baseCount: number;
+    onChange: (items: ExtraItem[]) => void;
+  }): React.JSX.Element
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// features/transactions/entry/typeForms/ExtraItemsField.test.tsx
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { ExtraItemsField } from './ExtraItemsField';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('ExtraItemsField', () => {
+  it('renders one row per item with its account and amount', () => {
+    const out = html(
+      <ExtraItemsField
+        items={[
+          { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+          { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+        ]}
+        accounts={['Expenses:Tips', 'Expenses:Fees']}
+        defaultCurrency="USD"
+        baseCount={2}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Extra items');
+    expect(out).toContain('Expenses:Tips');
+    expect(out).toContain('20');
+    expect(out).toContain('Expenses:Fees');
+  });
+
+  it('renders only the add button when empty', () => {
+    const out = html(
+      <ExtraItemsField
+        items={[]}
+        accounts={[]}
+        defaultCurrency="USD"
+        baseCount={2}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Add item');
+  });
+
+  it('disables adding when the posting cap is reached', () => {
+    const items = Array.from({ length: 48 }, () => ({
+      account: 'Expenses:Fees',
+      amount: '1',
+      currency: 'USD',
+    }));
+    const out = html(
+      <ExtraItemsField
+        items={items}
+        accounts={['Expenses:Fees']}
+        defaultCurrency="USD"
+        baseCount={2}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('disabled');
+    expect(out).toContain('limit');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/typeForms/ExtraItemsField.test.tsx`
+Expected: FAIL — cannot resolve `./ExtraItemsField`.
+
+- [ ] **Step 3: Write the component**
+
+First confirm the `Button` import path and prop names:
+
+Run: `sed -n '1,60p' components/ui/button.tsx`
+
+Adjust the `variant`/`size` values below to ones the component actually defines (the block below assumes shadcn defaults `variant="outline" | "ghost"`, `size="sm" | "icon"`). Then create:
+
+```tsx
+// features/transactions/entry/typeForms/ExtraItemsField.tsx
+'use client';
+
+import React from 'react';
+import AmountInput from '../../AmountInput';
+import { CurrencyCombobox, SectionLabel } from './fields';
+import type { ExtraItem } from '../types/extraItems';
+import Combobox from '@/components/Combobox';
+import { Button } from '@/components/ui/button';
+
+const MAX_POSTINGS = 50;
+
+export function ExtraItemsField({
+  items,
+  accounts,
+  defaultCurrency,
+  baseCount,
+  onChange,
+}: {
+  items: ExtraItem[];
+  accounts: string[];
+  defaultCurrency: string;
+  baseCount: number;
+  onChange: (items: ExtraItem[]) => void;
+}): React.JSX.Element {
+  const atCap = baseCount + items.length >= MAX_POSTINGS;
+
+  const setItem = (index: number, patch: Partial<ExtraItem>) =>
+    onChange(items.map((item, i) => (i === index ? { ...item, ...patch } : item)));
+  const addItem = () =>
+    onChange([...items, { account: '', amount: '', currency: defaultCurrency }]);
+  const removeItem = (index: number) =>
+    onChange(items.filter((_, i) => i !== index));
+
+  return (
+    <section className="flex flex-col gap-3">
+      <SectionLabel>Extra items (fees, tips…)</SectionLabel>
+
+      {items.map((item, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Combobox
+            value={item.account}
+            onChange={(account) => setItem(index, { account })}
+            options={accounts}
+            placeholder="Account, e.g. Expenses:Fees"
+          />
+          <AmountInput
+            value={item.amount}
+            onChange={(amount) => setItem(index, { amount })}
+            placeholder="Amount"
+            className="w-28 text-right tabular-nums"
+          />
+          <CurrencyCombobox
+            value={item.currency}
+            onChange={(currency) => setItem(index, { currency })}
+            className="w-24"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Remove item"
+            onClick={() => removeItem(index)}
+          >
+            ×
+          </Button>
+        </div>
+      ))}
+
+      <div className="flex flex-col gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="self-start"
+          disabled={atCap}
+          onClick={addItem}
+        >
+          + Add item
+        </Button>
+        {atCap && (
+          <span className="text-xs text-muted-foreground">
+            Posting limit reached ({MAX_POSTINGS}).
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/typeForms/ExtraItemsField.test.tsx`
+Expected: PASS. If the empty-state or cap markup differs, adjust the assertion strings to the real rendered text (do not weaken the intent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/ExtraItemsField.tsx features/transactions/entry/typeForms/ExtraItemsField.test.tsx
+git commit -m "feat(entry): add ExtraItemsField dynamic row component"
+```
+
+---
+
+### Task 8: Wire ExtraItemsField into the four forms
+
+**Files:**
+- Modify: `features/transactions/entry/typeForms/ExpenseForm.tsx`
+- Modify: `features/transactions/entry/typeForms/IncomeForm.tsx`
+- Modify: `features/transactions/entry/typeForms/TransferForm.tsx`
+- Modify: `features/transactions/entry/typeForms/ExchangeForm.tsx`
+- Test: `features/transactions/entry/typeForms/ExpenseForm.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `ExtraItemsField` (Task 7). Each form already holds its adapter `fields` in `useState` and calls `update(next)` which re-runs `adapter.compile`. `fields.extraItems` now exists on all four.
+
+**Context:** Each form's `update(next)` both `setFields(next)` and dispatches `replaceAll` with the recompiled draft, so passing a new `extraItems` array through `update` is all that is needed — no reducer changes.
+
+- [ ] **Step 1: Extend the ExpenseForm test**
+
+Add this case to `features/transactions/entry/typeForms/ExpenseForm.test.tsx`:
+
+```ts
+it('renders the extra-items section and seeds a fee from a 3-posting draft', () => {
+  const draft = initDraft(
+    {
+      date: '2026-06-29',
+      payee: 'Diner',
+      postings: [
+        { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+        { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+      ],
+    },
+    'USD'
+  );
+  const out = html(
+    <ExpenseForm
+      draft={draft}
+      dispatch={() => {}}
+      accounts={['Assets:Checking', 'Expenses:Dining', 'Expenses:Tips']}
+      payees={['Diner']}
+      defaultCurrency="USD"
+    />
+  );
+  expect(out).toContain('Extra items');
+  expect(out).toContain('Expenses:Tips');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run features/transactions/entry/typeForms/ExpenseForm.test.tsx`
+Expected: FAIL — output does not contain "Extra items".
+
+- [ ] **Step 3: Add the field to ExpenseForm**
+
+In `features/transactions/entry/typeForms/ExpenseForm.tsx`, add the import:
+
+```tsx
+import { ExtraItemsField } from './ExtraItemsField';
+```
+
+Then, inside the `<section>`, immediately after the "Spent on" `<AccountField>` block, add:
+
+```tsx
+<ExtraItemsField
+  items={fields.extraItems}
+  accounts={accounts}
+  defaultCurrency={fields.currency || defaultCurrency}
+  baseCount={2}
+  onChange={(extraItems) => update({ ...fields, extraItems })}
+/>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run features/transactions/entry/typeForms/ExpenseForm.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Add the field to the other three forms**
+
+Apply the same import and the same `<ExtraItemsField>` block, placed after the last account field inside each form's `<section>`:
+
+- `IncomeForm.tsx` — after the "From" (`from`) account field. Use `defaultCurrency={fields.currency || defaultCurrency}`.
+- `TransferForm.tsx` — after the "To" (`to`) account field. Use `defaultCurrency={fields.currency || defaultCurrency}`.
+- `ExchangeForm.tsx` — after the "Into" (`gotInto`) account field. Use `defaultCurrency={fields.gaveCurrency || defaultCurrency}` (fees default to the currency the user is paying with).
+
+Each form already destructures `accounts` and `defaultCurrency` from `TypeFormProps` and defines `update`, so the block compiles as-is once imported. If a form does not currently destructure `defaultCurrency`, add it to the props destructure.
+
+- [ ] **Step 6: Run the full entry test suite and type-check**
+
+Run: `pnpm exec vitest run features/transactions/entry && pnpm exec tsc --noEmit`
+Expected: PASS with no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add features/transactions/entry/typeForms/ExpenseForm.tsx features/transactions/entry/typeForms/IncomeForm.tsx features/transactions/entry/typeForms/TransferForm.tsx features/transactions/entry/typeForms/ExchangeForm.tsx features/transactions/entry/typeForms/ExpenseForm.test.tsx
+git commit -m "feat(entry): expose extra items in the guided type forms"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the whole suite: `pnpm exec vitest run`
+- [ ] Type-check: `pnpm exec tsc --noEmit`
+- [ ] Lint the touched files: `pnpm lint`
+- [ ] Manual smoke: start the app, open transaction entry → Types tab → Expense, add two extra items in different currencies, confirm the Raw lens shows the expected balancing postings and the balance indicator reads "balanced".
+
+## Notes on design decisions (for the implementer)
+
+- **Why keep a separate empty-extras branch in every `compile`?** The regression guarantee. `balancingPostings` normalizes amounts through `Number`, which would turn `"-42.50"` into `"-42.5"` and rewrite every existing user's ledger output. The empty branch preserves the exact current strings; the arithmetic path only runs when the user actually added an extra item.
+- **Why does `detect` pick `expensePostings[0]` as the base?** In an Expense/Income, the base and the extras share the same account role, so position is the only signal. `compile` always emits the base first, so `compile → detect` round-trips. A hand-built draft with a different order picks a different base — acceptable and deterministic.
+- **Determinism guard:** every `detect` returns `null` unless the whole draft balances (`computeBalance(...).kind === 'balanced'`), the absorbing account is a single account (`singleAccount`), and no posting carries an unexpected role. A draft that is unrecognized today is never mis-recognized; it still falls back to the Form/Raw lens.

--- a/docs/superpowers/specs/2026-07-09-extra-items-guided-forms-design.md
+++ b/docs/superpowers/specs/2026-07-09-extra-items-guided-forms-design.md
@@ -1,0 +1,140 @@
+# Extra Items in Guided Transaction Forms
+
+**Date:** 2026-07-09
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+A single transaction often carries incidental extra postings — a tip on a
+meal, a shipping fee on a purchase, a broker fee on a trade, a processor cut on
+income. The **Form** and **Raw** entry lenses already allow arbitrary extra
+postings (min 2, max 50). The **Types** tab does not: each of the five guided
+forms compiles to exactly two postings, so a user working in a guided form has
+no way to add a fee or tip without dropping down to the Form/Raw lens.
+
+This design adds a dynamic "extra items" list to the guided forms so a user can
+append as many fee/tip-style postings as they want, each with its own account,
+amount, and currency.
+
+## Scope
+
+- **In scope:** Expense, Exchange, Transfer, Income guided forms.
+- **Out of scope:** Fix Balance form (a balance assertion has no meaningful
+  notion of extra items).
+- **Out of scope:** changes to the generic `Transaction` model, the Form lens,
+  or the Raw lens — they already support arbitrary postings.
+
+## Data Model
+
+A new shared type describes one extra item:
+
+```ts
+type ExtraItem = { account: string; amount: string; currency: string };
+```
+
+Each extra item corresponds to exactly one ledger posting.
+
+`ExtraItem[]` is added to the **domain field types** of the four affected
+adapters (`expense.ts`, `exchange.ts`, `transfer.ts`, `income.ts`) as
+`extraItems: ExtraItem[]`. It is **not** added to the generic `Transaction`
+class — after compilation, extras are simply additional entries in the
+existing `postings` array.
+
+Each adapter's `emptyFields()` seeds `extraItems: []`.
+
+## Compile (fields → postings)
+
+Each extra item compiles to one posting `{account, amount, currency}`. The
+form's **balancing account** absorbs the extras, emitting one posting per
+distinct currency. Nothing relies on ledger's blank-posting elision — every
+amount is explicit, matching the current adapters' behavior.
+
+The absorbing account and direction are form-specific:
+
+| Form     | Base posting            | Absorbing account | Effect of extras                                          |
+|----------|-------------------------|-------------------|-----------------------------------------------------------|
+| Expense  | `spentOn +base`         | `paidFrom`        | outflow grows: `paidFrom = -(base + extras)` per currency |
+| Transfer | `to +base`              | `from`            | outflow grows: `from = -(base + extras)` per currency     |
+| Exchange | buy/sell with `@@` cost | paying asset acct | fee posting(s) added; asset pays the extra per currency   |
+| Income   | `source -base`          | `earnedTo`        | inflow shrinks: `earnedTo = +(base - extras)` per currency |
+
+Grouping rule: sum extra amounts by currency; the base currency folds into its
+own currency group. Emit one absorbing posting per distinct currency present
+across base + extras.
+
+### Example (Expense)
+
+Base 100 USD to `Expenses:Dining`, paid from `Assets:Checking`, plus tip 20 USD
+and fee 2 EUR:
+
+```
+Expenses:Dining   100 USD
+Expenses:Tips      20 USD
+Expenses:Fees       2 EUR
+Assets:Checking  -120 USD
+Assets:Checking    -2 EUR
+```
+
+`Assets:Checking` emits two postings because two currencies are present.
+
+## Detect (postings → fields)
+
+`detect()` currently returns fields only for the exact two-posting shape. It
+must now accept **N postings**:
+
+1. Identify the base posting using the existing per-adapter rule (Expense: the
+   positive `Expenses:*` posting; Income: the negative `Income:*` posting;
+   etc.).
+2. Identify the absorbing account — the asset/liability posting(s) filling the
+   `paidFrom`/`from`/`earnedTo` role.
+3. Everything remaining becomes `extraItems`.
+
+**Determinism guard:** only lift a posting into `extraItems` when the two
+canonical postings are unambiguously identifiable (a single base posting of the
+expected account type plus a single absorbing asset/liability account, possibly
+split across currencies). If the classification is ambiguous, `detect()`
+returns `null` and the draft falls back to the Form/Raw lens exactly as it does
+today. This guarantees no regression: a draft that is recognized today stays
+recognized; a draft that is unrecognized today is never *mis*-recognized.
+
+`detectType()` in the registry is unchanged in spirit: the first adapter whose
+`detect()` returns non-null wins, and adapter order is preserved. The added
+extra-item handling must not let, e.g., an Expense-with-extras draft be misread
+as a Transfer.
+
+## UI
+
+A new shared component `ExtraItemsField.tsx` lives in
+`features/transactions/entry/typeForms/` and is rendered by all four affected
+forms.
+
+- Section label: "Extra items (fees, tips…)" with a `[+ add item]` button.
+- Each row: Account combobox (default filter to Expense accounts, any account
+  allowed) · AmountInput · CurrencyCombobox (defaults to the form's currency) ·
+  remove `[x]` button.
+- An empty list renders only the add button (no visual clutter).
+- Reuses the existing `Combobox`, `AmountInput`, and `CurrencyCombobox`
+  widgets — the same components used by `PostingRow`.
+
+Each form renders `<ExtraItemsField items={fields.extraItems} onChange={…} />`
+below its core fields and above the balance/preview area.
+
+**Cap:** the total posting count remains bounded by the existing
+`MAX_POSTINGS = 50` (schema.ts). Adding an item that would exceed the cap is
+disabled with a hint.
+
+## Testing
+
+- **Adapter compile** (each of the four): base + N extras same currency; mixed
+  currency producing per-currency absorbing postings; zero extras producing
+  byte-identical output to today (regression guard).
+- **Adapter detect round-trip**: `compile → detect` returns identical fields
+  including extras; an ambiguous three-posting draft returns `null`; existing
+  two-posting drafts still detect unchanged.
+- **detectType ordering**: an Expense-with-extras draft is not misread as
+  Transfer, and analogous cross-type checks.
+- **Schema**: N extras within `MAX_POSTINGS` passes; exceeding 50 is rejected.
+- **Component** (`ExtraItemsField`): add/remove rows; currency defaulting to the
+  form currency.
+- **Snapshot**: serialized ledger output for the mixed-currency Expense example
+  above.

--- a/features/transactions/entry/TransactionEntry.test.tsx
+++ b/features/transactions/entry/TransactionEntry.test.tsx
@@ -134,8 +134,11 @@ describe('TransactionEntry', () => {
           status: 'none',
           note: '',
           postings: [
-            { account: 'Expenses:Food', amount: '5', currency: 'USD' },
-            { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+            {
+              account: 'Equity:Opening Balances',
+              amount: '10',
+              currency: 'USD',
+            },
             { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
           ],
         }}

--- a/features/transactions/entry/TypeLens.test.tsx
+++ b/features/transactions/entry/TypeLens.test.tsx
@@ -47,8 +47,7 @@ describe('TypeLens', () => {
         date: '2026-06-29',
         payee: 'Split',
         postings: [
-          { account: 'Expenses:Food', amount: '5', currency: 'USD' },
-          { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+          { account: 'Equity:Opening Balances', amount: '10', currency: 'USD' },
           { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
         ],
       },

--- a/features/transactions/entry/typeForms/ExchangeForm.tsx
+++ b/features/transactions/entry/typeForms/ExchangeForm.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { exchangeAdapter, type ExchangeFields } from '../types/exchange';
+import { ExtraItemsField } from './ExtraItemsField';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
@@ -89,6 +90,14 @@ export function ExchangeForm({
           accounts={accounts}
           value={fields.gotInto}
           onChange={(gotInto) => update({ ...fields, gotInto })}
+        />
+
+        <ExtraItemsField
+          items={fields.extraItems}
+          accounts={accounts}
+          defaultCurrency={fields.gaveCurrency || defaultCurrency}
+          baseCount={2}
+          onChange={(extraItems) => update({ ...fields, extraItems })}
         />
       </section>
     </div>

--- a/features/transactions/entry/typeForms/ExpenseForm.test.tsx
+++ b/features/transactions/entry/typeForms/ExpenseForm.test.tsx
@@ -34,6 +34,32 @@ describe('ExpenseForm', () => {
     expect(out).toContain('42.5');
   });
 
+  it('renders the extra-items section and seeds a fee from a 3-posting draft', () => {
+    const draft = initDraft(
+      {
+        date: '2026-06-29',
+        payee: 'Diner',
+        postings: [
+          { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+          { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+        ],
+      },
+      'USD'
+    );
+    const out = html(
+      <ExpenseForm
+        draft={draft}
+        dispatch={() => {}}
+        accounts={['Assets:Checking', 'Expenses:Dining', 'Expenses:Tips']}
+        payees={['Diner']}
+        defaultCurrency="USD"
+      />
+    );
+    expect(out).toContain('Extra items');
+    expect(out).toContain('Expenses:Tips');
+  });
+
   it('renders empty fields for a fresh draft without crashing', () => {
     const out = html(
       <ExpenseForm

--- a/features/transactions/entry/typeForms/ExpenseForm.tsx
+++ b/features/transactions/entry/typeForms/ExpenseForm.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { expenseAdapter, type ExpenseFields } from '../types/expense';
+import { ExtraItemsField } from './ExtraItemsField';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
@@ -71,6 +72,14 @@ export function ExpenseForm({
           accounts={accounts}
           value={fields.spentOn}
           onChange={(spentOn) => update({ ...fields, spentOn })}
+        />
+
+        <ExtraItemsField
+          items={fields.extraItems}
+          accounts={accounts}
+          defaultCurrency={fields.currency || defaultCurrency}
+          baseCount={2}
+          onChange={(extraItems) => update({ ...fields, extraItems })}
         />
       </section>
     </div>

--- a/features/transactions/entry/typeForms/ExtraItemsField.test.tsx
+++ b/features/transactions/entry/typeForms/ExtraItemsField.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { ExtraItemsField } from './ExtraItemsField';
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('ExtraItemsField', () => {
+  it('renders one row per item with its account and amount', () => {
+    const out = html(
+      <ExtraItemsField
+        items={[
+          { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+          { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+        ]}
+        accounts={['Expenses:Tips', 'Expenses:Fees']}
+        defaultCurrency="USD"
+        baseCount={2}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Extra items');
+    expect(out).toContain('Expenses:Tips');
+    expect(out).toContain('20');
+    expect(out).toContain('Expenses:Fees');
+  });
+
+  it('renders only the add button when empty', () => {
+    const out = html(
+      <ExtraItemsField
+        items={[]}
+        accounts={[]}
+        defaultCurrency="USD"
+        baseCount={2}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('Add item');
+  });
+
+  it('disables adding when the posting cap is reached', () => {
+    const items = Array.from({ length: 48 }, () => ({
+      account: 'Expenses:Fees',
+      amount: '1',
+      currency: 'USD',
+    }));
+    const out = html(
+      <ExtraItemsField
+        items={items}
+        accounts={['Expenses:Fees']}
+        defaultCurrency="USD"
+        baseCount={2}
+        onChange={() => {}}
+      />
+    );
+    expect(out).toContain('disabled');
+    expect(out).toContain('limit');
+  });
+});

--- a/features/transactions/entry/typeForms/ExtraItemsField.tsx
+++ b/features/transactions/entry/typeForms/ExtraItemsField.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import AmountInput from '../../AmountInput';
 import type { ExtraItem } from '../types/extraItems';
-import { CurrencyCombobox, SectionLabel } from './fields';
+import { CurrencyCombobox, optionsForRoles, SectionLabel } from './fields';
 import Combobox from '@/components/Combobox';
 import { Button } from '@/components/ui/button';
 
@@ -23,6 +23,7 @@ export function ExtraItemsField({
   onChange: (items: ExtraItem[]) => void;
 }): React.JSX.Element {
   const atCap = baseCount + items.length >= MAX_POSTINGS;
+  const expenseAccounts = optionsForRoles(accounts, 'expense');
 
   const setItem = (index: number, patch: Partial<ExtraItem>) =>
     onChange(
@@ -49,7 +50,7 @@ export function ExtraItemsField({
           <Combobox
             value={item.account}
             onChange={(account) => setItem(index, { account })}
-            options={accounts}
+            options={expenseAccounts}
             placeholder="Account, e.g. Expenses:Fees"
           />
           <AmountInput

--- a/features/transactions/entry/typeForms/ExtraItemsField.tsx
+++ b/features/transactions/entry/typeForms/ExtraItemsField.tsx
@@ -26,15 +26,19 @@ export function ExtraItemsField({
 
   const setItem = (index: number, patch: Partial<ExtraItem>) =>
     onChange(
-      items.map((item, i) => (i === index ? { ...item, ...patch } : item))
+      items.map((item, itemIndex) =>
+        itemIndex === index ? { ...item, ...patch } : item
+      )
     );
-  const addItem = () =>
+  const addItem = () => {
+    if (atCap) return;
     onChange([
       ...items,
       { account: '', amount: '', currency: defaultCurrency },
     ]);
+  };
   const removeItem = (index: number) =>
-    onChange(items.filter((_, i) => i !== index));
+    onChange(items.filter((_, itemIndex) => itemIndex !== index));
 
   return (
     <section className="flex flex-col gap-3">

--- a/features/transactions/entry/typeForms/ExtraItemsField.tsx
+++ b/features/transactions/entry/typeForms/ExtraItemsField.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React from 'react';
+import AmountInput from '../../AmountInput';
+import type { ExtraItem } from '../types/extraItems';
+import { CurrencyCombobox, SectionLabel } from './fields';
+import Combobox from '@/components/Combobox';
+import { Button } from '@/components/ui/button';
+
+const MAX_POSTINGS = 50;
+
+export function ExtraItemsField({
+  items,
+  accounts,
+  defaultCurrency,
+  baseCount,
+  onChange,
+}: {
+  items: ExtraItem[];
+  accounts: string[];
+  defaultCurrency: string;
+  baseCount: number;
+  onChange: (items: ExtraItem[]) => void;
+}): React.JSX.Element {
+  const atCap = baseCount + items.length >= MAX_POSTINGS;
+
+  const setItem = (index: number, patch: Partial<ExtraItem>) =>
+    onChange(
+      items.map((item, i) => (i === index ? { ...item, ...patch } : item))
+    );
+  const addItem = () =>
+    onChange([
+      ...items,
+      { account: '', amount: '', currency: defaultCurrency },
+    ]);
+  const removeItem = (index: number) =>
+    onChange(items.filter((_, i) => i !== index));
+
+  return (
+    <section className="flex flex-col gap-3">
+      <SectionLabel>Extra items (fees, tips…)</SectionLabel>
+
+      {items.map((item, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Combobox
+            value={item.account}
+            onChange={(account) => setItem(index, { account })}
+            options={accounts}
+            placeholder="Account, e.g. Expenses:Fees"
+          />
+          <AmountInput
+            value={item.amount}
+            onChange={(amount) => setItem(index, { amount })}
+            placeholder="Amount"
+            className="w-28 text-right tabular-nums"
+          />
+          <CurrencyCombobox
+            value={item.currency}
+            onChange={(currency) => setItem(index, { currency })}
+            className="w-24"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Remove item"
+            onClick={() => removeItem(index)}
+          >
+            ×
+          </Button>
+        </div>
+      ))}
+
+      <div className="flex flex-col gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="self-start"
+          disabled={atCap}
+          onClick={addItem}
+        >
+          + Add item
+        </Button>
+        {atCap && (
+          <span className="text-xs text-muted-foreground">
+            Posting limit reached ({MAX_POSTINGS}).
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/features/transactions/entry/typeForms/ExtraItemsField.tsx
+++ b/features/transactions/entry/typeForms/ExtraItemsField.tsx
@@ -22,8 +22,32 @@ export function ExtraItemsField({
   baseCount: number;
   onChange: (items: ExtraItem[]) => void;
 }): React.JSX.Element {
-  const atCap = baseCount + items.length >= MAX_POSTINGS;
+  // `compile` emits one balancing posting per distinct residual currency, so the
+  // compiled transaction can exceed the row count when extras span several
+  // currencies. Bound the worst case: the fixed non-balancing base postings
+  // (`baseCount - 1`), one posting per row, and one balancing posting per
+  // distinct currency in play (the base residual currency plus each row's).
+  const residualCurrencies = new Set([
+    defaultCurrency,
+    ...items.map((item) => item.currency),
+  ]).size;
+  const atCap =
+    baseCount - 1 + items.length + residualCurrencies >= MAX_POSTINGS;
   const expenseAccounts = optionsForRoles(accounts, 'expense');
+
+  // `Combobox` keeps uncontrolled internal state (open/search) that is not
+  // derived from `value`, so keying rows by array index would misassociate that
+  // state when a middle row is removed and the rows below shift up. Track a
+  // stable per-row id instead, kept in lockstep with `items` on add/remove and
+  // regenerated when the array is replaced from outside (type switch / detect).
+  const [rowIds, setRowIds] = React.useState<string[]>(() =>
+    items.map(() => crypto.randomUUID())
+  );
+  let ids = rowIds;
+  if (ids.length !== items.length) {
+    ids = items.map(() => crypto.randomUUID());
+    setRowIds(ids);
+  }
 
   const setItem = (index: number, patch: Partial<ExtraItem>) =>
     onChange(
@@ -33,20 +57,25 @@ export function ExtraItemsField({
     );
   const addItem = () => {
     if (atCap) return;
+    setRowIds((current) => [...current, crypto.randomUUID()]);
     onChange([
       ...items,
       { account: '', amount: '', currency: defaultCurrency },
     ]);
   };
-  const removeItem = (index: number) =>
+  const removeItem = (index: number) => {
+    setRowIds((current) =>
+      current.filter((_, itemIndex) => itemIndex !== index)
+    );
     onChange(items.filter((_, itemIndex) => itemIndex !== index));
+  };
 
   return (
     <section className="flex flex-col gap-3">
       <SectionLabel>Extra items (fees, tips…)</SectionLabel>
 
       {items.map((item, index) => (
-        <div key={index} className="flex items-center gap-2">
+        <div key={ids[index]} className="flex items-center gap-2">
           <Combobox
             value={item.account}
             onChange={(account) => setItem(index, { account })}

--- a/features/transactions/entry/typeForms/IncomeForm.tsx
+++ b/features/transactions/entry/typeForms/IncomeForm.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { incomeAdapter, type IncomeFields } from '../types/income';
+import { ExtraItemsField } from './ExtraItemsField';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
@@ -71,6 +72,14 @@ export function IncomeForm({
           accounts={accounts}
           value={fields.from}
           onChange={(from) => update({ ...fields, from })}
+        />
+
+        <ExtraItemsField
+          items={fields.extraItems}
+          accounts={accounts}
+          defaultCurrency={fields.currency || defaultCurrency}
+          baseCount={2}
+          onChange={(extraItems) => update({ ...fields, extraItems })}
         />
       </section>
     </div>

--- a/features/transactions/entry/typeForms/TransferForm.tsx
+++ b/features/transactions/entry/typeForms/TransferForm.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useState } from 'react';
 import AmountInput from '../../AmountInput';
 import { headerOf } from '../types/adapter';
 import { transferAdapter, type TransferFields } from '../types/transfer';
+import { ExtraItemsField } from './ExtraItemsField';
 import { HeaderFieldsEditor } from './HeaderFields';
 import { Field, SectionLabel, AccountField, CurrencyCombobox } from './fields';
 import type { TypeFormProps } from './props';
@@ -71,6 +72,14 @@ export function TransferForm({
           accounts={accounts}
           value={fields.to}
           onChange={(to) => update({ ...fields, to })}
+        />
+
+        <ExtraItemsField
+          items={fields.extraItems}
+          accounts={accounts}
+          defaultCurrency={fields.currency || defaultCurrency}
+          baseCount={2}
+          onChange={(extraItems) => update({ ...fields, extraItems })}
         />
       </section>
     </div>

--- a/features/transactions/entry/typeLensState.test.ts
+++ b/features/transactions/entry/typeLensState.test.ts
@@ -35,8 +35,7 @@ const unrecognizedDraft = () =>
       date: '2026-07-05',
       payee: 'Split',
       postings: [
-        { account: 'Expenses:Food', amount: '5', currency: 'USD' },
-        { account: 'Expenses:Fun', amount: '5', currency: 'USD' },
+        { account: 'Equity:Opening Balances', amount: '10', currency: 'USD' },
         { account: 'Assets:Checking', amount: '-10', currency: 'USD' },
       ],
     },

--- a/features/transactions/entry/types/exchange.test.ts
+++ b/features/transactions/entry/types/exchange.test.ts
@@ -22,6 +22,7 @@ describe('exchangeAdapter.compile', () => {
         gotAmount: '92',
         gotCurrency: 'EUR',
         gotInto: 'Assets:EUR-Wallet',
+        extraItems: [],
       },
       ctx
     );
@@ -33,6 +34,33 @@ describe('exchangeAdapter.compile', () => {
         cost: { amount: '100', currency: 'USD' },
       },
       { account: 'Assets:Checking', amount: '-100', currency: 'USD' },
+    ]);
+  });
+  it('routes a broker fee through the paying account', () => {
+    const draft = exchangeAdapter.compile(
+      {
+        ...header,
+        gaveAmount: '100',
+        gaveCurrency: 'USD',
+        gaveFrom: 'Assets:Bank',
+        gotAmount: '1',
+        gotCurrency: 'BTC',
+        gotInto: 'Assets:BTC',
+        extraItems: [
+          { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      {
+        account: 'Assets:BTC',
+        amount: '1',
+        currency: 'BTC',
+        cost: { amount: '100', currency: 'USD' },
+      },
+      { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+      { account: 'Assets:Bank', amount: '-102', currency: 'USD' },
     ]);
   });
 });
@@ -60,6 +88,7 @@ describe('exchangeAdapter.detect', () => {
       gotAmount: '92',
       gotCurrency: 'EUR',
       gotInto: 'Assets:EUR-Wallet',
+      extraItems: [],
     });
   });
   it('round-trips compile -> detect', () => {
@@ -72,6 +101,7 @@ describe('exchangeAdapter.detect', () => {
       gotAmount: '46',
       gotCurrency: 'EUR',
       gotInto: 'Assets:EUR',
+      extraItems: [],
     };
     expect(
       exchangeAdapter.detect(exchangeAdapter.compile(fields, ctx))
@@ -86,5 +116,23 @@ describe('exchangeAdapter.detect', () => {
         ])
       )
     ).toBeNull();
+  });
+  it('round-trips compile -> detect with a broker fee', () => {
+    const fields: ExchangeFields = {
+      ...header,
+      uid: undefined,
+      gaveAmount: '100',
+      gaveCurrency: 'USD',
+      gaveFrom: 'Assets:Bank',
+      gotAmount: '1',
+      gotCurrency: 'BTC',
+      gotInto: 'Assets:BTC',
+      extraItems: [
+        { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+      ],
+    };
+    expect(
+      exchangeAdapter.detect(exchangeAdapter.compile(fields, ctx))
+    ).toEqual(fields);
   });
 });

--- a/features/transactions/entry/types/exchange.ts
+++ b/features/transactions/entry/types/exchange.ts
@@ -1,5 +1,6 @@
 // features/transactions/entry/types/exchange.ts
 import type { DraftState } from '../draftReducer';
+import { classifyAccount } from './accountRole';
 import {
   type HeaderFields,
   type TransactionTypeAdapter,
@@ -7,6 +8,14 @@ import {
   headerOf,
 } from './adapter';
 import { absAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
 import { Transaction } from '@/lib/transactions/model';
 
 export type ExchangeFields = HeaderFields & {
@@ -16,6 +25,7 @@ export type ExchangeFields = HeaderFields & {
   gotAmount: string;
   gotCurrency: string;
   gotInto: string;
+  extraItems: ExtraItem[];
 };
 
 export const exchangeAdapter: TransactionTypeAdapter<ExchangeFields> = {
@@ -33,49 +43,72 @@ export const exchangeAdapter: TransactionTypeAdapter<ExchangeFields> = {
     gotAmount: '',
     gotCurrency: '',
     gotInto: '',
+    extraItems: [],
   }),
-  compile: (f, _ctx): DraftState =>
-    Transaction.fromHeader(
-      {
-        date: f.date,
-        payee: f.payee,
-        status: f.status,
-        note: f.note,
-        uid: f.uid,
-      },
-      [
-        {
-          account: f.gotInto,
-          amount: f.gotAmount,
-          currency: f.gotCurrency,
-          cost: { amount: f.gaveAmount, currency: f.gaveCurrency },
-        },
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const got = {
+      account: f.gotInto,
+      amount: f.gotAmount,
+      currency: f.gotCurrency,
+      cost: { amount: f.gaveAmount, currency: f.gaveCurrency },
+    };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        got,
         {
           account: f.gaveFrom,
           amount: `-${absAmount(f.gaveAmount)}`,
           currency: f.gaveCurrency,
         },
-      ]
-    ),
+      ]);
+    }
+    const items = [got, ...extras];
+    return Transaction.fromHeader(header, [
+      ...items,
+      ...balancingPostings(f.gaveFrom, items),
+    ]);
+  },
   detect: (draft): ExchangeFields | null => {
-    if (draft.postings.length !== 2) return null;
-    if (draft.postings.some((p) => p.assertion)) return null;
-    const got = draft.postings.find((p) => p.cost);
-    const gave = draft.postings.find((p) => !p.cost);
-    if (!got?.cost || !gave || got === gave) return null;
-    const { cost } = got;
-    if (got.amount === '' || gave.amount === '') return null;
-    if (!(Number(got.amount) > 0) || !(Number(gave.amount) < 0)) return null;
-    if (gave.currency !== cost.currency) return null;
-    if (Math.abs(Number(gave.amount) + Number(cost.amount)) > 1e-9) return null;
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.assertion)) return null;
+    const costPostings = postings.filter((p) => p.cost);
+    if (costPostings.length !== 1) return null;
+    const got = costPostings[0];
+    const cost = got.cost;
+    if (!cost) return null;
+    const rest = postings.filter((p) => p !== got);
+    const expensePostings = rest.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    const gavePostings = rest.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    if (expensePostings.length + gavePostings.length !== rest.length)
+      return null;
+    if (gavePostings.length < 1) return null;
+    const gaveFrom = singleAccount(gavePostings);
+    if (!gaveFrom) return null;
+    if (got.amount === '' || !(Number(got.amount) > 0)) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
     return {
       ...headerOf(draft),
       gaveAmount: cost.amount,
       gaveCurrency: cost.currency,
-      gaveFrom: gave.account,
+      gaveFrom,
       gotAmount: absAmount(got.amount),
       gotCurrency: got.currency,
       gotInto: got.account,
+      extraItems: toExtraItems(expensePostings),
     };
   },
 };

--- a/features/transactions/entry/types/expense.test.ts
+++ b/features/transactions/entry/types/expense.test.ts
@@ -11,7 +11,7 @@ const header = {
 };
 
 describe('expenseAdapter.compile', () => {
-  it('builds a +expense / -asset pair', () => {
+  it('builds a +expense / -asset pair with no extras', () => {
     const draft = expenseAdapter.compile(
       {
         ...header,
@@ -19,6 +19,7 @@ describe('expenseAdapter.compile', () => {
         currency: 'USD',
         paidFrom: 'Assets:Checking',
         spentOn: 'Expenses:Groceries',
+        extraItems: [],
       },
       ctx
     );
@@ -28,15 +29,40 @@ describe('expenseAdapter.compile', () => {
     ]);
     expect(draft.payee).toBe('Whole Foods');
   });
+
+  it('appends extra items and folds them into the paying posting', () => {
+    const draft = expenseAdapter.compile(
+      {
+        ...header,
+        amount: '100',
+        currency: 'USD',
+        paidFrom: 'Assets:Checking',
+        spentOn: 'Expenses:Dining',
+        extraItems: [
+          { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+          { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+    ]);
+  });
 });
 
 describe('expenseAdapter.detect', () => {
-  const draft = Transaction.of('2026-06-29', 'Whole Foods', 'none', '', [
+  const clean = Transaction.of('2026-06-29', 'Whole Foods', 'none', '', [
     { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
     { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
   ]);
-  it('recognizes a clean asset->expense pair', () => {
-    expect(expenseAdapter.detect(draft)).toEqual({
+
+  it('recognizes a clean asset->expense pair with empty extras', () => {
+    expect(expenseAdapter.detect(clean)).toEqual({
       date: '2026-06-29',
       payee: 'Whole Foods',
       status: 'none',
@@ -46,45 +72,66 @@ describe('expenseAdapter.detect', () => {
       currency: 'USD',
       paidFrom: 'Assets:Checking',
       spentOn: 'Expenses:Groceries',
+      extraItems: [],
     });
   });
-  it('round-trips compile -> detect', () => {
+
+  it('recovers extra items from a 3-posting split', () => {
+    const draft = Transaction.of('2026-06-29', 'Whole Foods', 'none', '', [
+      { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+      { account: 'Expenses:Tax', amount: '3', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-45.50', currency: 'USD' },
+    ]);
+    expect(expenseAdapter.detect(draft)).toMatchObject({
+      amount: '42.50',
+      paidFrom: 'Assets:Checking',
+      spentOn: 'Expenses:Groceries',
+      extraItems: [{ account: 'Expenses:Tax', amount: '3', currency: 'USD' }],
+    });
+  });
+
+  it('round-trips compile -> detect with extras', () => {
     const fields: ExpenseFields = {
       ...header,
       uid: undefined,
-      amount: '12.00',
+      amount: '100',
       currency: 'USD',
       paidFrom: 'Assets:Cash',
       spentOn: 'Expenses:Coffee',
+      extraItems: [{ account: 'Expenses:Tips', amount: '5', currency: 'USD' }],
     };
     expect(expenseAdapter.detect(expenseAdapter.compile(fields, ctx))).toEqual(
       fields
     );
   });
-  it('rejects a 3-posting split', () => {
+
+  it('rejects two distinct paying accounts', () => {
     expect(
       expenseAdapter.detect(
-        Transaction.of(draft.date, draft.payee, draft.status, draft.note, [
-          ...draft.postings,
-          { account: 'Expenses:Tax', amount: '0', currency: 'USD' },
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-20', currency: 'USD' },
+          { account: 'Assets:Cash', amount: '-22.50', currency: 'USD' },
         ])
       )
     ).toBeNull();
   });
-  it('rejects an asset->asset transfer', () => {
+
+  it('rejects an unbalanced draft', () => {
     expect(
       expenseAdapter.detect(
-        Transaction.of(draft.date, draft.payee, draft.status, draft.note, [
-          { account: 'Assets:Savings', amount: '500', currency: 'USD' },
-          { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-40', currency: 'USD' },
         ])
       )
     ).toBeNull();
   });
+
   it('rejects a cost-bearing posting', () => {
     expect(
       expenseAdapter.detect(
-        Transaction.of(draft.date, draft.payee, draft.status, draft.note, [
+        Transaction.of('2026-06-29', 'x', 'none', '', [
           {
             account: 'Expenses:Groceries',
             amount: '42.50',
@@ -92,6 +139,17 @@ describe('expenseAdapter.detect', () => {
             cost: { amount: '1', currency: 'EUR' },
           },
           { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+        ])
+      )
+    ).toBeNull();
+  });
+
+  it('rejects an asset->asset transfer (no expense posting)', () => {
+    expect(
+      expenseAdapter.detect(
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
         ])
       )
     ).toBeNull();

--- a/features/transactions/entry/types/expense.ts
+++ b/features/transactions/entry/types/expense.ts
@@ -7,6 +7,14 @@ import {
   headerOf,
 } from './adapter';
 import { absAmount, negateAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
 import { Transaction } from '@/lib/transactions/model';
 
 export type ExpenseFields = HeaderFields & {
@@ -14,6 +22,7 @@ export type ExpenseFields = HeaderFields & {
   currency: string;
   paidFrom: string;
   spentOn: string;
+  extraItems: ExtraItem[];
 };
 
 export const expenseAdapter: TransactionTypeAdapter<ExpenseFields> = {
@@ -29,46 +38,60 @@ export const expenseAdapter: TransactionTypeAdapter<ExpenseFields> = {
     currency: ctx.defaultCurrency,
     paidFrom: '',
     spentOn: '',
+    extraItems: [],
   }),
-  compile: (f, _ctx): DraftState =>
-    Transaction.fromHeader(
-      {
-        date: f.date,
-        payee: f.payee,
-        status: f.status,
-        note: f.note,
-        uid: f.uid,
-      },
-      [
-        { account: f.spentOn, amount: f.amount, currency: f.currency },
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const base = { account: f.spentOn, amount: f.amount, currency: f.currency };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        base,
         {
           account: f.paidFrom,
           amount: negateAmount(f.amount),
           currency: f.currency,
         },
-      ]
-    ),
+      ]);
+    }
+    const items = [base, ...extras];
+    return Transaction.fromHeader(header, [
+      ...items,
+      ...balancingPostings(f.paidFrom, items),
+    ]);
+  },
   detect: (draft): ExpenseFields | null => {
-    if (draft.postings.length !== 2) return null;
-    if (draft.postings.some((p) => p.cost || p.assertion)) return null;
-    const exp = draft.postings.find(
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.cost || p.assertion)) return null;
+    const expensePostings = postings.filter(
       (p) => classifyAccount(p.account) === 'expense'
     );
-    const pay = draft.postings.find((p) => {
+    const payingPostings = postings.filter((p) => {
       const role = classifyAccount(p.account);
       return role === 'asset' || role === 'liability';
     });
-    if (!exp || !pay || exp === pay) return null;
-    if (exp.amount === '' || pay.amount === '') return null;
-    if (exp.currency !== pay.currency) return null;
-    if (!(Number(exp.amount) > 0)) return null;
-    if (Math.abs(Number(exp.amount) + Number(pay.amount)) > 1e-9) return null;
+    if (expensePostings.length + payingPostings.length !== postings.length)
+      return null;
+    if (expensePostings.length < 1 || payingPostings.length < 1) return null;
+    const paidFrom = singleAccount(payingPostings);
+    if (!paidFrom) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    const base = expensePostings[0];
+    if (base.amount === '' || !(Number(base.amount) > 0)) return null;
     return {
       ...headerOf(draft),
-      amount: absAmount(exp.amount),
-      currency: exp.currency,
-      paidFrom: pay.account,
-      spentOn: exp.account,
+      amount: absAmount(base.amount),
+      currency: base.currency,
+      paidFrom,
+      spentOn: base.account,
+      extraItems: toExtraItems(expensePostings.slice(1)),
     };
   },
 };

--- a/features/transactions/entry/types/extraItems.test.ts
+++ b/features/transactions/entry/types/extraItems.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatAmount,
+  residualByCurrency,
+  balancingPostings,
+  extraItemPostings,
+  toExtraItems,
+  singleAccount,
+} from './extraItems';
+
+describe('formatAmount', () => {
+  it('trims float noise and negative zero', () => {
+    expect(formatAmount(120)).toBe('120');
+    expect(formatAmount(-42.5)).toBe('-42.5');
+    expect(formatAmount(0.1 + 0.2)).toBe('0.3');
+    expect(formatAmount(-0)).toBe('0');
+  });
+});
+
+describe('residualByCurrency', () => {
+  it('sums plain postings per currency in first-seen order', () => {
+    const net = residualByCurrency([
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+    ]);
+    expect([...net]).toEqual([
+      ['USD', 120],
+      ['EUR', 2],
+    ]);
+  });
+
+  it('honors @@ cost annotations', () => {
+    const net = residualByCurrency([
+      {
+        account: 'Assets:BTC',
+        amount: '1',
+        currency: 'BTC',
+        cost: { amount: '100', currency: 'USD' },
+      },
+    ]);
+    expect(net.get('USD')).toBe(100);
+    expect(net.has('BTC')).toBe(false);
+  });
+});
+
+describe('balancingPostings', () => {
+  it('emits one negated posting per nonzero currency', () => {
+    const out = balancingPostings('Assets:Checking', [
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
+    ]);
+    expect(out).toEqual([
+      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+    ]);
+  });
+
+  it('drops currencies that already net to zero', () => {
+    const out = balancingPostings('Assets:Checking', [
+      { account: 'A', amount: '5', currency: 'USD' },
+      { account: 'B', amount: '-5', currency: 'USD' },
+    ]);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('extraItemPostings', () => {
+  it('maps rows to postings and drops fully-blank rows', () => {
+    expect(
+      extraItemPostings([
+        { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+        { account: '', amount: '', currency: 'USD' },
+      ])
+    ).toEqual([{ account: 'Expenses:Tips', amount: '20', currency: 'USD' }]);
+  });
+});
+
+describe('toExtraItems', () => {
+  it('projects postings to plain item rows', () => {
+    expect(
+      toExtraItems([
+        { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      ])
+    ).toEqual([{ account: 'Expenses:Tips', amount: '20', currency: 'USD' }]);
+  });
+});
+
+describe('singleAccount', () => {
+  it('returns the account when all postings share one', () => {
+    expect(
+      singleAccount([
+        { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+      ])
+    ).toBe('Assets:Checking');
+  });
+  it('returns null for zero or multiple distinct accounts', () => {
+    expect(singleAccount([])).toBeNull();
+    expect(
+      singleAccount([
+        { account: 'Assets:A', amount: '1', currency: 'USD' },
+        { account: 'Assets:B', amount: '-1', currency: 'USD' },
+      ])
+    ).toBeNull();
+  });
+});

--- a/features/transactions/entry/types/extraItems.test.ts
+++ b/features/transactions/entry/types/extraItems.test.ts
@@ -15,6 +15,11 @@ describe('formatAmount', () => {
     expect(formatAmount(0.1 + 0.2)).toBe('0.3');
     expect(formatAmount(-0)).toBe('0');
   });
+
+  it('never emits scientific notation for small magnitudes', () => {
+    expect(formatAmount(5e-7)).toBe('0.0000005');
+    expect(formatAmount(-1e-7)).toBe('-0.0000001');
+  });
 });
 
 describe('residualByCurrency', () => {

--- a/features/transactions/entry/types/extraItems.test.ts
+++ b/features/transactions/entry/types/extraItems.test.ts
@@ -72,11 +72,13 @@ describe('balancingPostings', () => {
 });
 
 describe('extraItemPostings', () => {
-  it('maps rows to postings and drops fully-blank rows', () => {
+  it('maps rows to postings and drops rows missing an account or amount', () => {
     expect(
       extraItemPostings([
         { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
         { account: '', amount: '', currency: 'USD' },
+        { account: 'Expenses:Fees', amount: '', currency: 'USD' },
+        { account: '', amount: '5', currency: 'USD' },
       ])
     ).toEqual([{ account: 'Expenses:Tips', amount: '20', currency: 'USD' }]);
   });

--- a/features/transactions/entry/types/extraItems.ts
+++ b/features/transactions/entry/types/extraItems.ts
@@ -2,11 +2,12 @@ import type { Posting } from '@/lib/transactions/posting';
 
 export type ExtraItem = { account: string; amount: string; currency: string };
 
-/** Format a computed numeric amount to a compact string (trailing zeros trimmed, no -0). */
+/** Format a computed numeric amount to a compact string (trailing zeros trimmed, no -0, no scientific notation). */
 export const formatAmount = (n: number): string => {
   if (!Number.isFinite(n)) return '0';
-  const fixed = Number(n.toFixed(10));
-  return (Object.is(fixed, -0) ? 0 : fixed).toString();
+  if (n === 0) return '0';
+  const trimmed = n.toFixed(10).replace(/\.?0+$/, '');
+  return trimmed === '-0' ? '0' : trimmed;
 };
 
 /**

--- a/features/transactions/entry/types/extraItems.ts
+++ b/features/transactions/entry/types/extraItems.ts
@@ -2,7 +2,12 @@ import type { Posting } from '@/lib/transactions/posting';
 
 export type ExtraItem = { account: string; amount: string; currency: string };
 
-/** Format a computed numeric amount to a compact string (trailing zeros trimmed, no -0, no scientific notation). */
+/**
+ * Format a computed numeric amount to a compact string: trailing zeros trimmed,
+ * no `-0`. Uses `toFixed(10)`, which stays in plain decimal notation for every
+ * realistic currency magnitude (`toFixed` only switches to exponential form at
+ * `|n| >= 1e21`, far beyond any sum reachable here).
+ */
 export const formatAmount = (n: number): string => {
   if (!Number.isFinite(n)) return '0';
   if (n === 0) return '0';

--- a/features/transactions/entry/types/extraItems.ts
+++ b/features/transactions/entry/types/extraItems.ts
@@ -1,0 +1,77 @@
+import type { Posting } from '@/lib/transactions/posting';
+
+export type ExtraItem = { account: string; amount: string; currency: string };
+
+/** Format a computed numeric amount to a compact string (trailing zeros trimmed, no -0). */
+export const formatAmount = (n: number): string => {
+  if (!Number.isFinite(n)) return '0';
+  const fixed = Number(n.toFixed(10));
+  return (Object.is(fixed, -0) ? 0 : fixed).toString();
+};
+
+/**
+ * Net amount per currency across postings, honoring `@@` cost annotations
+ * (a cost-bearing posting contributes its signed cost to the cost currency,
+ * exactly like {@link computeBalance}). Insertion order = first-seen currency.
+ */
+export const residualByCurrency = (
+  postings: readonly Posting[]
+): Map<string, number> => {
+  const net = new Map<string, number>();
+  for (const posting of postings) {
+    if (posting.cost) {
+      const amount = Number(posting.amount);
+      const cost = Number(posting.cost.amount);
+      if (!Number.isFinite(amount) || !Number.isFinite(cost)) continue;
+      const sign = amount < 0 ? -1 : 1;
+      net.set(
+        posting.cost.currency,
+        (net.get(posting.cost.currency) ?? 0) + sign * cost
+      );
+    } else {
+      const value = Number(posting.amount);
+      if (!Number.isFinite(value)) continue;
+      net.set(posting.currency, (net.get(posting.currency) ?? 0) + value);
+    }
+  }
+  return net;
+};
+
+/** Postings for `account` that zero the residual of `others`, one per nonzero currency. */
+export const balancingPostings = (
+  account: string,
+  others: readonly Posting[]
+): Posting[] => {
+  const net = residualByCurrency(others);
+  const out: Posting[] = [];
+  for (const [currency, total] of net) {
+    if (Math.abs(total) <= 1e-9) continue;
+    out.push({ account, amount: formatAmount(-total), currency });
+  }
+  return out;
+};
+
+/** Map extra-item rows to postings, dropping fully-blank rows. */
+export const extraItemPostings = (items: readonly ExtraItem[]): Posting[] =>
+  items
+    .filter((item) => item.account.trim() !== '' || item.amount.trim() !== '')
+    .map((item) => ({
+      account: item.account,
+      amount: item.amount,
+      currency: item.currency,
+    }));
+
+/** Project postings back to plain extra-item rows. */
+export const toExtraItems = (postings: readonly Posting[]): ExtraItem[] =>
+  postings.map((posting) => ({
+    account: posting.account,
+    amount: posting.amount,
+    currency: posting.currency,
+  }));
+
+/** The one account shared by every posting, or null if none / more than one. */
+export const singleAccount = (postings: readonly Posting[]): string | null => {
+  const accounts = new Set(postings.map((posting) => posting.account));
+  if (accounts.size !== 1) return null;
+  return [...accounts][0] ?? null;
+};

--- a/features/transactions/entry/types/extraItems.ts
+++ b/features/transactions/entry/types/extraItems.ts
@@ -52,10 +52,15 @@ export const balancingPostings = (
   return out;
 };
 
-/** Map extra-item rows to postings, dropping fully-blank rows. */
+/**
+ * Map extra-item rows to postings, dropping rows that lack an account or an
+ * amount. A row with only one field filled is a partially-entered fee line, not
+ * a posting: emitting it (e.g. a blank amount) would silently fold into
+ * auto-balance rather than the intended fee, so both fields are required.
+ */
 export const extraItemPostings = (items: readonly ExtraItem[]): Posting[] =>
   items
-    .filter((item) => item.account.trim() !== '' || item.amount.trim() !== '')
+    .filter((item) => item.account.trim() !== '' && item.amount.trim() !== '')
     .map((item) => ({
       account: item.account,
       amount: item.amount,

--- a/features/transactions/entry/types/income.test.ts
+++ b/features/transactions/entry/types/income.test.ts
@@ -5,67 +5,94 @@ import { Transaction } from '@/lib/transactions/model';
 const ctx = { defaultCurrency: 'USD' };
 const header = {
   date: '2026-06-29',
-  payee: 'Acme Corp',
+  payee: 'Employer',
   status: 'none' as const,
   note: '',
 };
 
 describe('incomeAdapter.compile', () => {
-  it('builds a +asset / -income pair', () => {
+  it('builds a +asset / -income pair with no extras', () => {
     const draft = incomeAdapter.compile(
       {
         ...header,
-        amount: '3000',
+        amount: '1000',
         currency: 'USD',
         receivedInto: 'Assets:Checking',
         from: 'Income:Salary',
+        extraItems: [],
       },
       ctx
     );
     expect(draft.postings).toEqual([
-      { account: 'Assets:Checking', amount: '3000', currency: 'USD' },
-      { account: 'Income:Salary', amount: '-3000', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '1000', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+    ]);
+  });
+
+  it('subtracts fee extras from the net received', () => {
+    const draft = incomeAdapter.compile(
+      {
+        ...header,
+        amount: '1000',
+        currency: 'USD',
+        receivedInto: 'Assets:Checking',
+        from: 'Income:Salary',
+        extraItems: [
+          { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Assets:Checking', amount: '970', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
     ]);
   });
 });
 
 describe('incomeAdapter.detect', () => {
-  const draft = Transaction.of('2026-06-29', 'Acme Corp', 'none', '', [
-    { account: 'Assets:Checking', amount: '3000', currency: 'USD' },
-    { account: 'Income:Salary', amount: '-3000', currency: 'USD' },
-  ]);
-  it('recognizes a clean income->asset pair', () => {
+  it('recognizes a clean income pair with empty extras', () => {
+    const draft = Transaction.of('2026-06-29', 'Employer', 'none', '', [
+      { account: 'Assets:Checking', amount: '1000', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+    ]);
     expect(incomeAdapter.detect(draft)).toEqual({
       date: '2026-06-29',
-      payee: 'Acme Corp',
+      payee: 'Employer',
       status: 'none',
       note: '',
       uid: undefined,
-      amount: '3000',
+      amount: '1000',
       currency: 'USD',
       receivedInto: 'Assets:Checking',
       from: 'Income:Salary',
+      extraItems: [],
     });
   });
-  it('round-trips compile -> detect', () => {
+
+  it('round-trips compile -> detect with extras', () => {
     const fields: IncomeFields = {
       ...header,
       uid: undefined,
-      amount: '50',
+      amount: '1000',
       currency: 'USD',
-      receivedInto: 'Assets:Cash',
-      from: 'Income:Gifts',
+      receivedInto: 'Assets:Checking',
+      from: 'Income:Salary',
+      extraItems: [{ account: 'Expenses:Fees', amount: '30', currency: 'USD' }],
     };
     expect(incomeAdapter.detect(incomeAdapter.compile(fields, ctx))).toEqual(
       fields
     );
   });
-  it('rejects an expense pair', () => {
+
+  it('rejects a draft with two income sources', () => {
     expect(
       incomeAdapter.detect(
-        Transaction.of(draft.date, draft.payee, draft.status, draft.note, [
-          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
-          { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Assets:Checking', amount: '1000', currency: 'USD' },
+          { account: 'Income:Salary', amount: '-600', currency: 'USD' },
+          { account: 'Income:Bonus', amount: '-400', currency: 'USD' },
         ])
       )
     ).toBeNull();

--- a/features/transactions/entry/types/income.ts
+++ b/features/transactions/entry/types/income.ts
@@ -7,6 +7,14 @@ import {
   headerOf,
 } from './adapter';
 import { absAmount, negateAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
 import { Transaction } from '@/lib/transactions/model';
 
 export type IncomeFields = HeaderFields & {
@@ -14,6 +22,7 @@ export type IncomeFields = HeaderFields & {
   currency: string;
   receivedInto: string;
   from: string;
+  extraItems: ExtraItem[];
 };
 
 export const incomeAdapter: TransactionTypeAdapter<IncomeFields> = {
@@ -29,46 +38,66 @@ export const incomeAdapter: TransactionTypeAdapter<IncomeFields> = {
     currency: ctx.defaultCurrency,
     receivedInto: '',
     from: '',
+    extraItems: [],
   }),
-  compile: (f, _ctx): DraftState =>
-    Transaction.fromHeader(
-      {
-        date: f.date,
-        payee: f.payee,
-        status: f.status,
-        note: f.note,
-        uid: f.uid,
-      },
-      [
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const source = {
+      account: f.from,
+      amount: negateAmount(f.amount),
+      currency: f.currency,
+    };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
         { account: f.receivedInto, amount: f.amount, currency: f.currency },
-        {
-          account: f.from,
-          amount: negateAmount(f.amount),
-          currency: f.currency,
-        },
-      ]
-    ),
+        source,
+      ]);
+    }
+    const items = [source, ...extras];
+    return Transaction.fromHeader(header, [
+      ...balancingPostings(f.receivedInto, items),
+      ...items,
+    ]);
+  },
   detect: (draft): IncomeFields | null => {
-    if (draft.postings.length !== 2) return null;
-    if (draft.postings.some((p) => p.cost || p.assertion)) return null;
-    const asset = draft.postings.find(
-      (p) => classifyAccount(p.account) === 'asset'
-    );
-    const income = draft.postings.find(
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.cost || p.assertion)) return null;
+    const incomePostings = postings.filter(
       (p) => classifyAccount(p.account) === 'income'
     );
-    if (!asset || !income || asset === income) return null;
-    if (asset.amount === '' || income.amount === '') return null;
-    if (asset.currency !== income.currency) return null;
-    if (!(Number(asset.amount) > 0)) return null;
-    if (Math.abs(Number(asset.amount) + Number(income.amount)) > 1e-9)
+    const assetPostings = postings.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    const expensePostings = postings.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    if (
+      incomePostings.length + assetPostings.length + expensePostings.length !==
+      postings.length
+    )
       return null;
+    if (incomePostings.length !== 1 || assetPostings.length < 1) return null;
+    const receivedInto = singleAccount(assetPostings);
+    if (!receivedInto) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    const base = incomePostings[0];
+    if (base.amount === '' || !(Number(base.amount) < 0)) return null;
     return {
       ...headerOf(draft),
-      amount: absAmount(asset.amount),
-      currency: asset.currency,
-      receivedInto: asset.account,
-      from: income.account,
+      amount: absAmount(base.amount),
+      currency: base.currency,
+      receivedInto,
+      from: base.account,
+      extraItems: toExtraItems(expensePostings),
     };
   },
 };

--- a/features/transactions/entry/types/registry.test.ts
+++ b/features/transactions/entry/types/registry.test.ts
@@ -1,6 +1,7 @@
 // features/transactions/entry/types/registry.test.ts
 import { describe, it, expect } from 'vitest';
 import { TYPE_ADAPTERS, detectType } from './registry';
+import { Transaction } from '@/lib/transactions/model';
 
 const draft = (postings: object[]) =>
   ({
@@ -64,7 +65,7 @@ describe('detectType', () => {
       )?.id
     ).toBe('fix-balance');
   });
-  it('returns null for a 3-posting split (falls back to Form)', () => {
+  it('classifies a multi-expense-line draft with a single payer as expense', () => {
     expect(
       detectType(
         draft([
@@ -72,8 +73,8 @@ describe('detectType', () => {
           { account: 'Expenses:B', amount: '10', currency: 'USD' },
           { account: 'Assets:Checking', amount: '-20', currency: 'USD' },
         ])
-      )
-    ).toBeNull();
+      )?.id
+    ).toBe('expense');
   });
   it('returns null for a non-standard-root journal', () => {
     expect(
@@ -84,5 +85,54 @@ describe('detectType', () => {
         ])
       )
     ).toBeNull();
+  });
+});
+
+describe('detectType with extra items', () => {
+  it('classifies an expense with a tip as expense', () => {
+    const transaction = Transaction.of('2026-06-29', 'Diner', 'none', '', [
+      { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
+      { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
+    ]);
+    expect(detectType(transaction)?.id).toBe('expense');
+  });
+
+  it('classifies a transfer with a wire fee as transfer, not expense', () => {
+    const transaction = Transaction.of('2026-06-29', 'Transfer', 'none', '', [
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-515', currency: 'USD' },
+    ]);
+    expect(detectType(transaction)?.id).toBe('transfer');
+  });
+
+  it('classifies income with a processor fee as income, not expense', () => {
+    const transaction = Transaction.of('2026-06-29', 'Employer', 'none', '', [
+      { account: 'Assets:Checking', amount: '970', currency: 'USD' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+      { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
+    ]);
+    expect(detectType(transaction)?.id).toBe('income');
+  });
+
+  it('classifies an exchange with a broker fee as exchange', () => {
+    const transaction = Transaction.of(
+      '2026-06-29',
+      'Currency exchange',
+      'none',
+      '',
+      [
+        {
+          account: 'Assets:BTC',
+          amount: '1',
+          currency: 'BTC',
+          cost: { amount: '100', currency: 'USD' },
+        },
+        { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
+        { account: 'Assets:Bank', amount: '-102', currency: 'USD' },
+      ]
+    );
+    expect(detectType(transaction)?.id).toBe('exchange');
   });
 });

--- a/features/transactions/entry/types/transfer.test.ts
+++ b/features/transactions/entry/types/transfer.test.ts
@@ -11,7 +11,7 @@ const header = {
 };
 
 describe('transferAdapter.compile', () => {
-  it('builds a +to / -from asset pair', () => {
+  it('builds a to/from pair with no extras', () => {
     const draft = transferAdapter.compile(
       {
         ...header,
@@ -19,6 +19,7 @@ describe('transferAdapter.compile', () => {
         currency: 'USD',
         from: 'Assets:Checking',
         to: 'Assets:Savings',
+        extraItems: [],
       },
       ctx
     );
@@ -27,17 +28,35 @@ describe('transferAdapter.compile', () => {
       { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
     ]);
   });
-  it('emptyFields defaults the payee to Transfer', () => {
-    expect(transferAdapter.emptyFields(ctx).payee).toBe('Transfer');
+
+  it('adds a transfer fee to the source outflow', () => {
+    const draft = transferAdapter.compile(
+      {
+        ...header,
+        amount: '500',
+        currency: 'USD',
+        from: 'Assets:Checking',
+        to: 'Assets:Savings',
+        extraItems: [
+          { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+        ],
+      },
+      ctx
+    );
+    expect(draft.postings).toEqual([
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-515', currency: 'USD' },
+    ]);
   });
 });
 
 describe('transferAdapter.detect', () => {
-  const draft = Transaction.of('2026-06-29', 'Transfer', 'none', '', [
-    { account: 'Assets:Savings', amount: '500', currency: 'USD' },
-    { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
-  ]);
-  it('recognizes a clean asset->asset move', () => {
+  it('recognizes a clean transfer with empty extras', () => {
+    const draft = Transaction.of('2026-06-29', 'Transfer', 'none', '', [
+      { account: 'Assets:Savings', amount: '500', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
+    ]);
     expect(transferAdapter.detect(draft)).toEqual({
       date: '2026-06-29',
       payee: 'Transfer',
@@ -48,27 +67,34 @@ describe('transferAdapter.detect', () => {
       currency: 'USD',
       from: 'Assets:Checking',
       to: 'Assets:Savings',
+      extraItems: [],
     });
   });
-  it('round-trips compile -> detect', () => {
+
+  it('round-trips compile -> detect with a fee', () => {
     const fields: TransferFields = {
       ...header,
       uid: undefined,
-      amount: '20',
+      amount: '500',
       currency: 'USD',
-      from: 'Assets:Cash',
-      to: 'Assets:Wallet',
+      from: 'Assets:Checking',
+      to: 'Assets:Savings',
+      extraItems: [
+        { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
+      ],
     };
     expect(
       transferAdapter.detect(transferAdapter.compile(fields, ctx))
     ).toEqual(fields);
   });
-  it('rejects an expense pair (one side is an expense)', () => {
+
+  it('rejects two positive destinations', () => {
     expect(
       transferAdapter.detect(
-        Transaction.of(draft.date, draft.payee, draft.status, draft.note, [
-          { account: 'Expenses:Groceries', amount: '42.50', currency: 'USD' },
-          { account: 'Assets:Checking', amount: '-42.50', currency: 'USD' },
+        Transaction.of('2026-06-29', 'x', 'none', '', [
+          { account: 'Assets:Savings', amount: '300', currency: 'USD' },
+          { account: 'Assets:Brokerage', amount: '200', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '-500', currency: 'USD' },
         ])
       )
     ).toBeNull();

--- a/features/transactions/entry/types/transfer.ts
+++ b/features/transactions/entry/types/transfer.ts
@@ -7,6 +7,14 @@ import {
   headerOf,
 } from './adapter';
 import { absAmount, negateAmount } from './amount';
+import {
+  type ExtraItem,
+  balancingPostings,
+  extraItemPostings,
+  singleAccount,
+  toExtraItems,
+} from './extraItems';
+import { computeBalance } from '@/lib/transactions/balance';
 import { Transaction } from '@/lib/transactions/model';
 
 export type TransferFields = HeaderFields & {
@@ -14,6 +22,7 @@ export type TransferFields = HeaderFields & {
   currency: string;
   from: string;
   to: string;
+  extraItems: ExtraItem[];
 };
 
 export const transferAdapter: TransactionTypeAdapter<TransferFields> = {
@@ -29,43 +38,62 @@ export const transferAdapter: TransactionTypeAdapter<TransferFields> = {
     currency: ctx.defaultCurrency,
     from: '',
     to: '',
+    extraItems: [],
   }),
-  compile: (f, _ctx): DraftState =>
-    Transaction.fromHeader(
-      {
-        date: f.date,
-        payee: f.payee,
-        status: f.status,
-        note: f.note,
-        uid: f.uid,
-      },
-      [
-        { account: f.to, amount: f.amount, currency: f.currency },
+  compile: (f, _ctx): DraftState => {
+    const header = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+    };
+    const to = { account: f.to, amount: f.amount, currency: f.currency };
+    const extras = extraItemPostings(f.extraItems);
+    if (extras.length === 0) {
+      return Transaction.fromHeader(header, [
+        to,
         {
           account: f.from,
           amount: negateAmount(f.amount),
           currency: f.currency,
         },
-      ]
-    ),
+      ]);
+    }
+    const items = [to, ...extras];
+    return Transaction.fromHeader(header, [
+      ...items,
+      ...balancingPostings(f.from, items),
+    ]);
+  },
   detect: (draft): TransferFields | null => {
-    if (draft.postings.length !== 2) return null;
-    if (draft.postings.some((p) => p.cost || p.assertion)) return null;
-    if (draft.postings.some((p) => classifyAccount(p.account) !== 'asset'))
+    const postings = draft.postings;
+    if (postings.length < 2) return null;
+    if (postings.some((p) => p.cost || p.assertion)) return null;
+    const assetPostings = postings.filter((p) => {
+      const role = classifyAccount(p.account);
+      return role === 'asset' || role === 'liability';
+    });
+    const expensePostings = postings.filter(
+      (p) => classifyAccount(p.account) === 'expense'
+    );
+    if (assetPostings.length + expensePostings.length !== postings.length)
       return null;
-    const [a, b] = draft.postings;
-    if (a.amount === '' || b.amount === '') return null;
-    if (a.currency !== b.currency) return null;
-    if (Math.abs(Number(a.amount) + Number(b.amount)) > 1e-9) return null;
-    const to = Number(a.amount) > 0 ? a : b;
-    const from = Number(a.amount) > 0 ? b : a;
-    if (!(Number(to.amount) > 0)) return null;
+    if (assetPostings.length < 2) return null;
+    if (computeBalance(postings).kind !== 'balanced') return null;
+    const positives = assetPostings.filter((p) => Number(p.amount) > 0);
+    const negatives = assetPostings.filter((p) => Number(p.amount) < 0);
+    if (positives.length !== 1) return null;
+    const to = positives[0];
+    const from = singleAccount(negatives);
+    if (!from || from === to.account) return null;
     return {
       ...headerOf(draft),
       amount: absAmount(to.amount),
       currency: to.currency,
-      from: from.account,
+      from,
       to: to.account,
+      extraItems: toExtraItems(expensePostings),
     };
   },
 };

--- a/features/transactions/entry/types/transfer.ts
+++ b/features/transactions/entry/types/transfer.ts
@@ -70,19 +70,26 @@ export const transferAdapter: TransactionTypeAdapter<TransferFields> = {
     const postings = draft.postings;
     if (postings.length < 2) return null;
     if (postings.some((p) => p.cost || p.assertion)) return null;
-    const assetPostings = postings.filter((p) => {
+    const assetOrLiabilityPostings = postings.filter((p) => {
       const role = classifyAccount(p.account);
       return role === 'asset' || role === 'liability';
     });
     const expensePostings = postings.filter(
       (p) => classifyAccount(p.account) === 'expense'
     );
-    if (assetPostings.length + expensePostings.length !== postings.length)
+    if (
+      assetOrLiabilityPostings.length + expensePostings.length !==
+      postings.length
+    )
       return null;
-    if (assetPostings.length < 2) return null;
+    if (assetOrLiabilityPostings.length < 2) return null;
     if (computeBalance(postings).kind !== 'balanced') return null;
-    const positives = assetPostings.filter((p) => Number(p.amount) > 0);
-    const negatives = assetPostings.filter((p) => Number(p.amount) < 0);
+    const positives = assetOrLiabilityPostings.filter(
+      (p) => Number(p.amount) > 0
+    );
+    const negatives = assetOrLiabilityPostings.filter(
+      (p) => Number(p.amount) < 0
+    );
     if (positives.length !== 1) return null;
     const to = positives[0];
     const from = singleAccount(negatives);


### PR DESCRIPTION
## What

Adds a dynamic **extra items** list to the four guided transaction-entry forms (Expense, Income, Transfer, Exchange), so a single transaction can carry an arbitrary number of extra postings — a tip on a meal, a shipping fee on a purchase, a broker fee on a trade, a processor cut on income. FixBalance is untouched.

Previously these guided forms compiled to exactly two postings; extra lines were only reachable by dropping to the Form/Raw lens.

## How

- **`types/extraItems.ts`** — shared helper: `ExtraItem`, `formatAmount`, `residualByCurrency`, `balancingPostings`, `extraItemPostings`, `toExtraItems`, `singleAccount`.
- **Each adapter** gains `extraItems: ExtraItem[]`. `compile` appends the extras and lets the form's absorbing account balance them — one posting per currency (handles the `@@` cost path for Exchange). `detect` recovers extras by partitioning postings by account role.
- **`ExtraItemsField.tsx`** — dynamic row component (account + amount + currency + remove; add button capped at `MAX_POSTINGS`), wired into all four forms.

### Multi-currency example (Expense)

```
Expenses:Dining   100 USD
Expenses:Tips      20 USD
Expenses:Fees       2 EUR
Assets:Checking  -120 USD
Assets:Checking    -2 EUR
```

## Invariants

- **Regression-safe:** when `extraItems` is empty, `compile` output is byte-identical to before (explicit empty-extras branch using the prior string form — computed absorbing postings never rewrite existing users' ledger output).
- **Deterministic detect:** returns null unless the whole draft balances, the absorbing account is a single account, and there are no stray account roles. Cross-type detection is locked in by tests (a transfer-with-fee stays Transfer, income-with-fee stays Income, etc.).

## Notes

- Type detection now recognizes plain asset↔liability 2-posting transactions (e.g. a credit-card payment) as **Transfer** — previously they fell through to the Form fallback. Non-destructive (round-trips identically); consistent with the Transfer/Income forms already offering liability accounts.
- Extra-item account picker is scoped to expense-role accounts (matching what `detect` recovers).

## Testing

- Full suite: **977/977** green; entry suite **130/130**; `tsc` and `eslint` clean.
- New coverage: helper functions, per-adapter compile/detect round-trips (incl. multi-currency and exchange cost), cross-type detection ordering, and the `ExtraItemsField` component.
