### PR TITLE
feat(transactions): split expenses and income across categories

### DIFF
--- a/features/transactions/entry/typeForms/ExtraItemsField.tsx
+++ b/features/transactions/entry/typeForms/ExtraItemsField.tsx
@@ -15,12 +15,19 @@ export function ExtraItemsField({
   defaultCurrency,
   baseCount,
   onChange,
+  sectionLabel = 'Extra items (fees, tips…)',
+  addLabel = 'Add item',
 }: {
   items: ExtraItem[];
   accounts: string[];
   defaultCurrency: string;
   baseCount: number;
   onChange: (items: ExtraItem[]) => void;
+  // Quick-entry reuses this component with its own copy — an expense splits into
+  // "another category", income into "a deduction" — but the row logic (stable
+  // ids, posting cap, per-row currency) stays shared instead of forked.
+  sectionLabel?: string;
+  addLabel?: string;
 }): React.JSX.Element {
   // `compile` emits one balancing posting per distinct residual currency, so the
   // compiled transaction can exceed the row count when extras span several
@@ -72,7 +79,7 @@ export function ExtraItemsField({
 
   return (
     <section className="flex flex-col gap-3">
-      <SectionLabel>Extra items (fees, tips…)</SectionLabel>
+      <SectionLabel>{sectionLabel}</SectionLabel>
 
       {items.map((item, index) => (
         <div
@@ -119,7 +126,7 @@ export function ExtraItemsField({
           disabled={atCap}
           onClick={addItem}
         >
-          + Add item
+          + {addLabel}
         </Button>
         {atCap && (
           <span className="text-xs text-muted-foreground">

--- a/features/transactions/quickEntrySpecs.test.tsx
+++ b/features/transactions/quickEntrySpecs.test.tsx
@@ -114,6 +114,64 @@ describe('resolvePayee falls back to a sensible leaf/label', () => {
   });
 });
 
+describe('splits surface extra category lines to the adapter', () => {
+  it('expense: each split is its own posting, paid-from balances the rest', () => {
+    const spec = specOf('expense');
+    const fields = {
+      ...spec.makeEmpty(ctx),
+      amount: '30',
+      spentOn: 'Expenses:Groceries',
+      paidFrom: 'Assets:Checking',
+      extraItems: [
+        { account: 'Expenses:Household', amount: '20', currency: 'USD' },
+      ],
+    };
+    const draft = spec.compile(fields, ctx);
+    expect(draft.toWire('create').postings).toEqual([
+      { account: 'Expenses:Groceries', amount: '30', currency: 'USD' },
+      { account: 'Expenses:Household', amount: '20', currency: 'USD' },
+      // Amount-less: ledger fills the −50 residual, never JS.
+      { account: 'Assets:Checking', amount: '', currency: '' },
+    ]);
+  });
+
+  it('income: deductions post alongside the source, received-into balances', () => {
+    const spec = specOf('income');
+    const fields = {
+      ...spec.makeEmpty(ctx),
+      amount: '1000',
+      receivedInto: 'Assets:Checking',
+      from: 'Income:Salary',
+      extraItems: [{ account: 'Expenses:Tax', amount: '200', currency: 'USD' }],
+    };
+    const draft = spec.compile(fields, ctx);
+    expect(draft.toWire('create').postings).toEqual([
+      { account: 'Assets:Checking', amount: '', currency: '' },
+      { account: 'Income:Salary', amount: '-1000', currency: 'USD' },
+      { account: 'Expenses:Tax', amount: '200', currency: 'USD' },
+    ]);
+  });
+
+  it('drops half-filled split rows (an account or amount alone is not a posting)', () => {
+    const spec = specOf('expense');
+    const fields = {
+      ...spec.makeEmpty(ctx),
+      amount: '30',
+      spentOn: 'Expenses:Groceries',
+      paidFrom: 'Assets:Checking',
+      extraItems: [
+        { account: 'Expenses:Household', amount: '', currency: 'USD' },
+      ],
+    };
+    const draft = spec.compile(fields, ctx);
+    // No real extra → plain two-posting expense with an explicit −30.
+    expect(draft.toWire('create').postings).toEqual([
+      { account: 'Expenses:Groceries', amount: '30', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-30', currency: 'USD' },
+    ]);
+  });
+});
+
 describe('debt spec compiles to the right accounts', () => {
   const debt = specOf('debt');
   const fields = (patch: Record<string, string>) => ({

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { XIcon } from 'lucide-react';
 import React from 'react';
 import AmountInput from './AmountInput';
 import type { DraftState } from './entry/draftReducer';
@@ -16,6 +17,7 @@ import type {
 } from './entry/types/adapter';
 import { exchangeAdapter, type ExchangeFields } from './entry/types/exchange';
 import { expenseAdapter, type ExpenseFields } from './entry/types/expense';
+import type { ExtraItem } from './entry/types/extraItems';
 import {
   fixBalanceAdapter,
   type FixBalanceFields,
@@ -95,6 +97,74 @@ const AmountRow = ({
   </Field>
 );
 
+// Optional extra category lines on an expense/income. Collapsed to a single
+// "add line" affordance by default so the common one-category entry stays
+// clean; each added row is a category + amount. The adapters already turn these
+// into balancing postings, so ledger — not this UI — does the summing.
+const SplitRows = ({
+  label,
+  addLabel,
+  items,
+  currency,
+  accounts,
+  onChange,
+}: {
+  label: string;
+  addLabel: string;
+  items: ExtraItem[];
+  currency: string;
+  accounts: string[];
+  onChange: (items: ExtraItem[]) => void;
+}) => {
+  const setItem = (index: number, patch: Partial<ExtraItem>) =>
+    onChange(items.map((it, i) => (i === index ? { ...it, ...patch } : it)));
+  const add = () => onChange([...items, { account: '', amount: '', currency }]);
+  const remove = (index: number) =>
+    onChange(items.filter((_, i) => i !== index));
+
+  return (
+    <>
+      {items.map((item, index) => (
+        <div key={index} className="flex items-end gap-2">
+          <div className="flex-1">
+            <AccountField
+              label={label}
+              role="expense"
+              accounts={accounts}
+              value={item.account}
+              onChange={(account) => setItem(index, { account })}
+            />
+          </div>
+          <AmountInput
+            value={item.amount}
+            onChange={(amount) => setItem(index, { amount })}
+            placeholder="0.00"
+            className="w-28 text-right tabular-nums"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Remove line"
+            onClick={() => remove(index)}
+          >
+            <XIcon />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start px-1 text-muted-foreground"
+        onClick={add}
+      >
+        + {addLabel}
+      </Button>
+    </>
+  );
+};
+
 const expenseSpec: QuickEntrySpec<ExpenseFields> = {
   kind: 'expense',
   label: 'Expense',
@@ -128,6 +198,14 @@ const expenseSpec: QuickEntrySpec<ExpenseFields> = {
         accounts={accounts}
         value={fields.spentOn}
         onChange={(spentOn) => update({ spentOn })}
+      />
+      <SplitRows
+        label="Category"
+        addLabel="Split into another category"
+        items={fields.extraItems}
+        currency={fields.currency}
+        accounts={accounts}
+        onChange={(extraItems) => update({ extraItems })}
       />
       <AccountField
         label="Paid from"
@@ -180,6 +258,14 @@ const incomeSpec: QuickEntrySpec<IncomeFields> = {
         accounts={accounts}
         value={fields.from}
         onChange={(from) => update({ from })}
+      />
+      <SplitRows
+        label="Deduction"
+        addLabel="Add a deduction"
+        items={fields.extraItems}
+        currency={fields.currency}
+        accounts={accounts}
+        onChange={(extraItems) => update({ extraItems })}
       />
     </>
   ),

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { XIcon } from 'lucide-react';
 import React from 'react';
 import AmountInput from './AmountInput';
 import type { DraftState } from './entry/draftReducer';
+import { ExtraItemsField } from './entry/typeForms/ExtraItemsField';
 import {
   AccountField,
   CurrencyCombobox,
@@ -17,7 +17,6 @@ import type {
 } from './entry/types/adapter';
 import { exchangeAdapter, type ExchangeFields } from './entry/types/exchange';
 import { expenseAdapter, type ExpenseFields } from './entry/types/expense';
-import type { ExtraItem } from './entry/types/extraItems';
 import {
   fixBalanceAdapter,
   type FixBalanceFields,
@@ -97,74 +96,6 @@ const AmountRow = ({
   </Field>
 );
 
-// Optional extra category lines on an expense/income. Collapsed to a single
-// "add line" affordance by default so the common one-category entry stays
-// clean; each added row is a category + amount. The adapters already turn these
-// into balancing postings, so ledger — not this UI — does the summing.
-const SplitRows = ({
-  label,
-  addLabel,
-  items,
-  currency,
-  accounts,
-  onChange,
-}: {
-  label: string;
-  addLabel: string;
-  items: ExtraItem[];
-  currency: string;
-  accounts: string[];
-  onChange: (items: ExtraItem[]) => void;
-}) => {
-  const setItem = (index: number, patch: Partial<ExtraItem>) =>
-    onChange(items.map((it, i) => (i === index ? { ...it, ...patch } : it)));
-  const add = () => onChange([...items, { account: '', amount: '', currency }]);
-  const remove = (index: number) =>
-    onChange(items.filter((_, i) => i !== index));
-
-  return (
-    <>
-      {items.map((item, index) => (
-        <div key={index} className="flex items-end gap-2">
-          <div className="flex-1">
-            <AccountField
-              label={label}
-              role="expense"
-              accounts={accounts}
-              value={item.account}
-              onChange={(account) => setItem(index, { account })}
-            />
-          </div>
-          <AmountInput
-            value={item.amount}
-            onChange={(amount) => setItem(index, { amount })}
-            placeholder="0.00"
-            className="w-28 text-right tabular-nums"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Remove line"
-            onClick={() => remove(index)}
-          >
-            <XIcon />
-          </Button>
-        </div>
-      ))}
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="self-start px-1 text-muted-foreground"
-        onClick={add}
-      >
-        + {addLabel}
-      </Button>
-    </>
-  );
-};
-
 const expenseSpec: QuickEntrySpec<ExpenseFields> = {
   kind: 'expense',
   label: 'Expense',
@@ -199,12 +130,13 @@ const expenseSpec: QuickEntrySpec<ExpenseFields> = {
         value={fields.spentOn}
         onChange={(spentOn) => update({ spentOn })}
       />
-      <SplitRows
-        label="Category"
-        addLabel="Split into another category"
+      <ExtraItemsField
+        sectionLabel="Split into another category"
+        addLabel="another category"
         items={fields.extraItems}
-        currency={fields.currency}
         accounts={accounts}
+        defaultCurrency={fields.currency}
+        baseCount={2}
         onChange={(extraItems) => update({ extraItems })}
       />
       <AccountField
@@ -259,12 +191,13 @@ const incomeSpec: QuickEntrySpec<IncomeFields> = {
         value={fields.from}
         onChange={(from) => update({ from })}
       />
-      <SplitRows
-        label="Deduction"
-        addLabel="Add a deduction"
+      <ExtraItemsField
+        sectionLabel="Deductions"
+        addLabel="a deduction"
         items={fields.extraItems}
-        currency={fields.currency}
         accounts={accounts}
+        defaultCurrency={fields.currency}
+        baseCount={2}
         onChange={(extraItems) => update({ extraItems })}
       />
     </>


### PR DESCRIPTION
Surfaces the entry adapters' existing `extraItems` in the quick-entry form.

## What
A collapsed **"add another line"** affordance under **Expense** and **Income**:
- Expense: split one receipt across several categories (groceries + household).
- Income: carry deductions on a paycheck (salary − tax → net into an account).

The single-category default is unchanged — the extra rows only appear once you add one.

## Accounting stays in ledger
Extra rows compile to postings; the paid-from / received-into line is left
**amount-less** so ledger fills the residual. No JS summation (CLAUDE.md hard rule).
Half-filled rows (account or amount alone) are dropped rather than emitted.

## Tests
`quickEntrySpecs.test.tsx` covers the expense split, income deductions, and the
half-filled-row drop. `tsc --noEmit` and `vitest run features/transactions` green.