### PR TITLE
fix(entry): reset all lenses on "Save & add another"

### DIFF
--- a/features/transactions/entry/TransactionEntry.tsx
+++ b/features/transactions/entry/TransactionEntry.tsx
@@ -90,6 +90,11 @@ const TransactionEntry = ({
     mode === 'edit' && !detectType(draft) ? 'form' : orderedTabs[0]
   );
   const [rawError, setRawError] = useState<string | null>(null);
+  // Bumped by resetForm to remount the active lens. Each lens seeds local
+  // useState from the draft only at mount (RawLens text, TypeLens picked, the
+  // type forms' field state), so a plain draft replace leaves that state stale
+  // after "Save & add another". Remounting re-seeds it all from the fresh draft.
+  const [resetKey, setResetKey] = useState(0);
 
   const formRef = useRef<HTMLFormElement>(null);
   // Set by the "Save & add another" button so the success effect resets the
@@ -101,6 +106,8 @@ const TransactionEntry = ({
       type: 'replaceAll',
       state: initDraft({ date: todayISO() }, defaultCurrency),
     });
+    setRawError(null);
+    setResetKey((k) => k + 1);
   }, [defaultCurrency]);
 
   useEffect(() => {
@@ -177,6 +184,7 @@ const TransactionEntry = ({
 
           {active === 'types' && (
             <TypeLens
+              key={resetKey}
               draft={draft}
               dispatch={dispatch}
               accounts={accounts}
@@ -201,6 +209,7 @@ const TransactionEntry = ({
 
           {active === 'raw' && (
             <RawLens
+              key={resetKey}
               draft={draft}
               dispatch={dispatch}
               onError={setRawError}


### PR DESCRIPTION
## Problem

\"Save & add another\" only replaced the shared transaction draft. Each entry lens seeds its own local `useState` **at mount** from the draft and never re-syncs:

- `RawLens` — `text` + `error` (stale raw ledger text stayed on screen)
- `TypeLens` — `picked` (previously selected type chip stayed)
- each type form — `fields`; `ExtraItemsField` — `rowIds`

Only the stateless `FormLens` reset correctly. On the Raw or Types tab the visible fields kept the previous transaction's values while the submitted draft was actually empty — a confusing mismatch.

## Fix

Bump a `resetKey` in `resetForm` and key `TypeLens`/`RawLens` on it. The active lens remounts and re-seeds every local `useState` from the fresh draft in one stroke — covers raw text, type selection, and nested type-form/`ExtraItems` state. Also clears `rawError` on reset.

## Verification

- `tsc --noEmit` clean
- eslint clean
- 10/10 existing `TransactionEntry` tests pass

Interaction regression test omitted: the existing suite is static-render only (`renderToStaticMarkup`) and can't drive the `useActionState`-triggered reset effect.