### PR TITLE
refactor(layout): shared PageContainer for consistent page layout

### DIFF
--- a/LEDGER-AUDIT.md
+++ b/LEDGER-AUDIT.md
@@ -1,0 +1,148 @@
+# Ledger Reimplementation Audit — 2026-07-10
+
+Full-codebase audit for application logic that reimplements in JS/TS what the
+`ledger` CLI can compute directly. Principle: **ledger does the accounting
+math; app code only orchestrates ledger, parses its output, and handles what
+ledger genuinely cannot (DB provenance, auth, formatting, HTTP).**
+
+Reference bug that motivated the audit (already fixed in PR #83):
+`lib/prices/knownPrices.ts` `latestGenuinePrice` + `lib/prices/service.ts`
+`listKnownPricesInBase` picked "latest price" by array position instead of
+asking ledger to value it.
+
+Scope: 856 TS/TSX files discovered; 205 excluded as stale `.claude/worktrees/`
+copies; the remaining **651 files all scanned** (18 domain buckets, zero
+overlap, zero unassigned). Every finding below was verified by actually
+running ledger 3.4.1 (`3.4.1-20251025`, Homebrew) against synthetic
+multi-commodity journals — commands and outputs, not memory. **Findings pass
+only — no fixes applied yet.**
+
+Result: **15 confirmed reimplementations** (3 high), **4 unavoidable
+selections** (documented, leave as-is), 2 scan claims refuted during
+verification.
+
+---
+
+## Confirmed reimplementation — act
+
+### High — transaction write/validation path can accept/reject data differently than ledger
+
+| # | Location | What JS computes | Verified ledger replacement | Risk |
+|---|----------|------------------|-----------------------------|------|
+| 1 | `lib/transactions/balance.ts:15` `computeBalance` | Full balancing algorithm: per-currency float sums, `@@` cost bridging, assertion-posting exclusion, `1e-9` epsilon | `ledger -f - balance` on the formatted draft; stderr `Unbalanced remainder is:` is the authoritative verdict (verified on stdin) | Verified two-way divergence: JS excludes assertion-only postings (`= USD 500`) that ledger treats as balance assignments; JS fixed epsilon vs ledger's per-commodity display precision — each side accepts drafts the other rejects |
+| 2 | `lib/transactions/schema.ts:111` `transactionDraftSchema` superRefine | Copy-pasted duplicate of #1, gating **server-side saves** | Ledger-backed validation before write (`lib/journal/service.ts` already shells out at :144/:383) | Same divergences as #1, at the exact point where data gets persisted |
+| 3 | `features/transactions/entry/types/extraItems.ts:47` `balancingPostings` | Sums the residual per currency in floats and writes explicit balancing amounts into the journal | Emit a single amount-less posting and let ledger elide it (verified: absorbs multi-commodity residuals and cost annotations; `fixBalanceAdapter` already does this) | A float-computed amount written to the journal can differ from the exact residual; ledger then rejects the transaction or reports an imbalance |
+
+Downstream consumers of #1 (same root cause, fix together):
+`features/transactions/entry/TransactionEntry.tsx:144` canSubmit gate,
+`features/transactions/entry/FormLens.tsx:214-243` BalanceIndicator residual
+display, and the adapters' `detect()` in `expense.ts:85` / `income.ts:91` /
+`transfer.ts:86` / `exchange.ts:102`.
+
+Caveat: these run client-side per keystroke where shelling out is impossible —
+keep the JS for instant feedback, but make a debounced server-side ledger
+check the authority for submit/save.
+
+### Medium — report/display values can diverge from ledger output
+
+| # | Location | What JS computes | Verified ledger replacement | Risk |
+|---|----------|------------------|-----------------------------|------|
+| 4 | `features/portfolio/parsePortfolio.ts:65` `extractTotal` | Grand total = last non-empty output line | `balance <prefix> -X CCY --depth 1 --format '%A\|%T\n'`, take the prefix-anchored row | Reproduced live: one unpriced commodity makes the Portfolio header show `100 XYZ` as the Total (USD) figure |
+| 5 | `lib/payees/parse.ts:16` `parsePayeeRows` (+ `app/api/payees/export/route.ts:23`, `features/payees/Payees.tsx:50` grandTotal) | Per-payee sums via float Map, filter > 0, sort descending | `reg ^Expenses --by-payee --collapse -X <base> --sort '-display_amount'` — verified: one converted row per payee, correct descending order, no adjustment contamination. **Do not use `-P` without `--collapse`: it segfaults (see gotchas)** | Float drift; `parseAmount`'s token-guessing coerces unexpected shapes to 0. Bonus bug: the `Commodities revalued` pseudo-payee is rendered as a real payee on the page and in the CSV export |
+| 6 | `features/dashboard/Dashboard.tsx:95` | Month/year expense totals = `lastNonEmptyLine` of a periodic register's `%T` column | `bal ^Expenses -p 'this month' -X <ccy> --collapse --format '%T\n'` (single-line output, verified; same for 'this year') | `%T` accumulates in processing order; `<Revalued>` rows plus the default `--sort -date` make last-row-position fragile |
+| 7 | `lib/monthly/csv.ts:22` `cashFlowRowsToCsv` + `features/monthlyComparison/MonthlyComparison.tsx:66` | `net = income − expenses` float subtraction over two separate ledger runs | A single register can emit per-month net, but it needs `--collapse` plus format-level negation — bare `--invert` emits per-account rows, and `--invert --collapse` double-counts on 3.4.1 | Cent-level float drift; a month whose amount fails to parse defaults to 0 silently; CSV and table code paths can diverge |
+| 8 | `lib/portfolio/csv.ts:16` `splitNative` | Regex re-decomposes a rendered amount string into (quantity, commodity) | `--format '%A\|%(quantity(scrub(display_total)))\|%(commodity(scrub(display_total)))\n'` (verified: emits `2335\|$`, `0.09\|BTC`, `5\|AAPL`) | The misparse reproduces on real production data — the price-db forces commodity-prefix rendering for BTC and KIRT |
+| 9 | `lib/prices/provider.ts:87` `fetchPricesUsd` | Fiat USD rate composed in JS via the tether pivot: `tetherUsd / perFiat` | Emit the raw quotes as two `P` directives (`P <date> USDT <tetherUsd> USD` and `P <date> USDT <perFiat> <FIAT>`) and let `-X USD` bridge (verified: identical valuation) | Low divergence risk in practice; but raw-quote storage changes the prices UI and manual-price-precedence data model — a design decision, not a drop-in |
+| 10 | `lib/transactions/model.ts:299` `magnitudesByCurrency` (rendered in `features/transactions/TransactionRowItem.tsx:38`) | Positive posting sums per currency, float addition + `toFixed(2)` | A register keyed on `xact.beg_line` reproduces the values (verified; the `tag("uid")` variant fails because `:uid:` is flag-tag syntax) | Display-only; skips elided-amount postings and `@@` costs, hardcodes 2 decimals |
+
+### Low — order/perf only, values already come from ledger
+
+| # | Location | Issue | Fix |
+|---|----------|-------|-----|
+| 11 | `features/reconcile/Reconcile.utils.ts:28` `parseReconcileRows` | `Reconcile.tsx` disables runLedger's sort (`sortByDate: false`) then re-sorts ascending in JS | Pass `--sort date` to the register call; delete the `.sort()` (keep the `days` computation — it needs wall-clock now) |
+| 12 | `features/monthlyComparison/MonthlyComparison.utils.ts:34` `getCashFlow` | JS income sign flip, fetch-all-history, `.slice(-36)` windowing | `--invert` on the income run + `-p 'last 36 months'`. Semantic note: `slice(-36)` keeps the last 36 months-with-data while `-p` is a calendar window — the calendar window is arguably the intended behavior |
+| 13 | `features/netWorth/NetWorth.tsx:29` | Fetch-all-history + `.slice(-36)` | `--display 'date>=[cutoff]'` — NOT `-b`: the `%T` running total must accumulate from journal start (verified identical values) |
+
+---
+
+## Unavoidable selection — leave, documented
+
+JS selecting among ledger's emitted rows where ledger has no single-answer
+query. Verified by attempting (and failing) the candidate replacements.
+
+- `features/dashboard/Dashboard.utils.ts:4` `getHighestExpense` — the obvious
+  replacement `--sort '-amount' --head 1` fails when actually run: `--head` is
+  a no-op under `--monthly` grouping, and `-amount` sorts pre-conversion
+  commodities. The JS max-scan stays.
+- `features/prices/PriceHistoryView.tsx:26` — `points.at(-1)?.quote` picks the
+  chart's quote commodity by array position — the exact shape of the reference
+  bug. No ledger query replaces it (`-V` returns the stale cross-quote,
+  verified), but it is actionable internally: reuse `latestGenuinePrice` so
+  `/prices` and `/prices/[symbol]` agree on the current quote.
+- `lib/prices/knownPrices.ts:100` `latestGenuinePrice` — the reference case
+  itself: the set-date and original-quote views genuinely need JS (ledger's
+  `value_date` is the report date, not the price's set-date — re-confirmed).
+  Consider shrinking its authority to date/staleness and original-quote
+  display only. Side note: the comment at lines 92–95 claims `ledger prices`
+  forward-carries the prevailing price onto later posting dates; this did not
+  reproduce in a direct test.
+- `lib/settings/parseUnconverted.ts:27` — both candidate single-query
+  replacements fail on 3.4.1: `--format '%(commodity(display_total))'` errors
+  with `Cannot convert a balance with multiple commodities to an amount`, and
+  the alternative errors outright on journals with @-cost postings. Keep the
+  regex row-selection.
+
+---
+
+## Refuted during verification
+
+- Payees via `reg ^Expenses -P -X <base>`: **segfaults ledger
+  3.4.1-20251025** (exit 139, reproduced repeatedly on multi-commodity
+  journals; `runLedger` uses `execFile`, so this would be a production error).
+  The `--by-payee --collapse` variant works cleanly, which is why finding #5
+  survives with that command. The `%T`-based grandTotal variant was only
+  tested on the crashing command; with `--collapse` a trivial sum of the
+  displayed rows (presentation) or a `%T` third column both remain options.
+
+---
+
+## Ledger 3.4.1 gotchas discovered (all verified)
+
+- `reg -P -X <ccy>` segfaults on multi-commodity journals; adding
+  `--collapse` avoids the crash.
+- `--sort '-amount'` under `-X` compares pre-conversion commodities; use
+  `--sort '-display_amount'` to rank by the converted value.
+- `--head` is a no-op under `--monthly` grouping.
+- `ledger print` does **not** materialize elided amounts (with or without
+  `--explicit`); only register formats expose the generated postings.
+- `--invert --collapse` double-counts on grouped registers.
+
+---
+
+## Coverage
+
+856 TS/TSX files discovered → 205 excluded (stale `.claude/worktrees/`
+copies) → 651 partitioned into 18 buckets → **651 scanned = 651 in scope**.
+447 files were logged skipped-with-reason inside their buckets (pure
+presentational, type-only, test, static config) but each was individually
+accounted for. Test files were read for intent only; all findings target
+production code.
+
+| Bucket | Files | Findings | Bucket | Files | Findings |
+|---|---|---|---|---|---|
+| prices | 47 | 3 | accounts-payees | 40 | 3 |
+| settings | 54 | 1 | components-misc | 40 | 0 |
+| transactions-feature-1 | 42 | 3 | savedviews-currencies | 39 | 0 |
+| transactions-feature-2 | 41 | 3 | transactions-lib | 39 | 3 |
+| storage-db-audit | 41 | 0 | auth-security | 38 | 0 |
+| reports-balances | 37 | 7 | journal-core | 36 | 0 |
+| crypto-lib | 34 | 0 | crypto-portfolio | 33 | 2 |
+| utils-lib-misc | 31 | 0 | api-routes-app | 26 | 1 |
+| components-ui | 24 | 0 | misc-root | 9 | 0 |
+
+26 raw findings → 25 after cross-bucket dedup → all 25 adversarially verified
+with real ledger runs (none dropped by the verification cap).
+
+**Biggest single win: the transaction-balancing trio (#1–#3) — one root
+cause, three sites, and the only cluster where divergence corrupts what gets
+written rather than what gets displayed.**

--- a/app/accounts/[account]/page.tsx
+++ b/app/accounts/[account]/page.tsx
@@ -1,3 +1,4 @@
+import PageContainer from '@/components/PageContainer';
 import { TableScroll } from '@/components/ui/table';
 import AccountHeader from '@/features/accounts/AccountHeader';
 import { requireUser } from '@/lib/auth/require-user';
@@ -34,7 +35,7 @@ const Account = async ({
     .reverse()
     .map((result) => result.split('|').map((each) => each.trim()));
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <AccountHeader
         account={account}
         balance={balance}
@@ -131,7 +132,7 @@ const Account = async ({
           </table>
         </TableScroll>
       </div>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/app/balance/[from]/[to]/page.tsx
+++ b/app/balance/[from]/[to]/page.tsx
@@ -2,6 +2,7 @@ import Chart from '@/components/Chart';
 import DateFilter from '@/components/DateFilter';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { Card, CardContent } from '@/components/ui/card';
 import SaveViewButton from '@/features/savedViews/SaveViewButton';
 import { requireUser } from '@/lib/auth/require-user';
@@ -50,7 +51,7 @@ const PeriodBalance = async ({
       ?.split('|')[2] ?? '';
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">
@@ -166,7 +167,7 @@ const PeriodBalance = async ({
           </CardContent>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/app/balance/page.tsx
+++ b/app/balance/page.tsx
@@ -1,5 +1,6 @@
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { Card } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
 import { parseBalanceRows } from '@/lib/balance/parse';
@@ -25,7 +26,7 @@ const Balance = async () => {
     .filter((r) => r.account !== 'Total')
     .map((r) => `${r.account}|${r.amount}`);
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -98,7 +99,7 @@ const Balance = async () => {
           </table>
         </TableScroll>
       </Card>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -1,5 +1,6 @@
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { TableScroll } from '@/components/ui/table';
 import { getBaseCurrency } from '@/lib/settings';
 import formatAmount from '@/utils/formatAmount';
@@ -20,7 +21,7 @@ const Debts = async () => {
   const total = allDebts[allDebts.length - 1] ?? '';
   const debts = allDebts.slice(1, allDebts.length - 1);
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -91,7 +92,7 @@ const Debts = async () => {
           </table>
         </TableScroll>
       </div>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -79,7 +80,7 @@ export default function ImportPage() {
   };
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">
@@ -161,6 +162,6 @@ export default function ImportPage() {
           </li>
         </ul>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/registers/monthly/[account]/page.tsx
+++ b/app/registers/monthly/[account]/page.tsx
@@ -1,4 +1,5 @@
 import Chart from '@/components/Chart';
+import PageContainer from '@/components/PageContainer';
 import { Card, CardContent } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
 import RegisterHeader from '@/features/registers/monthly/RegisterHeader';
@@ -41,7 +42,7 @@ const Monthly = async ({
   ]);
   const results = stdout.split('NNN').filter(Boolean);
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <RegisterHeader
         account={account}
         balance={balance}
@@ -115,7 +116,7 @@ const Monthly = async ({
           </CardContent>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/app/settings/activity/page.tsx
+++ b/app/settings/activity/page.tsx
@@ -1,4 +1,3 @@
-import PageContainer from '@/components/PageContainer';
 import { ActivityList } from '@/features/activity';
 import {
   ACTIVITY_PAGE_SIZE,
@@ -36,14 +35,12 @@ const ActivityPage = async ({
     hasMore && page.length > 0 ? encodeCursor(page[page.length - 1]) : null;
 
   return (
-    <PageContainer>
-      <ActivityList
-        rows={page}
-        type={type}
-        result={result}
-        nextCursor={nextCursor}
-      />
-    </PageContainer>
+    <ActivityList
+      rows={page}
+      type={type}
+      result={result}
+      nextCursor={nextCursor}
+    />
   );
 };
 

--- a/app/settings/activity/page.tsx
+++ b/app/settings/activity/page.tsx
@@ -1,3 +1,4 @@
+import PageContainer from '@/components/PageContainer';
 import { ActivityList } from '@/features/activity';
 import {
   ACTIVITY_PAGE_SIZE,
@@ -35,12 +36,14 @@ const ActivityPage = async ({
     hasMore && page.length > 0 ? encodeCursor(page[page.length - 1]) : null;
 
   return (
-    <ActivityList
-      rows={page}
-      type={type}
-      result={result}
-      nextCursor={nextCursor}
-    />
+    <PageContainer>
+      <ActivityList
+        rows={page}
+        type={type}
+        result={result}
+        nextCursor={nextCursor}
+      />
+    </PageContainer>
   );
 };
 

--- a/app/settings/passkeys/page.tsx
+++ b/app/settings/passkeys/page.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import PageContainer from '@/components/PageContainer';
 import { authClient } from '@/lib/auth-client';
 import { PasskeyManagerPage } from '@naeemba/next-starter/pages/passkey-manager';
 
 export default function Page() {
-  return <PasskeyManagerPage authClient={authClient} />;
+  return (
+    <PageContainer>
+      <PasskeyManagerPage authClient={authClient} />
+    </PageContainer>
+  );
 }

--- a/components/PageContainer/PageContainer.tsx
+++ b/components/PageContainer/PageContainer.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils';
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+// Standardizes the vertical rhythm of a page's content stack so every app page
+// lays out identically. Width, horizontal padding, and top/bottom padding are
+// owned by AppShell's content column — deliberately absent here so pages cannot
+// diverge on those. `className` is an escape hatch for a genuine per-page need.
+const PageContainer = ({ children, className }: Props) => (
+  <div className={cn('flex flex-col gap-6', className)}>{children}</div>
+);
+
+export default PageContainer;

--- a/components/PageContainer/index.ts
+++ b/components/PageContainer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PageContainer';

--- a/docs/superpowers/specs/2026-07-10-page-container-design.md
+++ b/docs/superpowers/specs/2026-07-10-page-container-design.md
@@ -1,0 +1,100 @@
+# PageContainer — consistent page layout
+
+**Date:** 2026-07-10
+**Status:** Approved, pending implementation
+
+## Problem
+
+App pages render at inconsistent widths and vertical rhythm. Prices and
+price-history look narrow and re-centered; currencies is double-padded; reports
+fill the full column; dashboard uses a different gap than everything else.
+
+The outer column is **already** consistent: `AppShell` wraps every non-bare
+page in `mx-auto w-full max-w-7xl px-4 pt-8 pb-…` (`components/AppShell/AppShell.tsx:54`).
+Width is single-source there. The divergence comes entirely from feature roots
+layering their own wrappers on top of that column:
+
+| Page(s) | Ad-hoc outer wrapper | Problem |
+| --- | --- | --- |
+| prices, price-history | `mx-auto w-full max-w-3xl space-y-6 p-4` | re-narrows, re-centers, doubles padding |
+| currencies | `space-y-6 p-4 sm:p-6` | doubles padding |
+| netWorth, monthly, transactions, reconcile, payees, portfolio | `flex flex-col gap-6` | fine, but ad-hoc/duplicated |
+| dashboard | `flex flex-col gap-8` | different vertical rhythm |
+| balance, debts, payees, import | inline in `page.tsx` | no shared wrapper |
+
+## Solution
+
+One shared wrapper component every app page renders its content into. It owns
+**only** the page-content rhythm; width and padding stay owned by `AppShell` so
+they cannot diverge.
+
+### Component
+
+`components/PageContainer/PageContainer.tsx`
+
+```tsx
+import { cn } from '@/lib/utils';
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const PageContainer = ({ children, className }: Props) => (
+  <div className={cn('flex flex-col gap-6', className)}>{children}</div>
+);
+
+export default PageContainer;
+```
+
+- Canonical vertical rhythm: `gap-6` (the majority value). Dashboard's `gap-8`
+  and the `space-y-6` variants collapse into it.
+- **No** `max-w-*`, **no** `mx-auto`, **no** `p-*`. Width, horizontal padding,
+  and top/bottom padding remain in `AppShell`. This is what makes every page
+  identical.
+- `className` passthrough is the only escape hatch, for a genuine per-page need.
+- Barrel `components/PageContainer/index.ts` re-exporting default, matching the
+  existing `components/AppShell` folder convention.
+
+### Rollout
+
+Replace each page's ad-hoc outer wrapper with `<PageContainer>`; do not nest a
+`PageContainer` inside another. Prefer editing the feature root component (so
+nested subroutes reusing it inherit the wrapper); for pages that compose inline
+in `page.tsx`, wrap there.
+
+**24 app routes in scope:**
+
+accounts, accounts/[account], balance, balance/[from]/[to], currencies,
+dashboard, debts, import, monthly, net-worth, payees, payees/[from]/[to],
+portfolio, prices, prices/[symbol], reconcile, registers/monthly/[account],
+settings, settings/activity, settings/passkeys, templates, transactions,
+transactions/new, transactions/[uid]/edit.
+
+Per page: strip `max-w-*`, `mx-auto`, and page-level `p-*`/`sm:p-*` from the
+outer wrapper (they duplicate AppShell); fold whatever vertical spacing it used
+(`gap-8`, `space-y-6`) into PageContainer's `gap-6`.
+
+### Excluded — bare pages
+
+AppShell returns these without sidebar/header chrome; they own full-bleed
+layouts and must NOT get PageContainer:
+
+`/`, `/account/deleted`, `/sign-in`, `/sign-in/error`, `/sign-up`,
+`/crypto/setup`, `/crypto/unlock`
+
+(Source of truth: `AUTH_PATHS`, `CRYPTO_PATHS`, `PUBLIC_PATHS` in
+`components/AppShell/`.)
+
+## Non-goals
+
+- No page-title/header ownership. Each page keeps rendering its own `<h1>`.
+  (Title-size inconsistency is a separate follow-up.)
+- No change to `AppShell`'s outer column, banner slot, or bare-path logic.
+- No new width variants (uniform `max-w-7xl` for all).
+
+## Verification
+
+- `pnpm lint` and `pnpm build` clean.
+- Visual: a wide page (balance) and a former-narrow page (prices) render at the
+  same width with the same vertical rhythm; no double padding on currencies.

--- a/features/accounts/Accounts.tsx
+++ b/features/accounts/Accounts.tsx
@@ -2,6 +2,7 @@ import AccountsView from './AccountsView';
 import { buildAccountTree, countLeaves } from './accountTree';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { parseBalanceRows, type BalanceRow } from '@/lib/balance/parse';
 import { getBaseCurrency } from '@/lib/settings';
 import runLedger from '@/utils/runLedger';
@@ -31,7 +32,7 @@ const Accounts = async () => {
   const leafCount = countLeaves(buildAccountTree(rows));
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">Accounts</h1>
@@ -50,7 +51,7 @@ const Accounts = async () => {
         </p>
       </div>
       <AccountsView rows={rows} />
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/activity/ActivityList.tsx
+++ b/features/activity/ActivityList.tsx
@@ -1,5 +1,6 @@
 import ActivityRow from './ActivityRow';
 import { buildActivityQuery } from './params';
+import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import type { AuditLog } from '@/db/schema/auditLog';
 import type { ActivityType, ResultFilter } from '@/lib/audit';
@@ -54,7 +55,7 @@ const ActivityList = ({
   result: ResultFilter;
   nextCursor: string | null;
 }) => (
-  <div className="flex flex-col gap-6">
+  <PageContainer>
     <h1 className="text-2xl font-semibold">Activity</h1>
 
     <div className="flex flex-col gap-3">
@@ -94,7 +95,7 @@ const ActivityList = ({
         Load older
       </Link>
     )}
-  </div>
+  </PageContainer>
 );
 
 export default ActivityList;

--- a/features/currencies/CurrenciesView.tsx
+++ b/features/currencies/CurrenciesView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import CommodityCombobox from '@/components/CommodityCombobox/CommodityCombobox';
+import PageContainer from '@/components/PageContainer';
 import { TableScroll } from '@/components/ui/table';
 import {
   upsertMappingAction,
@@ -73,7 +74,7 @@ export default function CurrenciesView({ rows: initial }: Props) {
   };
 
   return (
-    <div className="space-y-6 p-4 sm:p-6">
+    <PageContainer>
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold">Currencies</h1>
         <p className="text-muted-foreground text-sm">
@@ -170,6 +171,6 @@ export default function CurrenciesView({ rows: initial }: Props) {
           </tbody>
         </table>
       </TableScroll>
-    </div>
+    </PageContainer>
   );
 }

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import EmptyJournal from './EmptyJournal';
 import SavedViewsCard from './SavedViewsCard';
 import Card from '@/components/Card';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import { Card as ShadcnCard } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
@@ -107,7 +108,7 @@ const Dashboard = async () => {
   }
 
   return (
-    <div className="flex flex-col gap-8">
+    <PageContainer>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
@@ -256,7 +257,7 @@ const Dashboard = async () => {
           <Stat label="Days since last" value={stats.daysSinceLast} />
         </ShadcnCard>
       </section>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/monthlyComparison/MonthlyComparison.tsx
+++ b/features/monthlyComparison/MonthlyComparison.tsx
@@ -2,6 +2,7 @@ import { getCashFlow } from './MonthlyComparison.utils';
 import Chart from '@/components/Chart';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { Card, CardContent } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
 import { getBaseCurrency } from '@/lib/settings';
@@ -18,7 +19,7 @@ const MonthlyComparison = async () => {
   const rows = await getCashFlow(currency);
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">Cash Flow</h1>
@@ -121,7 +122,7 @@ const MonthlyComparison = async () => {
           </CardContent>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/netWorth/NetWorth.tsx
+++ b/features/netWorth/NetWorth.tsx
@@ -1,6 +1,7 @@
 import Chart from '@/components/Chart';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { Card, CardContent } from '@/components/ui/card';
 import { parseNetWorthRows } from '@/lib/netWorth/parse';
 import { getBaseCurrency } from '@/lib/settings';
@@ -40,7 +41,7 @@ const NetWorth = async () => {
   const latest = rawAmounts[rawAmounts.length - 1] ?? '';
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -91,7 +92,7 @@ const NetWorth = async () => {
           )}
         </CardContent>
       </Card>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/payees/Payees.tsx
+++ b/features/payees/Payees.tsx
@@ -2,6 +2,7 @@ import Chart from '@/components/Chart';
 import DateFilter from '@/components/DateFilter';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { Card, CardContent } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
 import SaveViewButton from '@/features/savedViews/SaveViewButton';
@@ -50,7 +51,7 @@ const Payees = async ({ from: fromParam, to: toParam }: Props) => {
   const grandTotal = sorted.reduce((acc, r) => acc + r.total, 0);
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -151,7 +152,7 @@ const Payees = async ({ from: fromParam, to: toParam }: Props) => {
           </CardContent>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/portfolio/Portfolio.tsx
+++ b/features/portfolio/Portfolio.tsx
@@ -9,6 +9,7 @@ import {
 } from './parsePortfolio';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
@@ -78,7 +79,7 @@ const Portfolio = async () => {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <header className="flex flex-col gap-2">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
@@ -152,7 +153,7 @@ const Portfolio = async () => {
           </table>
         </TableScroll>
       </Card>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/prices/PriceHistoryView.tsx
+++ b/features/prices/PriceHistoryView.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import { priceFormatter } from './format.util';
+import PageContainer from '@/components/PageContainer';
 import { TableScroll } from '@/components/ui/table';
 import type { PricePoint } from '@/lib/prices';
 import { normalizeCommoditySymbol } from '@/lib/prices/symbols';
@@ -26,7 +27,7 @@ export const PriceHistoryView = ({ symbol, points }: Props) => {
   const quote = displayQuote(points.at(-1)?.quote ?? '');
 
   return (
-    <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
+    <PageContainer>
       <header className="space-y-1">
         <Link
           href="/prices"
@@ -108,6 +109,6 @@ export const PriceHistoryView = ({ symbol, points }: Props) => {
           </div>
         </>
       )}
-    </div>
+    </PageContainer>
   );
 };

--- a/features/prices/PricesTabs.tsx
+++ b/features/prices/PricesTabs.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { KnownPricesView } from './KnownPricesView';
 import { PriceCurrencyToggle } from './PriceCurrencyToggle';
 import { PricesView } from './PricesView';
+import PageContainer from '@/components/PageContainer';
 import type { ManualPrice } from '@/db/schema';
 import { TabBar } from '@/features/transactions/entry/TabBar';
 import type { KnownPrice } from '@/lib/prices';
@@ -31,7 +32,7 @@ export const PricesTabs = ({
   const [active, setActive] = useState('known');
 
   return (
-    <div className="mx-auto w-full max-w-3xl space-y-6 p-4">
+    <PageContainer>
       <header className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold">Prices</h1>
         {active === 'known' && (
@@ -58,6 +59,6 @@ export const PricesTabs = ({
           />
         </>
       )}
-    </div>
+    </PageContainer>
   );
 };

--- a/features/reconcile/Reconcile.tsx
+++ b/features/reconcile/Reconcile.tsx
@@ -1,6 +1,7 @@
 import { parseReconcileRows } from './Reconcile.utils';
 import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { getBaseCurrency } from '@/lib/settings';
 import formatAmount from '@/utils/formatAmount';
 import formatDate, { Format } from '@/utils/formatDate';
@@ -21,7 +22,7 @@ const Reconcile = async () => {
   const stale = rows.filter((r) => r.days > STALE_DAYS).length;
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -96,7 +97,7 @@ const Reconcile = async () => {
           </tbody>
         </table>
       </div>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/settings/Settings.tsx
+++ b/features/settings/Settings.tsx
@@ -3,6 +3,7 @@ import DangerZone from './DangerZone';
 import EntryTabOrderForm from './EntryTabOrderForm';
 import SecuritySection from './SecuritySection';
 import { clearSessionBaseCurrencyAction } from './actions';
+import PageContainer from '@/components/PageContainer';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -34,7 +35,7 @@ const Settings = ({
     (savedDefault === null && base !== envFallback);
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <h1 className="text-2xl font-semibold">Settings</h1>
 
       <Card>
@@ -82,7 +83,7 @@ const Settings = ({
       <ActivityCard rows={recentActivity} />
 
       <DangerZone />
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/templates/Templates.tsx
+++ b/features/templates/Templates.tsx
@@ -1,6 +1,7 @@
 import 'server-only';
 import TemplatesList from './TemplatesList';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import { requireUser } from '@/lib/auth/require-user';
 import { templateRepository } from '@/lib/templates';
@@ -12,7 +13,7 @@ const Templates = async () => {
   const templates = await templateRepository.list(user.id);
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <header className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold">Templates</h1>
@@ -29,7 +30,7 @@ const Templates = async () => {
         </Link>
       </header>
       <TemplatesList templates={templates} />
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/transactions/EditTransaction.tsx
+++ b/features/transactions/EditTransaction.tsx
@@ -2,6 +2,7 @@ import 'server-only';
 import { updateTransactionAction } from './actions';
 import TransactionEntry from './entry/TransactionEntry';
 import { getAccountBalance } from './entry/actions/getAccountBalance';
+import PageContainer from '@/components/PageContainer';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
 import { getAvailableCurrencies, getEntryTabOrder } from '@/lib/settings';
@@ -32,7 +33,7 @@ const EditTransaction = async ({ uid }: { uid: string }) => {
   ]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <PageContainer>
       <h1 className="text-2xl font-semibold">Edit transaction</h1>
       <TransactionEntry
         mode="edit"
@@ -47,7 +48,7 @@ const EditTransaction = async ({ uid }: { uid: string }) => {
         tabOrder={tabOrder}
         getAccountBalance={getAccountBalance}
       />
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/transactions/NewTransaction.tsx
+++ b/features/transactions/NewTransaction.tsx
@@ -2,6 +2,7 @@ import { createTransactionAction } from './actions';
 import TransactionEntry from './entry/TransactionEntry';
 import { getAccountBalance } from './entry/actions/getAccountBalance';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import TemplatePicker from '@/features/templates/TemplatePicker';
 import { requireUser } from '@/lib/auth/require-user';
 import { getAvailableCurrencies, getEntryTabOrder } from '@/lib/settings';
@@ -44,7 +45,7 @@ const NewTransaction = async ({ templateId }: Props) => {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <div>
         <div className="flex items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">
@@ -75,7 +76,7 @@ const NewTransaction = async ({ templateId }: Props) => {
         initialDraft={initialDraft}
         templateMissing={templateMissing}
       />
-    </div>
+    </PageContainer>
   );
 };
 

--- a/features/transactions/Transactions.tsx
+++ b/features/transactions/Transactions.tsx
@@ -6,6 +6,7 @@ import { type TransactionFilters } from './applyTransactionFilters';
 import { loadJournalTransactions } from './loadJournalTransactions';
 import { PAGE_SIZE, pageTransactions } from './pageTransactions';
 import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
 import { requireUser } from '@/lib/auth/require-user';
 import { savedViewService } from '@/lib/savedViews';
 
@@ -27,7 +28,7 @@ const Transactions = async ({
   ].sort();
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageContainer>
       <header className="flex items-center gap-2">
         <h1 className="text-2xl font-semibold">Transactions</h1>
         <Help label="About transactions">
@@ -48,7 +49,7 @@ const Transactions = async ({
         initialNextOffset={firstPage.nextOffset}
         filters={params}
       />
-    </div>
+    </PageContainer>
   );
 };
 


### PR DESCRIPTION
## Summary

Every app page now renders its content through a single `PageContainer` wrapper, so layouts are consistent instead of some pages centered/narrow and others full-width.

**Root cause:** `AppShell` already frames all app pages in one `max-w-7xl` column with consistent padding. The inconsistency came entirely from feature roots layering their own divergent wrappers on top:
- prices / price-history: `mx-auto w-full max-w-3xl space-y-6 p-4` → re-narrowed + re-centered + double padding
- currencies: `space-y-6 p-4 sm:p-6` → double padding
- dashboard: `flex flex-col gap-8` → different vertical rhythm

## Changes

- New `components/PageContainer` — owns only the page content stack's vertical rhythm (`flex flex-col gap-6`). Width, horizontal padding, and top/bottom padding stay owned by `AppShell` so pages cannot diverge on them. `className` passthrough is the only escape hatch.
- Rolled out across **23 app routes**, replacing each ad-hoc outer wrapper with `PageContainer`.
- **Bare pages excluded** (auth, crypto, landing, account/deleted) — `AppShell` renders those full-bleed with no sidebar chrome.
- Design spec: `docs/superpowers/specs/2026-07-10-page-container-design.md`.

Also includes an unrelated docs-only commit (`LEDGER-AUDIT.md`) — a ledger-reimplementation audit, findings only, no code changes.

## Verification

- `pnpm lint` — 0 errors (1 pre-existing unrelated warning in `TransactionList.tsx`)
- `tsc --noEmit` — clean
- `pnpm build` not run locally: prebuild `migrate` step needs `DATABASE_URL`, unavailable in this environment