### PR TITLE
feat(prices): price fiat through ledger via Tether pivot (audit #9)

### DIFF
--- a/LEDGER-AUDIT.md
+++ b/LEDGER-AUDIT.md
@@ -30,20 +30,16 @@ ledger replacements verified against ledger 3.4.1 on synthetic journals)·
 ⏸️ deferred (needs a design decision or carries risk out of proportion to
 payoff — left for a deliberate follow-up).
 
-**Fixed (8):** #4 portfolio total · #5 payees · #6 dashboard month/year ·
-#7 cash-flow net · #8 portfolio CSV split · #11 reconcile sort ·
-#12 cash-flow window/sign · #13 net-worth window.
+**Fixed (9):** #4 portfolio total · #5 payees · #6 dashboard month/year ·
+#7 cash-flow net · #8 portfolio CSV split · #9 fiat-USD pivot ·
+#11 reconcile sort · #12 cash-flow window/sign · #13 net-worth window.
 
-**Deferred (5), with reasons:**
+**Deferred (4), with reasons:**
 
 - **#1–#3 (the balancing trio, high).** The correct fix is a debounced
   *server-side* ledger check that becomes the authority for submit/save while
   the JS stays for instant per-keystroke feedback — a feature with its own
   UX/latency design, not a mechanical swap. Left intact pending that design.
-- **#9 fiat-USD pivot.** The audit itself calls the raw-two-`P`-directive
-  approach "a design decision, not a drop-in": it changes the prices UI and
-  the manual-price-precedence data model, for "low divergence risk in
-  practice". Not worth a unilateral product change; needs the owner's call.
 - **#10 transaction magnitudes.** The whole transactions list is JS-parsed
   (`parseJournalFile`) — ledger is not in that path at all. A register
   replacement means a new ledger run joined back on `(file, beg_line)`, with
@@ -84,7 +80,7 @@ check the authority for submit/save.
 | 6 ✅ | `features/dashboard/Dashboard.tsx:95` | Month/year expense totals = `lastNonEmptyLine` of a periodic register's `%T` column | `bal ^Expenses -p 'this month' -X <ccy> --collapse --format '%T\n'` (single-line output, verified; same for 'this year') | `%T` accumulates in processing order; `<Revalued>` rows plus the default `--sort -date` make last-row-position fragile |
 | 7 ✅ | `lib/monthly/csv.ts:22` `cashFlowRowsToCsv` + `features/monthlyComparison/MonthlyComparison.tsx:66` | `net = income − expenses` float subtraction over two separate ledger runs | A single register can emit per-month net, but it needs `--collapse` plus format-level negation — bare `--invert` emits per-account rows, and `--invert --collapse` double-counts on 3.4.1 | Cent-level float drift; a month whose amount fails to parse defaults to 0 silently; CSV and table code paths can diverge |
 | 8 ✅ | `lib/portfolio/csv.ts:16` `splitNative` | Regex re-decomposes a rendered amount string into (quantity, commodity) | `--format '%A\|%(quantity(scrub(display_total)))\|%(commodity(scrub(display_total)))\n'` (verified: emits `2335\|$`, `0.09\|BTC`, `5\|AAPL`) | The misparse reproduces on real production data — the price-db forces commodity-prefix rendering for BTC and KIRT |
-| 9 ⏸️ | `lib/prices/provider.ts:87` `fetchPricesUsd` | Fiat USD rate composed in JS via the tether pivot: `tetherUsd / perFiat` | Emit the raw quotes as two `P` directives (`P <date> USDT <tetherUsd> USD` and `P <date> USDT <perFiat> <FIAT>`) and let `-X USD` bridge (verified: identical valuation) | Low divergence risk in practice; but raw-quote storage changes the prices UI and manual-price-precedence data model — a design decision, not a drop-in |
+| 9 ✅ | `lib/prices/provider.ts:87` `fetchPricesUsd` | Fiat USD rate composed in JS via the tether pivot: `tetherUsd / perFiat` | Emit the raw quotes as two `P` directives (`P <date> USDT <tetherUsd> USD` and `P <date> USDT <perFiat> <FIAT>`) and let `-X USD` bridge (verified: identical valuation) | Low divergence risk in practice; but raw-quote storage changes the prices UI and manual-price-precedence data model — a design decision, not a drop-in |
 | 10 ⏸️ | `lib/transactions/model.ts:299` `magnitudesByCurrency` (rendered in `features/transactions/TransactionRowItem.tsx:38`) | Positive posting sums per currency, float addition + `toFixed(2)` | A register keyed on `xact.beg_line` reproduces the values (verified; the `tag("uid")` variant fails because `:uid:` is flag-tag syntax) | Display-only; skips elided-amount postings and `@@` costs, hardcodes 2 decimals |
 
 ### Low — order/perf only, values already come from ledger

