### PR TITLE
fix(prices): show freshest price, default to ledger-valued view

### DIFF
--- a/app/prices/page.tsx
+++ b/app/prices/page.tsx
@@ -5,17 +5,20 @@ import { getBaseCurrency } from '@/lib/settings';
 
 export const dynamic = 'force-dynamic';
 
-type SearchParams = { base?: string };
+type SearchParams = { quote?: string };
 
 const PricesPage = async ({
   searchParams,
 }: {
   searchParams: Promise<SearchParams>;
 }) => {
-  const { base } = await searchParams;
-  // `base=base` is a mode flag ("value into the display currency"), not the
-  // currency code itself — the label and target both come from getBaseCurrency.
-  const baseMode = base === 'base';
+  const { quote } = await searchParams;
+  // Default view values every holding into the display currency through
+  // ledger's own price graph (`-X`), so the price shown is ledger's — freshest,
+  // bridged, identical to every balance report. `?quote=original` opts into the
+  // raw per-commodity journal quote instead. The label and valuation target
+  // both come from getBaseCurrency.
+  const baseMode = quote !== 'original';
   const user = await requireUser();
   // The display currency the user picked (session cookie → saved setting →
   // default), the same resolver every report page uses. Distinct from the USD

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -40,17 +40,17 @@ export const KnownPricesView = ({ rows, baseMode, baseCurrency }: Props) => (
       >
         <Link
           href="/prices"
-          aria-current={!baseMode ? 'page' : undefined}
-          className={segmentClass(!baseMode)}
-        >
-          Original quote
-        </Link>
-        <Link
-          href="/prices?base=base"
           aria-current={baseMode ? 'page' : undefined}
-          className={`${segmentClass(baseMode)} border-l border-border`}
+          className={segmentClass(baseMode)}
         >
           In {baseCurrency}
+        </Link>
+        <Link
+          href="/prices?quote=original"
+          aria-current={!baseMode ? 'page' : undefined}
+          className={`${segmentClass(!baseMode)} border-l border-border`}
+        >
+          Original quote
         </Link>
       </div>
     </div>

--- a/features/prices/KnownPricesView.tsx
+++ b/features/prices/KnownPricesView.tsx
@@ -5,15 +5,7 @@ import { TableScroll } from '@/components/ui/table';
 import type { KnownPrice } from '@/lib/prices';
 import Link from 'next/link';
 
-type Props = { rows: KnownPrice[]; baseMode: boolean; baseCurrency: string };
-
-const segmentClass = (active: boolean): string =>
-  [
-    'px-3 py-1.5 font-medium transition-opacity',
-    active
-      ? 'bg-accent text-accent-foreground'
-      : 'opacity-60 hover:opacity-100',
-  ].join(' ');
+type Props = { rows: KnownPrice[] };
 
 const sourceLabel: Record<KnownPrice['source'], string> = {
   fetched: 'Fetched',
@@ -30,30 +22,8 @@ const ageLabel = (row: KnownPrice): string => {
   return `${row.ageDays} days ago`;
 };
 
-export const KnownPricesView = ({ rows, baseMode, baseCurrency }: Props) => (
+export const KnownPricesView = ({ rows }: Props) => (
   <div className="space-y-3">
-    <div className="flex justify-end">
-      <div
-        role="group"
-        aria-label="Price currency"
-        className="inline-flex overflow-hidden rounded-md border border-border text-sm"
-      >
-        <Link
-          href="/prices"
-          aria-current={baseMode ? 'page' : undefined}
-          className={segmentClass(baseMode)}
-        >
-          In {baseCurrency}
-        </Link>
-        <Link
-          href="/prices?quote=original"
-          aria-current={!baseMode ? 'page' : undefined}
-          className={`${segmentClass(!baseMode)} border-l border-border`}
-        >
-          Original quote
-        </Link>
-      </div>
-    </div>
     <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
       <TableScroll bleed={false}>
         <table>

--- a/features/prices/PriceCurrencyToggle.tsx
+++ b/features/prices/PriceCurrencyToggle.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+type Props = { baseMode: boolean; baseCurrency: string };
+
+const segmentClass = (active: boolean): string =>
+  [
+    'px-3 py-1.5 font-medium transition-opacity',
+    active
+      ? 'bg-accent text-accent-foreground'
+      : 'opacity-60 hover:opacity-100',
+  ].join(' ');
+
+export const PriceCurrencyToggle = ({ baseMode, baseCurrency }: Props) => (
+  <div
+    role="group"
+    aria-label="Price currency"
+    className="inline-flex overflow-hidden rounded-md border border-border text-sm"
+  >
+    <Link
+      href="/prices"
+      aria-current={baseMode ? 'page' : undefined}
+      className={segmentClass(baseMode)}
+    >
+      In {baseCurrency}
+    </Link>
+    <Link
+      href="/prices?quote=original"
+      aria-current={!baseMode ? 'page' : undefined}
+      className={`${segmentClass(!baseMode)} border-l border-border`}
+    >
+      Original quote
+    </Link>
+  </div>
+);

--- a/features/prices/PricesTabs.tsx
+++ b/features/prices/PricesTabs.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { KnownPricesView } from './KnownPricesView';
+import { PriceCurrencyToggle } from './PriceCurrencyToggle';
 import { PricesView } from './PricesView';
 import type { ManualPrice } from '@/db/schema';
 import { TabBar } from '@/features/transactions/entry/TabBar';
@@ -31,16 +32,18 @@ export const PricesTabs = ({
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
-      <header>
+      <header className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold">Prices</h1>
+        {active === 'known' && (
+          <PriceCurrencyToggle
+            baseMode={baseMode}
+            baseCurrency={baseCurrency}
+          />
+        )}
       </header>
       <TabBar tabs={TABS} active={active} onSelect={setActive} />
       {active === 'known' ? (
-        <KnownPricesView
-          rows={known}
-          baseMode={baseMode}
-          baseCurrency={baseCurrency}
-        />
+        <KnownPricesView rows={known} />
       ) : (
         <>
           <p className="text-muted-foreground text-sm">

--- a/lib/prices/knownPrices.test.ts
+++ b/lib/prices/knownPrices.test.ts
@@ -196,6 +196,36 @@ describe('latestGenuinePrice', () => {
     });
   });
 
+  it('breaks a no-base tie on the more recently set price, not commodity order', () => {
+    // A commodity priced only in cross-quotes (no base run). ledger
+    // forward-carries every active quote onto the same last posting date, so
+    // both runs tie on `last.date`; the winner must be the one whose price was
+    // set most recently (`changeDate`), regardless of Map insertion order.
+    const staleThenFresh = [
+      { date: '2026-01-01', price: 100, quote: 'DAI' },
+      { date: '2026-07-09', price: 100, quote: 'DAI' },
+      { date: '2026-07-05', price: 90, quote: 'EUR' },
+      { date: '2026-07-09', price: 90, quote: 'EUR' },
+    ];
+    expect(latestGenuinePrice(staleThenFresh, 'USD')).toEqual({
+      date: '2026-07-05',
+      price: 90,
+      quote: 'EUR',
+    });
+    // Same points, quotes swapped in order — the pick stays the fresher EUR run.
+    const freshThenStale = [
+      { date: '2026-07-05', price: 90, quote: 'EUR' },
+      { date: '2026-07-09', price: 90, quote: 'EUR' },
+      { date: '2026-01-01', price: 100, quote: 'DAI' },
+      { date: '2026-07-09', price: 100, quote: 'DAI' },
+    ];
+    expect(latestGenuinePrice(freshThenStale, 'USD')).toEqual({
+      date: '2026-07-05',
+      price: 90,
+      quote: 'EUR',
+    });
+  });
+
   it('still returns a non-base quote when it is genuinely the freshest', () => {
     const points = [
       { date: '2026-07-01', price: 62000, quote: '$' },

--- a/lib/prices/knownPrices.test.ts
+++ b/lib/prices/knownPrices.test.ts
@@ -167,6 +167,46 @@ describe('latestGenuinePrice', () => {
       quote: '$',
     });
   });
+
+  it('prefers the freshest quote run over a stale one that sorts last', () => {
+    // Shape mirrors `ledger prices BTC`: a fresh `$` fetch series followed by a
+    // stale `DAI` cost-annotation run (which sorts last as a commodity). The
+    // final row is the stale DAI one, but the current price is the fresh `$`.
+    const points = [
+      { date: '2026-07-06', price: 64174, quote: '$' },
+      { date: '2026-07-09', price: 62513, quote: '$' },
+      { date: '2025-01-20', price: 107424, quote: 'DAI' },
+    ];
+    expect(latestGenuinePrice(points, 'USD')).toEqual({
+      date: '2026-07-09',
+      price: 62513,
+      quote: '$',
+    });
+  });
+
+  it('breaks an equal-newest-date tie in favour of the base quote', () => {
+    const points = [
+      { date: '2026-07-09', price: 100, quote: 'DAI' },
+      { date: '2026-07-09', price: 62513, quote: '$' },
+    ];
+    expect(latestGenuinePrice(points, 'USD')).toEqual({
+      date: '2026-07-09',
+      price: 62513,
+      quote: '$',
+    });
+  });
+
+  it('still returns a non-base quote when it is genuinely the freshest', () => {
+    const points = [
+      { date: '2026-07-01', price: 62000, quote: '$' },
+      { date: '2026-07-09', price: 100, quote: 'DAI' },
+    ];
+    expect(latestGenuinePrice(points, 'USD')).toEqual({
+      date: '2026-07-09',
+      price: 100,
+      quote: 'DAI',
+    });
+  });
 });
 
 describe('parseBaseBalance', () => {

--- a/lib/prices/knownPrices.ts
+++ b/lib/prices/knownPrices.ts
@@ -14,6 +14,11 @@ export const PRICES_FORMAT =
  * `account|quantity|commodity` line per probe holding. `quantity` is the
  * full-precision value, `commodity` is the currency it resolved to (the base
  * when a conversion path existed, otherwise the holding's own commodity).
+ *
+ * Note: ledger has no accessor for the date of the price it selected —
+ * `value_date` is the valuation "as of" date (today / `--now`), not when the
+ * price was set — so recency for a valued holding is dated separately, from the
+ * dated price directives `ledger prices` reports (see latestGenuinePrice).
  */
 export const BALANCE_BASE_FORMAT =
   '%(account)|%(quantity(scrub(display_total)))|%(commodity(scrub(display_total)))\n';
@@ -70,23 +75,68 @@ export const ageInDays = (dateIso: string, todayIso: string): number => {
 };
 
 /**
- * The current price and the date it last changed. `ledger prices` forward-
- * carries the prevailing price onto every posting date, so the final row's
- * date can be a transaction date rather than when the price was actually set.
- * Returns the last point's price/quote paired with the date the price value
- * last changed (the start of the final constant-price run), so staleness
- * reflects how long the current price has stood. Returns null for empty input.
+ * The current price and the date it last changed.
+ *
+ * `ledger prices <symbol>` emits one ascending-by-date run per quote commodity,
+ * concatenated commodity-by-commodity — so a holding priced in several quotes
+ * (e.g. a fresh `$` fetch series plus stray `@@ DAI` cost annotations from
+ * postings) yields multiple runs back to back, and the final row belongs to
+ * whichever quote sorts last, not to the most recent price. Taking `points`'
+ * last element therefore surfaced a stale cross-quote price over a fresh base
+ * one. Instead: collapse each quote to its current price, then pick the freshest
+ * run. On an equal newest date the base-quote run wins, so the canonical pricing
+ * currency is preferred over an incidental cross-rate.
+ *
+ * Each run's date is the start of its final constant-price stretch: `ledger`
+ * forward-carries the prevailing price onto every later posting date, so a price
+ * is dated from when its value last changed, not from a subsequent transaction —
+ * staleness then reflects how long the current price has actually stood.
+ *
+ * Returns null for empty input. `base` is optional so history-only callers that
+ * do not care about the tie-break can omit it.
  */
-export const latestGenuinePrice = (points: PricePoint[]): PricePoint | null => {
+export const latestGenuinePrice = (
+  points: PricePoint[],
+  base?: string
+): PricePoint | null => {
   if (points.length === 0) return null;
-  const last = points[points.length - 1];
-  let changeDate = points[0].date;
-  for (let index = 1; index < points.length; index += 1) {
-    if (points[index].price !== points[index - 1].price) {
-      changeDate = points[index].date;
+
+  const runsByQuote = new Map<string, PricePoint[]>();
+  for (const point of points) {
+    const run = runsByQuote.get(point.quote);
+    if (run) run.push(point);
+    else runsByQuote.set(point.quote, [point]);
+  }
+
+  const normalizedBase = base ? (normalizeCommoditySymbol(base) ?? base) : null;
+
+  let best: { current: PricePoint; lastDate: string; isBase: boolean } | null =
+    null;
+  for (const run of runsByQuote.values()) {
+    const last = run[run.length - 1];
+    let changeDate = run[0].date;
+    for (let index = 1; index < run.length; index += 1) {
+      if (run[index].price !== run[index - 1].price) {
+        changeDate = run[index].date;
+      }
+    }
+    const isBase =
+      normalizedBase !== null &&
+      (normalizeCommoditySymbol(last.quote) ?? last.quote) === normalizedBase;
+    if (
+      !best ||
+      last.date > best.lastDate ||
+      (last.date === best.lastDate && isBase && !best.isBase)
+    ) {
+      best = {
+        current: { date: changeDate, price: last.price, quote: last.quote },
+        lastDate: last.date,
+        isBase,
+      };
     }
   }
-  return { date: changeDate, price: last.price, quote: last.quote };
+
+  return best ? best.current : null;
 };
 
 /**

--- a/lib/prices/knownPrices.ts
+++ b/lib/prices/knownPrices.ts
@@ -85,7 +85,9 @@ export const ageInDays = (dateIso: string, todayIso: string): number => {
  * last element therefore surfaced a stale cross-quote price over a fresh base
  * one. Instead: collapse each quote to its current price, then pick the freshest
  * run. On an equal newest date the base-quote run wins, so the canonical pricing
- * currency is preferred over an incidental cross-rate.
+ * currency is preferred over an incidental cross-rate; between two non-base
+ * cross-quotes the more recently set price wins, so the tie stays deterministic
+ * rather than following ledger's commodity-sort order.
  *
  * Each run's date is the start of its final constant-price stretch: `ledger`
  * forward-carries the prevailing price onto every later posting date, so a price
@@ -110,8 +112,12 @@ export const latestGenuinePrice = (
 
   const normalizedBase = base ? (normalizeCommoditySymbol(base) ?? base) : null;
 
-  let best: { current: PricePoint; lastDate: string; isBase: boolean } | null =
-    null;
+  let best: {
+    current: PricePoint;
+    lastDate: string;
+    changeDate: string;
+    isBase: boolean;
+  } | null = null;
   for (const run of runsByQuote.values()) {
     const last = run[run.length - 1];
     let changeDate = run[0].date;
@@ -123,14 +129,21 @@ export const latestGenuinePrice = (
     const isBase =
       normalizedBase !== null &&
       (normalizeCommoditySymbol(last.quote) ?? last.quote) === normalizedBase;
+    // Runs are ranked by their forward-carried last date first (freshest run
+    // wins). On an equal last date the base quote is preferred; when neither is
+    // the base — a commodity priced only in cross-quotes — the tie falls to the
+    // more recently *set* price (`changeDate`), keeping the pick deterministic
+    // instead of dependent on ledger's commodity-sort insertion order.
     if (
       !best ||
       last.date > best.lastDate ||
-      (last.date === best.lastDate && isBase && !best.isBase)
+      (last.date === best.lastDate &&
+        (isBase !== best.isBase ? isBase : changeDate > best.changeDate))
     ) {
       best = {
         current: { date: changeDate, price: last.price, quote: last.quote },
         lastDate: last.date,
+        changeDate,
         isBase,
       };
     }

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -703,6 +703,34 @@ describe('PriceService.listKnownPrices', () => {
     expect(widget?.source).toBe('none');
   });
 
+  it('surfaces the fresh base-quote price over a stale cross-quote cost', async () => {
+    // Mirrors real data: BTC carries fresh `$` fetch prices plus a lone,
+    // stale `@@ DAI` cost annotation from an old posting. `ledger prices BTC`
+    // lists the DAI run last (DAI sorts after `$`), but the current price is
+    // the fresh dollar one — it must not be shadowed by the stale DAI figure.
+    await seedUser(
+      ctx,
+      'u-multiquote',
+      [
+        'P 2026-07-06 BTC $64174',
+        'P 2026-07-09 BTC $62513',
+        '2025-01-20 old buy',
+        '    Assets:Crypto   0.05 BTC @@ 5371.20 DAI',
+        '    Assets:Cash',
+        '2026-07-10 hold',
+        '    Assets:Crypto   1 BTC',
+        '    Equity        -1 BTC',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const rows = await service.listKnownPrices('u-multiquote');
+    const btc = rows.find((row) => row.symbol === 'BTC');
+    expect(btc?.price).toBe(62513);
+    expect(normalizeCommoditySymbol(btc?.quote ?? '')).toBe('USD');
+    expect(btc?.date).toBe('2026-07-09');
+  });
+
   it('dates staleness from when the price was set, not a later posting', async () => {
     await seedUser(
       ctx,
@@ -837,6 +865,36 @@ describe('PriceService.listKnownPricesInBase', () => {
     const btc = rows.find((row) => row.symbol === 'BTC');
     expect(btc?.price).toBeCloseTo(40000, 6);
     expect(btc?.quote).toBe('USD');
+  });
+
+  it('reports the fresh base valuation, dated from the raw base-quote row', async () => {
+    // Mirrors prod: BTC carries a fresh `$` fetch price plus a stale `@@ DAI`
+    // cost annotation. The base valuation reports the fresh price; its date and
+    // recency ride along from the raw base-quote row (freshest `$` run), so the
+    // row reads fresh — not stale from the 2025 cost. (Ledger exposes no date
+    // for the price it selected, so the date is sourced from `ledger prices`.)
+    await seedUser(
+      ctx,
+      'u-valuedate',
+      [
+        'P 2026-07-06 BTC $64174',
+        'P 2026-07-09 BTC $62513',
+        '2025-01-20 old buy',
+        '    Assets:Crypto   0.05 BTC @@ 5371.20 DAI',
+        '    Assets:Cash',
+        '2026-07-10 hold',
+        '    Assets:Crypto   1 BTC',
+        '    Equity        -1 BTC',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    const rows = await service.listKnownPricesInBase('u-valuedate', 'USD');
+    const btc = rows.find((row) => row.symbol === 'BTC');
+    expect(btc?.price).toBe(62513);
+    expect(btc?.quote).toBe('USD');
+    // Date is the freshest base-quote price date, not the stale 2025 DAI cost.
+    expect(btc?.date).toBe('2026-07-09');
   });
 
   it('values a digit-bearing ticker that ledger surfaces quoted', async () => {

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -560,7 +560,7 @@ export class PriceService {
         }
 
         const history = await this.listPriceHistory(userId, symbol);
-        const latest = latestGenuinePrice(history);
+        const latest = latestGenuinePrice(history, base);
 
         if (!latest) {
           return {
@@ -755,7 +755,9 @@ export class PriceService {
       const hit = index !== undefined ? valued.get(index) : undefined;
       // Ledger emits `$` for dollar-denominated legs even when `base` is the
       // string `USD`, so normalize before comparing — otherwise a genuinely
-      // convertible holding would be reported as having no price.
+      // convertible holding would be reported as having no price. Only the price
+      // is re-valued; date, staleness and provenance ride along from the raw
+      // base-quote row (ledger has no accessor for the selected price's date).
       return hit && normalizeCommoditySymbol(hit.commodity) === base
         ? { ...row, price: hit.price, quote: base }
         : { ...row, price: null, quote: null };


### PR DESCRIPTION
## Problem

The Known prices tab showed stale, wrong prices. BTC displayed **107,424 DAI dated 2025-01-20 (535 days · stale)** while a fresh fetched price (`$62,513`, 2026-07-09) sat ignored.

Two causes:

1. **`latestGenuinePrice` picked the wrong row.** `ledger prices <symbol>` emits one date-ascending run *per quote commodity*, concatenated. It grabbed `points[length-1]` — the last row, which belongs to whichever quote sorts last (here a lone `@@ DAI` cost annotation from a 2025 posting), not the most recent price. Ledger orders by commodity group, not global date; our code assumed "last printed = newest."
2. **The default view showed raw journal quotes.** The `?base=base` (ledger-valued) view existed but wasn't the default, so users saw our-picked directive prices instead of ledger's valuation.

## Fix

- **`latestGenuinePrice` is now quote-aware**: collapse each quote to its current price (keeping the forward-carry change-date logic per run), then pick the freshest run. Base quote wins an equal-date tie. The price value is still ledger's `P` directive verbatim — we only select which emitted row is current.
- **Default the Known prices view to the ledger-valued path** (`-X` into the display currency): the price shown is ledger's own valuation — freshest, bridged, identical to every balance report. `?quote=original` opts into the raw per-commodity journal quote. Toggle relabeled ("In {base}" default, "Original quote" secondary).

## Who computes what

| Piece | Source |
|---|---|
| Price value | Ledger — `-X` / `market()`, freshest + bridged |
| Price date + staleness | Ledger's dated `P` directives (`ledger prices`); our code selects the latest genuine run |

Ledger has **no** accessor for the date of the price it selected — `value_date` is the valuation as-of date (today / `--now`), not the set-date (verified: `--now=2027-01-01` moved `value_date` to 2027 while the price held). So price recency stays sourced from the dated directives.

## Verification

- Reproduced against prod data: BTC now values **62,523 DAI** (62,513 `$` bridged through the fresh `$`/DAI quote), dated 2026-07-09, source fetched, **not stale**.
- 138 prices tests pass; new coverage: quote-aware selection (3 unit), base tie-break, and an end-to-end case (fresh `$` beats stale `@@ DAI`) through real ledger.
- `tsc --noEmit` + eslint clean.