### PR TITLE
feat(transactions): Debt quick-entry with two directions

### DIFF
--- a/features/transactions/QuickEntry.tsx
+++ b/features/transactions/QuickEntry.tsx
@@ -54,10 +54,7 @@ function QuickEntryContent({
     startTransition(async () => {
       const payee =
         fields.payee.trim() || spec.resolvePayee?.(fields) || spec.label;
-      const draft = spec.adapter.compile(
-        { ...fields, payee },
-        { defaultCurrency }
-      );
+      const draft = spec.compile({ ...fields, payee }, { defaultCurrency });
       const formData = new FormData();
       formData.set('draft', serializeDraftJson(draft, 'create'));
       const result = await createTransactionAction(null, formData);

--- a/features/transactions/quickEntrySpecs.test.tsx
+++ b/features/transactions/quickEntrySpecs.test.tsx
@@ -113,3 +113,40 @@ describe('resolvePayee falls back to a sensible leaf/label', () => {
     );
   });
 });
+
+describe('debt spec compiles to the right accounts', () => {
+  const debt = specOf('debt');
+  const fields = (patch: Record<string, string>) => ({
+    ...debt.makeEmpty(ctx),
+    person: 'Alex',
+    amount: '50',
+    cashAccount: 'Assets:Checking',
+    ...patch,
+  });
+  const postingsOf = (patch: Record<string, string>) =>
+    debt.compile(fields(patch), ctx).toWire('create').postings;
+
+  it('owed to you: their receivable rises, your cash falls', () => {
+    expect(postingsOf({ direction: 'owed-to-you' })).toEqual([
+      { account: 'Assets:Receivable:Alex', amount: '50', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-50', currency: 'USD' },
+    ]);
+  });
+
+  it('you owe them: your cash rises, your payable falls', () => {
+    expect(postingsOf({ direction: 'you-owe' })).toEqual([
+      { account: 'Assets:Checking', amount: '50', currency: 'USD' },
+      { account: 'Liabilities:Payable:Alex', amount: '-50', currency: 'USD' },
+    ]);
+  });
+
+  it('sanitizes a name into a single account segment', () => {
+    expect(postingsOf({ person: 'Bob:  Smith' })[0].account).toBe(
+      'Assets:Receivable:Bob Smith'
+    );
+  });
+
+  it('validate rejects a missing name', () => {
+    expect(debt.validate(fields({ person: '  ' }))).toBe('Enter a name.');
+  });
+});

--- a/features/transactions/quickEntrySpecs.test.tsx
+++ b/features/transactions/quickEntrySpecs.test.tsx
@@ -149,4 +149,16 @@ describe('debt spec compiles to the right accounts', () => {
   it('validate rejects a missing name', () => {
     expect(debt.validate(fields({ person: '  ' }))).toBe('Enter a name.');
   });
+
+  it('validate rejects the cash account resolving to the person account', () => {
+    expect(
+      debt.validate(
+        fields({
+          direction: 'owed-to-you',
+          person: 'Alex',
+          cashAccount: 'Assets:Receivable:Alex',
+        })
+      )
+    ).toBe('The cash account must differ from the person.');
+  });
 });

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import AmountInput from './AmountInput';
+import type { DraftState } from './entry/draftReducer';
 import {
   AccountField,
   CurrencyCombobox,
@@ -21,6 +22,8 @@ import {
 } from './entry/types/fixBalance';
 import { incomeAdapter, type IncomeFields } from './entry/types/income';
 import { transferAdapter, type TransferFields } from './entry/types/transfer';
+import Combobox from '@/components/Combobox';
+import { Button } from '@/components/ui/button';
 
 export type QuickEntryContext = { accounts: string[]; defaultCurrency: string };
 
@@ -30,16 +33,16 @@ type FieldsProps<F> = {
 } & QuickEntryContext;
 
 /**
- * A single quick-entry form: how to seed it, validate it, name it, and render
- * its handful of inputs. The heavy lifting — turning these simple fields into a
- * correctly balanced ledger draft — is delegated to the shared `adapter`, so
- * this file never does accounting math.
+ * A single quick-entry form: how to seed it, validate it, name it, render its
+ * handful of inputs, and compile it to a ledger draft. `compile` delegates to a
+ * shared type adapter, so this file never does accounting math — it only builds
+ * the simple fields and hands them off.
  */
 export type QuickEntrySpec<F extends HeaderFields> = {
   kind: string;
   label: string;
   icon: string;
-  adapter: TransactionTypeAdapter<F>;
+  compile: (fields: F, ctx: TypeContext) => DraftState;
   makeEmpty: (ctx: QuickEntryContext) => F;
   validate: (fields: F) => string | null;
   // Fallback payee when the user leaves it blank (the journal requires one).
@@ -96,7 +99,7 @@ const expenseSpec: QuickEntrySpec<ExpenseFields> = {
   kind: 'expense',
   label: 'Expense',
   icon: '🛒',
-  adapter: expenseAdapter,
+  compile: expenseAdapter.compile,
   makeEmpty: (ctx) => ({
     ...seed(expenseAdapter, ctx),
     paidFrom: firstMoneyAccount(ctx.accounts),
@@ -141,7 +144,7 @@ const incomeSpec: QuickEntrySpec<IncomeFields> = {
   kind: 'income',
   label: 'Income',
   icon: '💰',
-  adapter: incomeAdapter,
+  compile: incomeAdapter.compile,
   makeEmpty: (ctx) => ({
     ...seed(incomeAdapter, ctx),
     receivedInto: firstMoneyAccount(ctx.accounts),
@@ -186,7 +189,7 @@ const transferSpec: QuickEntrySpec<TransferFields> = {
   kind: 'transfer',
   label: 'Transfer',
   icon: '🔁',
-  adapter: transferAdapter,
+  compile: transferAdapter.compile,
   makeEmpty: (ctx) => ({
     ...seed(transferAdapter, ctx),
     from: firstMoneyAccount(ctx.accounts),
@@ -233,7 +236,7 @@ const exchangeSpec: QuickEntrySpec<ExchangeFields> = {
   kind: 'exchange',
   label: 'Exchange',
   icon: '💱',
-  adapter: exchangeAdapter,
+  compile: exchangeAdapter.compile,
   // Seed only the paid-from side; leave received-into blank so the two account
   // pickers don't default to the same account (validate then guards equality).
   makeEmpty: (ctx) => ({
@@ -293,7 +296,7 @@ const fixBalanceSpec: QuickEntrySpec<FixBalanceFields> = {
   kind: 'fix-balance',
   label: 'Fix balance',
   icon: '⚖️',
-  adapter: fixBalanceAdapter,
+  compile: fixBalanceAdapter.compile,
   makeEmpty: (ctx) => ({
     ...seed(fixBalanceAdapter, ctx),
     account: firstMoneyAccount(ctx.accounts),
@@ -325,6 +328,143 @@ const fixBalanceSpec: QuickEntrySpec<FixBalanceFields> = {
   ),
 };
 
+// --- Debt (money owed) -----------------------------------------------------
+// Not a registry adapter: a debt is mechanically a transfer, so it compiles via
+// transferAdapter. The value it adds is translation — the user names a person
+// and the form builds the right account (Assets:Receivable:<Name> for money
+// owed to them, Liabilities:Payable:<Name> for money they owe), so a per-person
+// balance is a single ledger query over `/:<Name>$/`.
+const RECEIVABLE_ROOT = 'Assets:Receivable';
+const PAYABLE_ROOT = 'Liabilities:Payable';
+
+type DebtDirection = 'owed-to-you' | 'you-owe';
+
+type DebtFields = HeaderFields & {
+  direction: DebtDirection;
+  person: string;
+  amount: string;
+  currency: string;
+  cashAccount: string;
+};
+
+// A person name becomes a single account segment: colons would fake a
+// sub-hierarchy and doubled spaces are rejected by the account schema.
+const cleanPerson = (raw: string) =>
+  raw.replace(/:/g, ' ').replace(/\s+/g, ' ').trim();
+
+// Existing people, parsed from the receivable/payable account leaves, so the
+// same person reuses the same account instead of spawning a near-duplicate.
+const knownPeople = (accounts: string[]): string[] => {
+  const people = new Set<string>();
+  for (const account of accounts) {
+    const match = account.match(
+      /^(?:Assets:Receivable|Liabilities:Payable):(.+)$/
+    );
+    if (match) people.add(match[1]);
+  }
+  return [...people];
+};
+
+const debtSpec: QuickEntrySpec<DebtFields> = {
+  kind: 'debt',
+  label: 'Debt',
+  icon: '🤝',
+  makeEmpty: (ctx) => ({
+    date: todayLocal(),
+    payee: '',
+    status: 'none',
+    note: '',
+    direction: 'owed-to-you',
+    person: '',
+    amount: '',
+    currency: ctx.defaultCurrency,
+    cashAccount: firstMoneyAccount(ctx.accounts),
+  }),
+  validate: (f) =>
+    !cleanPerson(f.person)
+      ? 'Enter a name.'
+      : !isPositive(f.amount)
+        ? 'Enter an amount.'
+        : !f.cashAccount.trim()
+          ? 'Pick an account.'
+          : null,
+  resolvePayee: (f) =>
+    f.direction === 'owed-to-you'
+      ? `Lent to ${cleanPerson(f.person)}`
+      : `Borrowed from ${cleanPerson(f.person)}`,
+  compile: (f, ctx) => {
+    const person = cleanPerson(f.person);
+    // `to` gets +amount, `from` gets −amount (transferAdapter convention).
+    // Owed to you: their receivable rises, your cash falls.
+    // You owe them: your cash rises, your payable falls (a liability you owe).
+    const [to, from] =
+      f.direction === 'owed-to-you'
+        ? [`${RECEIVABLE_ROOT}:${person}`, f.cashAccount]
+        : [f.cashAccount, `${PAYABLE_ROOT}:${person}`];
+    const transferFields: TransferFields = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+      amount: f.amount,
+      currency: f.currency,
+      from,
+      to,
+      extraItems: [],
+    };
+    return transferAdapter.compile(transferFields, ctx);
+  },
+  Fields: ({ fields, update, accounts, defaultCurrency }) => {
+    const owedToYou = fields.direction === 'owed-to-you';
+    return (
+      <>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            type="button"
+            variant={owedToYou ? 'default' : 'outline'}
+            onClick={() => update({ direction: 'owed-to-you' })}
+          >
+            They owe you
+          </Button>
+          <Button
+            type="button"
+            variant={owedToYou ? 'outline' : 'default'}
+            onClick={() => update({ direction: 'you-owe' })}
+          >
+            You owe them
+          </Button>
+        </div>
+
+        <Field label="Name">
+          <Combobox
+            value={fields.person}
+            onChange={(person) => update({ person })}
+            options={knownPeople(accounts)}
+            placeholder="e.g. Alex"
+          />
+        </Field>
+
+        <AmountRow
+          label="Amount"
+          amount={fields.amount}
+          currency={fields.currency || defaultCurrency}
+          onAmount={(amount) => update({ amount })}
+          onCurrency={(currency) => update({ currency })}
+        />
+
+        <AccountField
+          label={owedToYou ? 'Paid from' : 'Received into'}
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.cashAccount}
+          onChange={(cashAccount) => update({ cashAccount })}
+        />
+      </>
+    );
+  },
+};
+
 // Order shown in the dropdown; expense is the primary split-button action.
 // Erased to a uniform field type at the boundary (like registry.ts does with
 // its adapters) so the engine can treat every spec identically — each spec is
@@ -334,5 +474,6 @@ export const QUICK_ENTRY_SPECS = [
   incomeSpec,
   transferSpec,
   exchangeSpec,
+  debtSpec,
   fixBalanceSpec,
 ] as unknown as readonly QuickEntrySpec<HeaderFields>[];

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -358,7 +358,7 @@ const knownPeople = (accounts: string[]): string[] => {
   const people = new Set<string>();
   for (const account of accounts) {
     const match = account.match(
-      /^(?:Assets:Receivable|Liabilities:Payable):(.+)$/
+      /^(?:Assets:Receivable|Liabilities:Payable):([^:]+)$/
     );
     if (match) people.add(match[1]);
   }

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -365,6 +365,16 @@ const knownPeople = (accounts: string[]): string[] => {
   return [...people];
 };
 
+// Resolve the person account and its opposite (cash) side for a direction, so
+// validate and compile agree on which two accounts a debt touches.
+const debtAccounts = (
+  person: string,
+  f: DebtFields
+): [to: string, from: string] =>
+  f.direction === 'owed-to-you'
+    ? [`${RECEIVABLE_ROOT}:${person}`, f.cashAccount]
+    : [f.cashAccount, `${PAYABLE_ROOT}:${person}`];
+
 const debtSpec: QuickEntrySpec<DebtFields> = {
   kind: 'debt',
   label: 'Debt',
@@ -380,14 +390,17 @@ const debtSpec: QuickEntrySpec<DebtFields> = {
     currency: ctx.defaultCurrency,
     cashAccount: firstMoneyAccount(ctx.accounts),
   }),
-  validate: (f) =>
-    !cleanPerson(f.person)
-      ? 'Enter a name.'
-      : !isPositive(f.amount)
-        ? 'Enter an amount.'
-        : !f.cashAccount.trim()
-          ? 'Pick an account.'
-          : null,
+  validate: (f) => {
+    const person = cleanPerson(f.person);
+    if (!person) return 'Enter a name.';
+    if (!isPositive(f.amount)) return 'Enter an amount.';
+    if (!f.cashAccount.trim()) return 'Pick an account.';
+    const [to, from] = debtAccounts(person, f);
+    // The cash picker offers receivable/payable accounts too, so a user can
+    // pick the same person's account as cash — that nets to zero on one account.
+    if (from === to) return 'The cash account must differ from the person.';
+    return null;
+  },
   resolvePayee: (f) =>
     f.direction === 'owed-to-you'
       ? `Lent to ${cleanPerson(f.person)}`
@@ -397,10 +410,7 @@ const debtSpec: QuickEntrySpec<DebtFields> = {
     // `to` gets +amount, `from` gets −amount (transferAdapter convention).
     // Owed to you: their receivable rises, your cash falls.
     // You owe them: your cash rises, your payable falls (a liability you owe).
-    const [to, from] =
-      f.direction === 'owed-to-you'
-        ? [`${RECEIVABLE_ROOT}:${person}`, f.cashAccount]
-        : [f.cashAccount, `${PAYABLE_ROOT}:${person}`];
+    const [to, from] = debtAccounts(person, f);
     const transferFields: TransferFields = {
       date: f.date,
       payee: f.payee,


### PR DESCRIPTION
## What

Adds a **Debt** item to the quick-entry dropdown — a two-direction form for money owed, aimed at a user who doesn't think in double-entry.

- Tabs: **They owe you** / **You owe them**
- Fields: Name, Amount, and the cash account (labelled *Paid from* / *Received into* per direction)

## Account model

The form names a person and builds the right account, so a per-person balance is a single ledger query over the person's leaf (`ledger bal /:<Name>$/`):

| Direction | Account | Effect |
|-----------|---------|--------|
| They owe you | `Assets:Receivable:<Name>` | receivable rises, your cash falls |
| You owe them | `Liabilities:Payable:<Name>` | your cash rises, your payable falls |

Two trees (mirrored leaf) keep net-worth and balance reports correct with no negative-asset caveats.

## How

A debt is mechanically a **transfer**, so it compiles through `transferAdapter` — no new accounting code. `QuickEntrySpec` now carries a `compile` function directly (instead of requiring a full registry adapter), letting a type supply its own compilation without joining the full entry-form registry.

- **Name → single account segment**: colons stripped (no fake sub-hierarchy), doubled spaces collapsed, trimmed.
- **Reuse**: the Name field is a combobox of existing people parsed from `Receivable:*` / `Payable:*` leaves, so the same person maps to the same account.
- Blank description falls back to a direction-aware payee (`Lent to <Name>` / `Borrowed from <Name>`).

## Scope

Entry form only — the accounts show up in existing balance reports. A dedicated per-person "Debts" balances view is a follow-up.

## Tests

`quickEntrySpecs.test.tsx` covers both directions' postings, name sanitization, and validation. `tsc` clean, eslint clean, 27 passing. Not click-tested live yet.