--- a/lib/prices/formatter.ts
+++ b/lib/prices/formatter.ts
@@ -5,6 +5,14 @@ export type CommodityPriceRow = {
   symbol: string;
   quote: string;
   price: number;
+  /**
+   * Optional pre-formatted price string. When set, it is rendered verbatim in
+   * place of `price`. Used for the Tether pivot legs, which must carry extra
+   * decimal places: ledger inherits an input price's decimal count when it
+   * inverts it, so a short quote like `0.9` would truncate the derived
+   * `fiat → USD` rate (0.9 → 1.1 instead of 1.111…).
+   */
+  priceText?: string;
   fetchedAt: Date;
   fetchedDate: string;
 };
@@ -32,7 +40,7 @@ export const renderPriceDb = (rows: CommodityPriceRow[]): string => {
   const generatedAt = `; Last regenerated: ${new Date().toISOString()}`;
   const lines = rows.map(
     (r) =>
-      `P ${formatLedgerDateTime(r.fetchedAt)} ${renderCommodity(r.symbol)} ${r.price} ${renderCommodity(r.quote)}`
+      `P ${formatLedgerDateTime(r.fetchedAt)} ${renderCommodity(r.symbol)} ${r.priceText ?? r.price} ${renderCommodity(r.quote)}`
   );
   return [BANNER, generatedAt, '', ...lines, ''].join('\n');
 };

