### PR TITLE
fix(transactions): let ledger fill the balancing amount (#3)

### DIFF
--- a/features/transactions/entry/types/exchange.test.ts
+++ b/features/transactions/entry/types/exchange.test.ts
@@ -60,7 +60,8 @@ describe('exchangeAdapter.compile', () => {
         cost: { amount: '100', currency: 'USD' },
       },
       { account: 'Expenses:BrokerFee', amount: '2', currency: 'USD' },
-      { account: 'Assets:Bank', amount: '-102', currency: 'USD' },
+      // Amount-less: ledger fills the outflow (100 + 2 = 102) on save.
+      { account: 'Assets:Bank', amount: '', currency: '' },
     ]);
   });
 });

--- a/features/transactions/entry/types/exchange.ts
+++ b/features/transactions/entry/types/exchange.ts
@@ -99,7 +99,9 @@ export const exchangeAdapter: TransactionTypeAdapter<ExchangeFields> = {
     const gaveFrom = singleAccount(gavePostings);
     if (!gaveFrom) return null;
     if (got.amount === '' || !(Number(got.amount) > 0)) return null;
-    if (computeBalance(postings).kind !== 'balanced') return null;
+    const balanceKind = computeBalance(postings).kind;
+    if (balanceKind !== 'balanced' && balanceKind !== 'auto-balance')
+      return null;
     return {
       ...headerOf(draft),
       gaveAmount: cost.amount,

--- a/features/transactions/entry/types/expense.test.ts
+++ b/features/transactions/entry/types/expense.test.ts
@@ -49,8 +49,8 @@ describe('expenseAdapter.compile', () => {
       { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
       { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
       { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
-      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
-      { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+      // Amount-less: ledger fills the multi-currency residual on save.
+      { account: 'Assets:Checking', amount: '', currency: '' },
     ]);
   });
 });

--- a/features/transactions/entry/types/expense.ts
+++ b/features/transactions/entry/types/expense.ts
@@ -82,7 +82,9 @@ export const expenseAdapter: TransactionTypeAdapter<ExpenseFields> = {
     if (expensePostings.length < 1 || payingPostings.length < 1) return null;
     const paidFrom = singleAccount(payingPostings);
     if (!paidFrom) return null;
-    if (computeBalance(postings).kind !== 'balanced') return null;
+    const balanceKind = computeBalance(postings).kind;
+    if (balanceKind !== 'balanced' && balanceKind !== 'auto-balance')
+      return null;
     const base = expensePostings[0];
     if (base.amount === '' || !(Number(base.amount) > 0)) return null;
     return {

--- a/features/transactions/entry/types/extraItems.test.ts
+++ b/features/transactions/entry/types/extraItems.test.ts
@@ -1,26 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
-  formatAmount,
   residualByCurrency,
   balancingPostings,
   extraItemPostings,
   toExtraItems,
   singleAccount,
 } from './extraItems';
-
-describe('formatAmount', () => {
-  it('trims float noise and negative zero', () => {
-    expect(formatAmount(120)).toBe('120');
-    expect(formatAmount(-42.5)).toBe('-42.5');
-    expect(formatAmount(0.1 + 0.2)).toBe('0.3');
-    expect(formatAmount(-0)).toBe('0');
-  });
-
-  it('never emits scientific notation for small magnitudes', () => {
-    expect(formatAmount(5e-7)).toBe('0.0000005');
-    expect(formatAmount(-1e-7)).toBe('-0.0000001');
-  });
-});
 
 describe('residualByCurrency', () => {
   it('sums plain postings per currency in first-seen order', () => {
@@ -50,15 +35,15 @@ describe('residualByCurrency', () => {
 });
 
 describe('balancingPostings', () => {
-  it('emits one negated posting per nonzero currency', () => {
+  it('emits a single amount-less posting when there is a residual', () => {
+    // Ledger fills the exact amount(s) — even multi-currency — from the blank.
     const out = balancingPostings('Assets:Checking', [
       { account: 'Expenses:Dining', amount: '100', currency: 'USD' },
       { account: 'Expenses:Tips', amount: '20', currency: 'USD' },
       { account: 'Expenses:Fees', amount: '2', currency: 'EUR' },
     ]);
     expect(out).toEqual([
-      { account: 'Assets:Checking', amount: '-120', currency: 'USD' },
-      { account: 'Assets:Checking', amount: '-2', currency: 'EUR' },
+      { account: 'Assets:Checking', amount: '', currency: '' },
     ]);
   });
 

--- a/features/transactions/entry/types/extraItems.ts
+++ b/features/transactions/entry/types/extraItems.ts
@@ -3,22 +3,11 @@ import type { Posting } from '@/lib/transactions/posting';
 export type ExtraItem = { account: string; amount: string; currency: string };
 
 /**
- * Format a computed numeric amount to a compact string: trailing zeros trimmed,
- * no `-0`. Uses `toFixed(10)`, which stays in plain decimal notation for every
- * realistic currency magnitude (`toFixed` only switches to exponential form at
- * `|n| >= 1e21`, far beyond any sum reachable here).
- */
-export const formatAmount = (n: number): string => {
-  if (!Number.isFinite(n)) return '0';
-  if (n === 0) return '0';
-  const trimmed = n.toFixed(10).replace(/\.?0+$/, '');
-  return trimmed === '-0' ? '0' : trimmed;
-};
-
-/**
  * Net amount per currency across postings, honoring `@@` cost annotations
  * (a cost-bearing posting contributes its signed cost to the cost currency,
  * exactly like {@link computeBalance}). Insertion order = first-seen currency.
+ * Used only to decide *whether* a balancing line is needed — never to write an
+ * amount into the journal.
  */
 export const residualByCurrency = (
   postings: readonly Posting[]
@@ -43,18 +32,23 @@ export const residualByCurrency = (
   return net;
 };
 
-/** Postings for `account` that zero the residual of `others`, one per nonzero currency. */
+/**
+ * A single amount-less posting on `account` when `others` leave a residual;
+ * ledger fills the exact balancing amount (multi-currency and cost aware) when
+ * it parses the saved transaction. Empty when `others` already balance.
+ *
+ * We deliberately do NOT compute the amount in JS: a float-derived figure can
+ * diverge from ledger's exact residual and get the transaction rejected on
+ * save. The residual sum here is only a predicate — is a balancing line needed?
+ */
 export const balancingPostings = (
   account: string,
   others: readonly Posting[]
 ): Posting[] => {
-  const net = residualByCurrency(others);
-  const out: Posting[] = [];
-  for (const [currency, total] of net) {
-    if (Math.abs(total) <= 1e-9) continue;
-    out.push({ account, amount: formatAmount(-total), currency });
-  }
-  return out;
+  const hasResidual = [...residualByCurrency(others).values()].some(
+    (total) => Math.abs(total) > 1e-9
+  );
+  return hasResidual ? [{ account, amount: '', currency: '' }] : [];
 };
 
 /**

--- a/features/transactions/entry/types/income.test.ts
+++ b/features/transactions/entry/types/income.test.ts
@@ -44,7 +44,8 @@ describe('incomeAdapter.compile', () => {
       ctx
     );
     expect(draft.postings).toEqual([
-      { account: 'Assets:Checking', amount: '970', currency: 'USD' },
+      // Amount-less: ledger fills the net (1000 − 30 = 970) on save.
+      { account: 'Assets:Checking', amount: '', currency: '' },
       { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
       { account: 'Expenses:Fees', amount: '30', currency: 'USD' },
     ]);

--- a/features/transactions/entry/types/income.ts
+++ b/features/transactions/entry/types/income.ts
@@ -88,7 +88,9 @@ export const incomeAdapter: TransactionTypeAdapter<IncomeFields> = {
     if (incomePostings.length !== 1 || assetPostings.length < 1) return null;
     const receivedInto = singleAccount(assetPostings);
     if (!receivedInto) return null;
-    if (computeBalance(postings).kind !== 'balanced') return null;
+    const balanceKind = computeBalance(postings).kind;
+    if (balanceKind !== 'balanced' && balanceKind !== 'auto-balance')
+      return null;
     const base = incomePostings[0];
     if (base.amount === '' || !(Number(base.amount) < 0)) return null;
     return {

--- a/features/transactions/entry/types/transfer.test.ts
+++ b/features/transactions/entry/types/transfer.test.ts
@@ -46,7 +46,8 @@ describe('transferAdapter.compile', () => {
     expect(draft.postings).toEqual([
       { account: 'Assets:Savings', amount: '500', currency: 'USD' },
       { account: 'Expenses:WireFee', amount: '15', currency: 'USD' },
-      { account: 'Assets:Checking', amount: '-515', currency: 'USD' },
+      // Amount-less: ledger fills the outflow (500 + 15 = 515) on save.
+      { account: 'Assets:Checking', amount: '', currency: '' },
     ]);
   });
 });

--- a/features/transactions/entry/types/transfer.ts
+++ b/features/transactions/entry/types/transfer.ts
@@ -83,16 +83,20 @@ export const transferAdapter: TransactionTypeAdapter<TransferFields> = {
     )
       return null;
     if (assetOrLiabilityPostings.length < 2) return null;
-    if (computeBalance(postings).kind !== 'balanced') return null;
+    const balanceKind = computeBalance(postings).kind;
+    if (balanceKind !== 'balanced' && balanceKind !== 'auto-balance')
+      return null;
     const positives = assetOrLiabilityPostings.filter(
       (p) => Number(p.amount) > 0
     );
-    const negatives = assetOrLiabilityPostings.filter(
-      (p) => Number(p.amount) < 0
-    );
     if (positives.length !== 1) return null;
     const to = positives[0];
-    const from = singleAccount(negatives);
+    // `from` is the other asset/liability account. Its amount may be blank —
+    // ledger auto-balances the outflow — so identify it by account, not by
+    // sign (a `< 0` filter would miss the amount-less balancing posting).
+    const from = singleAccount(
+      assetOrLiabilityPostings.filter((p) => p.account !== to.account)
+    );
     if (!from || from === to.account) return null;
     return {
       ...headerOf(draft),


### PR DESCRIPTION
Audit #3 — the last of the balancing trio, and the only one that wrote a JS-computed number **into the journal**.

## Before
The four structured entry forms (expense/income/transfer/exchange) with extra items appended a balancing posting whose amount `balancingPostings` computed in JS floats (`formatAmount(-residual)`). A rounding divergence from ledger's exact residual → the transaction gets rejected on save.

## After
Emit **one amount-less posting**; ledger fills the exact amount — multi-currency and cost-aware — when it parses the saved transaction. Verified a single blank absorbs a USD+EUR residual (`ledger stats` accepts it, `print` fills both). This is the pattern `fixBalanceAdapter` already uses.

- `balancingPostings` → single `{account, amount:'', currency:''}` when there's a residual; `residualByCurrency` stays as a *predicate* only (is a line needed?), never a written amount. `formatAmount` deleted.
- `transfer.detect` keyed `from` off a `< 0` amount, which an amount-less outflow no longer has → identify it by account instead.
- The four `detect`s accept `auto-balance` (a saved amount-less posting parses back as a blank line), so the Types tab still recognises its own transactions on edit.

## Trade-off
The form preview now shows the balancing line **blank** ("Blank posting will auto-balance") instead of a pre-computed figure — ledger owns the number. `canSubmit` already accepts `auto-balance`, so submit is unaffected.

Full suite green (1018). Trio complete: #1 stays as the client-side live-feedback hint, #2 (schema) and #3 now defer to ledger.