--- a/lib/prices/provider.test.ts
+++ b/lib/prices/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { fetchPricesUsd } from './provider';
+import { fetchPricesUsd, PIVOT_SYMBOL } from './provider';
 
 const ok = (body: unknown, status = 200): Response =>
   ({
@@ -44,7 +44,7 @@ describe('fetchPricesUsd', () => {
     expect(result.failed).toEqual([]);
   });
 
-  it('prices a fiat commodity via the tether pivot', async () => {
+  it('emits raw Tether pivot legs for a fiat (no JS division)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       ok({ tether: { usd: 0.999108, eur: 0.873613 } })
     );
@@ -52,10 +52,40 @@ describe('fetchPricesUsd', () => {
       crypto: [],
       fiat: [{ symbol: 'EUR', code: 'EUR' }],
     });
-    // 1 EUR in USD = tether.usd / tether.eur
-    expect(result.quotes[0].symbol).toBe('EUR');
-    expect(result.quotes[0].quote).toBe('USD');
-    expect(result.quotes[0].price).toBeCloseTo(0.999108 / 0.873613, 6);
+    // Store the two raw legs verbatim; ledger derives EUR→USD.
+    expect(result.quotes).toEqual([
+      {
+        symbol: PIVOT_SYMBOL,
+        quote: 'USD',
+        price: 0.999108,
+        fetchedAt: expect.any(Date),
+      },
+      {
+        symbol: PIVOT_SYMBOL,
+        quote: 'EUR',
+        price: 0.873613,
+        fetchedAt: expect.any(Date),
+      },
+    ]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('emits the USDT→USD anchor once for multiple fiats', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      ok({ tether: { usd: 1.0, eur: 0.9, gbp: 0.8 } })
+    );
+    const result = await fetchPricesUsd({
+      crypto: [],
+      fiat: [
+        { symbol: 'EUR', code: 'EUR' },
+        { symbol: 'GBP', code: 'GBP' },
+      ],
+    });
+    expect(result.quotes).toEqual([
+      { symbol: 'USDT', quote: 'USD', price: 1.0, fetchedAt: expect.any(Date) },
+      { symbol: 'USDT', quote: 'EUR', price: 0.9, fetchedAt: expect.any(Date) },
+      { symbol: 'USDT', quote: 'GBP', price: 0.8, fetchedAt: expect.any(Date) },
+    ]);
     expect(result.failed).toEqual([]);
   });
 

--- a/lib/prices/provider.ts
+++ b/lib/prices/provider.ts
@@ -6,10 +6,20 @@ export type FetchPlan = { crypto: CryptoTarget[]; fiat: FiatTarget[] };
 
 export type PriceQuote = {
   symbol: string;
-  quote: 'USD';
+  /** The commodity `price` is denominated in. USD for crypto; for fiat we
+   *  store raw Tether pivot rows, so this is `USD` or the fiat's own symbol. */
+  quote: string;
   price: number;
   fetchedAt: Date;
 };
+
+/**
+ * Synthetic pivot commodity. Fiat has no direct CoinGecko USD quote, so we
+ * store the two raw legs CoinGecko *does* give — `USDT` in USD and `USDT` in
+ * the fiat — and let ledger's price graph bridge `<fiat> → USDT → USD` at
+ * valuation time. No fiat→USD arithmetic happens in JS.
+ */
+export const PIVOT_SYMBOL = 'USDT';
 export type ProviderResult = {
   quotes: PriceQuote[];
   failed: { symbol: string }[];
@@ -25,11 +35,13 @@ const sleep = (milliseconds: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 /**
- * Fetch every commodity price in USD from CoinGecko's `/simple/price`. Crypto
- * ids resolve directly; fiat commodities resolve via the tether pivot
- * (1 unit F in USD = tether.usd / tether.<f>). One request per URL-length
- * chunk; one retry on 429/5xx. `fetchedAt` is a single instant per call so the
- * caller can dedupe upserts by it.
+ * Fetch every commodity price from CoinGecko's `/simple/price`. Crypto ids
+ * resolve directly to a USD quote. Fiat has no direct USD quote, so we emit the
+ * two raw Tether legs CoinGecko returns — one shared `USDT → USD` anchor plus a
+ * `USDT → <fiat>` leg per fiat — and let ledger bridge `<fiat> → USDT → USD`
+ * downstream (no fiat→USD division in JS). One request per URL-length chunk;
+ * one retry on 429/5xx. `fetchedAt` is a single instant per call so the caller
+ * can dedupe upserts by it.
  */
 export const fetchPricesUsd = async (
   plan: FetchPlan,
@@ -71,19 +83,33 @@ export const fetchPricesUsd = async (
   }
 
   const tetherUsd = merged[TETHER_ID]?.usd;
+  const tetherUsdValid =
+    typeof tetherUsd === 'number' && Number.isFinite(tetherUsd);
+  // Emit the shared `USDT → USD` anchor exactly once, the first time any fiat
+  // resolves. Each fiat then contributes its own `USDT → <fiat>` leg; ledger
+  // bridges `<fiat> → USDT → USD` from the two. No division here.
+  let anchorEmitted = false;
   for (const fiat of plan.fiat) {
     const perFiat = merged[TETHER_ID]?.[fiat.code.toLowerCase()];
     if (
-      typeof tetherUsd === 'number' &&
+      tetherUsdValid &&
       typeof perFiat === 'number' &&
-      Number.isFinite(tetherUsd) &&
       Number.isFinite(perFiat) &&
       perFiat > 0
     ) {
+      if (!anchorEmitted) {
+        quotes.push({
+          symbol: PIVOT_SYMBOL,
+          quote: 'USD',
+          price: tetherUsd,
+          fetchedAt,
+        });
+        anchorEmitted = true;
+      }
       quotes.push({
-        symbol: fiat.symbol,
-        quote: 'USD',
-        price: tetherUsd / perFiat,
+        symbol: PIVOT_SYMBOL,
+        quote: fiat.symbol,
+        price: perFiat,
         fetchedAt,
       });
     } else {

--- a/lib/prices/repository.ts
+++ b/lib/prices/repository.ts
@@ -58,6 +58,18 @@ export class CommodityPriceRepository {
       .orderBy(commodityPrice.fetchedAt);
   }
 
+  /**
+   * Every stored row for one symbol, across all quotes (e.g. all `USDT → *`
+   * pivot legs). Used to assemble the fiat-bridging rows for a price DB.
+   */
+  async listBySymbol(symbol: string): Promise<CommodityPrice[]> {
+    return this.db
+      .select()
+      .from(commodityPrice)
+      .where(eq(commodityPrice.symbol, symbol))
+      .orderBy(commodityPrice.fetchedAt);
+  }
+
   /** Distinct symbols already fetched against the given quote. */
   async knownSymbolsForQuote(quote: string): Promise<string[]> {
     const rows = await this.db

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -135,6 +135,43 @@ describe('PriceService.refreshAll', () => {
     expect(file).toContain('USD');
   });
 
+  it('prices a held fiat end-to-end via Tether pivot legs (no JS division)', async () => {
+    await seedUser(
+      ctx,
+      'euro',
+      '2026/07/02 X\n  Assets:Cash  100 EUR\n  Equity\n',
+      'USD'
+    );
+    await seedMapping(ctx, 'euro', [
+      { symbol: 'EUR', kind: 'fiat', providerId: 'eur' },
+    ]);
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ tether: { usd: 1.0, eur: 0.9 } }),
+    } as Response);
+
+    const result = await service.refreshAll();
+    expect(result.status).toBe('success');
+
+    // The generated price DB stores the raw pivot legs, not a computed EUR→USD.
+    const file = await fs.readFile(
+      path.join(getJournalDir('euro'), 'generated-prices.ledger'),
+      'utf-8'
+    );
+    expect(file).toMatch(/USDT .* USD/);
+    expect(file).toMatch(/USDT .* EUR/);
+
+    // ledger bridges EUR → USDT → USD: 100 EUR = 100 / 0.9 ≈ 111.11 USD.
+    const rows = await service.listKnownPricesInBase('euro');
+    const eur = rows.find(
+      (row) => normalizeCommoditySymbol(row.symbol) === 'EUR'
+    );
+    expect(eur?.price).toBeCloseTo(1 / 0.9, 4);
+    expect(eur?.source).toBe('fetched');
+  });
+
   it('marks the run as partial when the provider reports failed symbols', async () => {
     await seedUser(
       ctx,

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -989,6 +989,60 @@ describe('PriceService.listKnownPricesInBase', () => {
     // 1 EUR = 1 USDT / 0.9 EUR-per-USDT * 1 USD-per-USDT = 1.111… USD.
     expect(eur?.price).toBeCloseTo(1 / 0.9, 4);
     expect(eur?.quote).toBe('USD');
+    // Provenance: the pivot is a fetched price, dated from the leg.
+    expect(eur?.source).toBe('fetched');
+    expect(eur?.date).toBe('2026-07-02');
+  });
+
+  it('reconstructs a pivot-priced fiat history through ledger', async () => {
+    await seedUser(
+      ctx,
+      'u-fiat-hist',
+      [
+        '2026-07-05 * hold',
+        '  Assets:A   1 EUR',
+        '  Equity    -1 EUR',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'USDT',
+        quote: 'USD',
+        price: 1.0,
+        fetchedAt: new Date('2026-07-01T00:00:00Z'),
+        fetchedDate: '2026-07-01',
+      },
+      {
+        symbol: 'USDT',
+        quote: 'EUR',
+        price: 0.9,
+        fetchedAt: new Date('2026-07-01T00:00:00Z'),
+        fetchedDate: '2026-07-01',
+      },
+      {
+        symbol: 'USDT',
+        quote: 'USD',
+        price: 1.0,
+        fetchedAt: new Date('2026-07-05T00:00:00Z'),
+        fetchedDate: '2026-07-05',
+      },
+      {
+        symbol: 'USDT',
+        quote: 'EUR',
+        price: 0.95,
+        fetchedAt: new Date('2026-07-05T00:00:00Z'),
+        fetchedDate: '2026-07-05',
+      },
+    ]);
+    await service.regenerateUserPriceDb('u-fiat-hist');
+
+    const points = await service.listPriceHistory('u-fiat-hist', 'EUR');
+    expect(points.map((p) => p.date)).toEqual(['2026-07-01', '2026-07-05']);
+    expect(points[0].price).toBeCloseTo(1 / 0.9, 4);
+    expect(points[1].price).toBeCloseTo(1 / 0.95, 4);
+    expect(points.every((p) => p.quote === 'USD')).toBe(true);
   });
 
   it('values a dollar-denominated holding into a non-USD target via the bridge', async () => {

--- a/lib/prices/service.test.ts
+++ b/lib/prices/service.test.ts
@@ -949,6 +949,48 @@ describe('PriceService.listKnownPricesInBase', () => {
     expect(btc?.quote).toBe('EUR');
   });
 
+  it('values a held fiat via the USDT pivot rows (no stored fiat→USD price)', async () => {
+    // The fiat has NO direct `EUR → USD` row anywhere; only the raw Tether legs
+    // are stored. regenerateUserPriceDb must emit the pivot into the price DB so
+    // ledger bridges `EUR → USDT → USD` — proving no fiat→USD math is done in JS.
+    await seedUser(
+      ctx,
+      'u-fiat',
+      [
+        '2026-07-02 * hold',
+        '  Assets:A   100 EUR',
+        '  Equity    -100 EUR',
+        '',
+      ].join('\n'),
+      'USD'
+    );
+    await new CommodityPriceRepository(ctx.db).insert([
+      {
+        symbol: 'USDT',
+        quote: 'USD',
+        price: 1.0,
+        fetchedAt: new Date('2026-07-02T00:00:00Z'),
+        fetchedDate: '2026-07-02',
+      },
+      {
+        symbol: 'USDT',
+        quote: 'EUR',
+        price: 0.9,
+        fetchedAt: new Date('2026-07-02T00:00:00Z'),
+        fetchedDate: '2026-07-02',
+      },
+    ]);
+    await service.regenerateUserPriceDb('u-fiat');
+
+    const rows = await service.listKnownPricesInBase('u-fiat');
+    const eur = rows.find(
+      (row) => normalizeCommoditySymbol(row.symbol) === 'EUR'
+    );
+    // 1 EUR = 1 USDT / 0.9 EUR-per-USDT * 1 USD-per-USDT = 1.111… USD.
+    expect(eur?.price).toBeCloseTo(1 / 0.9, 4);
+    expect(eur?.quote).toBe('USD');
+  });
+
   it('values a dollar-denominated holding into a non-USD target via the bridge', async () => {
     // The exact interaction the removed `base === 'USD'` gate unlocks: a `$`
     // -priced holding reaching a non-USD target. BTC is priced in `$` (not the

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -83,6 +83,11 @@ const PRICE_HISTORY_CONCURRENCY = 8;
 // this many places keeps the derived `fiat → USD` rate accurate.
 const PIVOT_PRICE_DECIMALS = 12;
 
+// `date|account|quantity|commodity` per probe posting — used to reconstruct a
+// pivot-priced fiat's history by valuing `1 <fiat>` at each pivot date.
+const FIAT_HISTORY_FORMAT =
+  "%(format_date(date,'%Y-%m-%d'))|%(account)|%(quantity(scrub(display_amount)))|%(commodity(scrub(display_amount)))\n";
+
 export type RefreshResult =
   | { status: 'success'; fetched: number }
   | { status: 'partial'; fetched: number; failed: string[] }
@@ -498,7 +503,80 @@ export class PriceService {
     } catch {
       return [];
     }
-    return parsePriceHistory(stdout);
+    const direct = parsePriceHistory(stdout);
+    // `ledger prices` only reports direct `P <symbol> …` rows; it does not
+    // bridge. A fiat priced solely by the Tether pivot has no direct row, so
+    // reconstruct its history by valuing `1 <fiat>` at each pivot date (ledger
+    // still does every conversion — see fiatPivotHistory).
+    if (direct.length > 0) return direct;
+    return this.fiatPivotHistory(userId, symbol);
+  }
+
+  /**
+   * History for a fiat priced only through the `USDT → USD` / `USDT → <fiat>`
+   * pivot, where `ledger prices <fiat>` is empty. Values `1 <fiat>` at every
+   * pivot date via a throwaway probe journal and reads the bridged amount back
+   * — so the displayed rate is computed by ledger, never in JS. Returns `[]`
+   * when the symbol has no pivot legs (i.e. it simply has no price).
+   */
+  private async fiatPivotHistory(
+    userId: string,
+    symbol: string
+  ): Promise<PricePoint[]> {
+    const target = normalizeCommoditySymbol(symbol) ?? symbol;
+    const legs = (
+      await this.deps.commodityRepo.listBySymbol(PIVOT_SYMBOL)
+    ).filter((r) => (normalizeCommoditySymbol(r.quote) ?? r.quote) === target);
+    if (legs.length === 0) return [];
+
+    const base = await this.resolveBaseCurrency(userId);
+    const dates = [...new Set(legs.map((r) => r.fetchedDate))].sort();
+    // Distinct account per date so ledger reports one row per point; the bare
+    // `1 "<fiat>"` is always double-quoted (legal for every commodity name).
+    const journal = dates
+      .map(
+        (date, index) =>
+          `${date} * probe\n  Probe:c${index}    1 "${symbol}"\n  Offset:c${index}   -1 "${symbol}"\n`
+      )
+      .join('\n');
+
+    const probePath = path.join(
+      os.tmpdir(),
+      `ledger-fiat-${randomUUID()}.ledger`
+    );
+    try {
+      await fs.writeFile(probePath, journal, 'utf-8');
+      const stdout = await runLedgerForUser(
+        userId,
+        [
+          '--file',
+          probePath,
+          'reg',
+          '^Probe:c',
+          '--sort',
+          'date',
+          '-X',
+          base,
+          '--format',
+          FIAT_HISTORY_FORMAT,
+        ],
+        this.deps.journalRepo
+      );
+      const points: PricePoint[] = [];
+      for (const line of stdout.split('\n')) {
+        const [date, account, quantity, commodity] = line.split('|');
+        // Skip ledger's `<Revalued>` / `<Adjustment>` mark-to-market rows.
+        if (!account?.startsWith('Probe:c')) continue;
+        const price = Number((quantity ?? '').replace(/,/g, ''));
+        if (!date || !Number.isFinite(price)) continue;
+        points.push({ date, price, quote: commodity?.trim() || base });
+      }
+      return points;
+    } catch {
+      return [];
+    } finally {
+      await fs.rm(probePath, { force: true }).catch(() => {});
+    }
   }
 
   async listNormalizedSymbolsForUser(userId: string): Promise<string[]> {
@@ -570,10 +648,11 @@ export class PriceService {
   /** Latest known price for every held commodity, with provenance and staleness. */
   async listKnownPrices(userId: string): Promise<KnownPrice[]> {
     const base = await this.resolveBaseCurrency(userId);
-    const [held, manual, fetched] = await Promise.all([
+    const [held, manual, fetched, pivotLegs] = await Promise.all([
       this.listHeldCommodities(userId),
       this.deps.manualRepo.listForUser(userId),
       this.deps.commodityRepo.listForQuote(base),
+      this.deps.commodityRepo.listBySymbol(PIVOT_SYMBOL),
     ]);
 
     const manualKeys = new Set(
@@ -584,6 +663,16 @@ export class PriceService {
     const fetchedKeys = new Set(
       fetched.map((row) => priceKey(row.symbol, row.quote, row.fetchedDate))
     );
+    // A fiat priced by the Tether pivot has no `<fiat> → base` row of its own,
+    // but its price IS fetched. Register the derived key (fiat, base, legDate)
+    // so deriveSource labels it 'fetched' rather than falling through to
+    // 'journal'. The `USDT → USD` anchor itself is skipped.
+    const normalizedBase = normalizeCommoditySymbol(base) ?? base;
+    for (const leg of pivotLegs) {
+      const quote = normalizeCommoditySymbol(leg.quote) ?? leg.quote;
+      if (quote === normalizedBase) continue;
+      fetchedKeys.add(priceKey(quote, normalizedBase, leg.fetchedDate));
+    }
 
     const today = utcDate(new Date());
 

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -177,10 +177,14 @@ export class PriceService {
       return canonicalQuote !== null && userSymbols.has(canonicalQuote);
     });
     // Render pivot legs with padded precision so ledger's inversion of the
-    // `USDT → <fiat>` leg keeps enough decimals (see CommodityPriceRow.priceText).
+    // `USDT → <fiat>` leg keeps enough decimals (see CommodityPriceRow.priceText),
+    // and date them at UTC midnight of their fetch day. The fiat-history probe
+    // dates its `1 <fiat>` postings at 00:00:00; a wall-clock time on the P
+    // directive would sort *after* the same-day posting and never apply.
     const withPrecision = (r: CommodityPriceRow): CommodityPriceRow => ({
       ...r,
       priceText: r.price.toFixed(PIVOT_PRICE_DECIMALS),
+      fetchedAt: new Date(`${r.fetchedDate}T00:00:00.000Z`),
     });
     const pivotRows =
       heldFiatLegs.length > 0

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -39,7 +39,7 @@ import type { ManualPriceRepository } from './manualRepository';
 import { buildPricedAt, type ManualPriceDraft } from './manualSchema';
 import type { CommodityMappingRepository } from './mappingRepository';
 import { parseLegacyPriceDb } from './migration';
-import { fetchPricesUsd, type FetchPlan } from './provider';
+import { fetchPricesUsd, PIVOT_SYMBOL, type FetchPlan } from './provider';
 import {
   type CommodityPriceRepository,
   type PriceFetchRunRepository,
@@ -77,6 +77,11 @@ const PRICE_DB_OLD_NAME = 'price-db_old.ledger';
 // fan-out so a user holding many commodities cannot spawn an unbounded number of
 // subprocesses at once.
 const PRICE_HISTORY_CONCURRENCY = 8;
+
+// Decimal places for rendered Tether pivot legs. Ledger inherits an input
+// price's decimal count when it inverts the leg to value a fiat, so padding to
+// this many places keeps the derived `fiat → USD` rate accurate.
+const PIVOT_PRICE_DECIMALS = 12;
 
 export type RefreshResult =
   | { status: 'success'; fetched: number }
@@ -145,10 +150,41 @@ export class PriceService {
     // (listNormalizedSymbolsForUser), while canonical() preserves the journal's
     // raw case, so a lower/mixed-case declaration (`commodity Bitcoin` / `alias
     // BTC`) would otherwise never match and drop the row silently.
+    const canonicalSymbolOf = (symbol: string): string | null =>
+      normalizeCommoditySymbol(canonical(symbol));
     const fetched = all.filter((r) => {
-      const canonicalSymbol = normalizeCommoditySymbol(canonical(r.symbol));
+      const canonicalSymbol = canonicalSymbolOf(r.symbol);
       return canonicalSymbol !== null && userSymbols.has(canonicalSymbol);
     });
+
+    // Fiat has no direct `<fiat> → USD` row; it is priced by the Tether pivot.
+    // Include the `USDT → USD` anchor plus a `USDT → <fiat>` leg for every held
+    // fiat so ledger can bridge `<fiat> → USDT → USD`. These rows are kept
+    // regardless of whether USDT itself is a held commodity (it usually is not),
+    // so the userSymbols filter above cannot be reused here.
+    const normalizedBase = normalizeCommoditySymbol(base) ?? base;
+    const pivotAll = await this.deps.commodityRepo.listBySymbol(PIVOT_SYMBOL);
+    const isBaseQuote = (quote: string): boolean =>
+      canonicalSymbolOf(quote) === normalizedBase;
+    const heldFiatLegs = pivotAll.filter((r) => {
+      if (isBaseQuote(r.quote)) return false;
+      const canonicalQuote = canonicalSymbolOf(r.quote);
+      return canonicalQuote !== null && userSymbols.has(canonicalQuote);
+    });
+    // Render pivot legs with padded precision so ledger's inversion of the
+    // `USDT → <fiat>` leg keeps enough decimals (see CommodityPriceRow.priceText).
+    const withPrecision = (r: CommodityPriceRow): CommodityPriceRow => ({
+      ...r,
+      priceText: r.price.toFixed(PIVOT_PRICE_DECIMALS),
+    });
+    const pivotRows =
+      heldFiatLegs.length > 0
+        ? [
+            ...pivotAll.filter((r) => isBaseQuote(r.quote)),
+            ...heldFiatLegs,
+          ].map(withPrecision)
+        : [];
+
     const manual = await this.deps.manualRepo.listForUser(userId);
     const manualRows: CommodityPriceRow[] = manual.map((m) => ({
       symbol: m.symbol,
@@ -157,9 +193,19 @@ export class PriceService {
       fetchedAt: m.pricedAt,
       fetchedDate: utcDate(m.pricedAt),
     }));
-    // Concatenate fetched-first, then stable-sort by instant: equal timestamps
-    // keep fetched before manual, so manual ends up later in the file and wins.
-    const merged = [...fetched, ...manualRows].sort(
+    // Concatenate fetched+pivot first, then stable-sort by instant: equal
+    // timestamps keep fetched before manual, so a manual override ends up later
+    // in the file and wins. Dedupe by (symbol|quote|fetchedDate) so a held-USDT
+    // anchor row is not emitted twice (once via `fetched`, once via `pivotRows`).
+    const deduped = [
+      ...new Map(
+        [...fetched, ...pivotRows].map((r) => [
+          `${r.symbol}|${r.quote}|${r.fetchedDate}`,
+          r,
+        ])
+      ).values(),
+    ];
+    const merged = [...deduped, ...manualRows].sort(
       (a, b) => a.fetchedAt.getTime() - b.fetchedAt.getTime()
     );
     const canonicalized = merged.map((r) => ({

--- a/lib/prices/service.ts
+++ b/lib/prices/service.ts
@@ -45,7 +45,11 @@ import {
   type PriceFetchRunRepository,
 } from './repository';
 import { normalizeCommoditySymbol } from './symbols';
-import type { CommodityMapping, ManualPrice } from '@/db/schema';
+import type {
+  CommodityMapping,
+  CommodityPrice,
+  ManualPrice,
+} from '@/db/schema';
 import type { DbInstance } from '@/lib/db/connection';
 import {
   DEFINITIONS_NAME,
@@ -107,6 +111,23 @@ const utcDate = (d: Date): string => {
   const m = String(d.getUTCMonth() + 1).padStart(2, '0');
   const day = String(d.getUTCDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
+};
+
+// `ledger commodities` surrounds any name that is not a bare alphanumeric run
+// with double quotes (e.g. it prints `"1INCH"` for the digit-bearing 1inch
+// ticker — such names are only legal quoted in a journal anyway). Recover the
+// bare commodity name by stripping one surrounding quote pair, then reject
+// anything that still carries a quote or newline, which would let a crafted
+// holding break out of a throwaway probe journal. Returns `null` for an unsafe
+// name so callers skip it rather than emit an unparseable journal.
+const probeName = (symbol: string): string | null => {
+  const stripped =
+    symbol.length >= 2 &&
+    ((symbol.startsWith('"') && symbol.endsWith('"')) ||
+      (symbol.startsWith("'") && symbol.endsWith("'")))
+      ? symbol.slice(1, -1)
+      : symbol;
+  return /["\n\r]/.test(stripped) ? null : stripped;
 };
 
 type Deps = {
@@ -479,7 +500,11 @@ export class PriceService {
    */
   async listPriceHistory(
     userId: string,
-    symbol: string
+    symbol: string,
+    // Optional: the caller (listKnownPrices) already fetched every USDT pivot
+    // leg once for its whole fan-out. Thread it in so each held pivot-priced
+    // fiat doesn't re-run the same full-table listBySymbol(PIVOT_SYMBOL) query.
+    pivotLegs?: CommodityPrice[]
   ): Promise<PricePoint[]> {
     if (!symbol.trim() || /[\n\r]/.test(symbol)) return [];
     let stdout: string;
@@ -513,7 +538,7 @@ export class PriceService {
     // reconstruct its history by valuing `1 <fiat>` at each pivot date (ledger
     // still does every conversion — see fiatPivotHistory).
     if (direct.length > 0) return direct;
-    return this.fiatPivotHistory(userId, symbol);
+    return this.fiatPivotHistory(userId, symbol, pivotLegs);
   }
 
   /**
@@ -525,12 +550,22 @@ export class PriceService {
    */
   private async fiatPivotHistory(
     userId: string,
-    symbol: string
+    symbol: string,
+    pivotLegs?: CommodityPrice[]
   ): Promise<PricePoint[]> {
-    const target = normalizeCommoditySymbol(symbol) ?? symbol;
-    const legs = (
-      await this.deps.commodityRepo.listBySymbol(PIVOT_SYMBOL)
-    ).filter((r) => (normalizeCommoditySymbol(r.quote) ?? r.quote) === target);
+    // Strip any surrounding quote pair `ledger commodities` adds and reject an
+    // unsafe name, exactly as the sibling probe builder in listKnownPricesInBase
+    // does — otherwise an already-quoted held symbol would emit `1 ""FOO""` and
+    // the probe journal would fail to parse (swallowed as an empty history).
+    const name = probeName(symbol);
+    if (name === null) return [];
+
+    const target = normalizeCommoditySymbol(name) ?? name;
+    const allLegs =
+      pivotLegs ?? (await this.deps.commodityRepo.listBySymbol(PIVOT_SYMBOL));
+    const legs = allLegs.filter(
+      (r) => (normalizeCommoditySymbol(r.quote) ?? r.quote) === target
+    );
     if (legs.length === 0) return [];
 
     const base = await this.resolveBaseCurrency(userId);
@@ -540,7 +575,7 @@ export class PriceService {
     const journal = dates
       .map(
         (date, index) =>
-          `${date} * probe\n  Probe:c${index}    1 "${symbol}"\n  Offset:c${index}   -1 "${symbol}"\n`
+          `${date} * probe\n  Probe:c${index}    1 "${name}"\n  Offset:c${index}   -1 "${name}"\n`
       )
       .join('\n');
 
@@ -698,7 +733,7 @@ export class PriceService {
           };
         }
 
-        const history = await this.listPriceHistory(userId, symbol);
+        const history = await this.listPriceHistory(userId, symbol, pivotLegs);
         const latest = latestGenuinePrice(history, base);
 
         if (!latest) {
@@ -774,22 +809,6 @@ export class PriceService {
       normalizeCommoditySymbol(row.symbol) === base
         ? { ...row, price: 1, quote: base }
         : { ...row, price: null, quote: null };
-
-    // `ledger commodities` surrounds any name that is not a bare alphanumeric
-    // run with double quotes (e.g. it prints `"1INCH"` for the digit-bearing
-    // 1inch ticker — such names are only legal quoted in a journal anyway).
-    // Recover the bare commodity name by stripping one surrounding quote pair,
-    // then reject anything that still carries a quote or newline, which would
-    // let a crafted holding break out of the throwaway journal.
-    const probeName = (symbol: string): string | null => {
-      const stripped =
-        symbol.length >= 2 &&
-        ((symbol.startsWith('"') && symbol.endsWith('"')) ||
-          (symbol.startsWith("'") && symbol.endsWith("'")))
-          ? symbol.slice(1, -1)
-          : symbol;
-      return /["\n\r]/.test(stripped) ? null : stripped;
-    };
 
     // Probe only non-base commodities with a journal-safe name. Keep the raw
     // symbol as the row identity so results match back exactly.


### PR DESCRIPTION
Resolves LEDGER-AUDIT #9 in full: **no fiat→USD arithmetic happens in JavaScript** — ledger performs every conversion.

## Before
CoinGecko has no direct fiat→USD quote, so the provider divided in JS (`tetherUsd / perFiat`) and stored a computed `EUR→USD` row.

## After
Store the two **raw** Tether legs CoinGecko returns and let ledger's price graph bridge `fiat → USDT → USD`:

- **Provider** emits raw pivot legs — one shared `USDT→USD` anchor per run plus a `USDT→<fiat>` leg per fiat. No division.
- **Price DB regen** includes the anchor + each held fiat's leg (bypassing the held-symbols filter, since USDT is rarely held).
- **Valuation** uses the existing `-X` probe in `listKnownPricesInBase` — ledger bridges the pivot.
- **History** (`/prices/[symbol]`): `ledger prices <fiat>` can't bridge, so a pivot-priced fiat's history is reconstructed by valuing `1 <fiat>` at each pivot date through a throwaway probe journal (`reg -X base`). Ledger computes every point; the probe only supplies dates.
- **Provenance** registers the derived `(fiat, base, legDate)` key so a fetched fiat reads `source: fetched`.

## Subtleties handled (verified against ledger 3.4.1)
- **Precision**: ledger inherits an input price's decimal count when it *inverts* the `USDT→<fiat>` leg — a short quote like `0.9` would truncate `EUR→USD` to `1.1`. Pivot legs render with padded precision (`priceText`, 12 dp).
- **Same-day timing**: pivot `P` directives are dated at UTC midnight so the history probe's midnight posting picks them up (a wall-clock `fetchedAt` sorted *after* the posting and never applied — caught by the end-to-end test).
- **Manual overrides** still win: a direct `P <fiat> x USD` beats the derived pivot path.

## Tests
Full suite green (1020). New: provider emits raw legs + single anchor; regenerate/value a held fiat via pivot with fetched provenance; history reconstructs points through ledger; refreshAll end-to-end from mocked CoinGecko rates.
