### PR TITLE
feat(transactions): add Refund quick-entry for money back

### DIFF
--- a/features/transactions/quickEntrySpecs.test.tsx
+++ b/features/transactions/quickEntrySpecs.test.tsx
@@ -114,6 +114,37 @@ describe('resolvePayee falls back to a sensible leaf/label', () => {
   });
 });
 
+describe('refund puts money back into an account and credits a category', () => {
+  const spec = specOf('refund');
+
+  it('compiles to money-in on the account and the category negated', () => {
+    const fields = {
+      ...spec.makeEmpty(ctx),
+      amount: '20',
+      receivedInto: 'Assets:Checking',
+      from: 'Expenses:Groceries',
+    };
+    expect(spec.compile(fields, ctx).toWire('create').postings).toEqual([
+      { account: 'Assets:Checking', amount: '20', currency: 'USD' },
+      { account: 'Expenses:Groceries', amount: '-20', currency: 'USD' },
+    ]);
+  });
+
+  it('names the payee after the refunded category', () => {
+    const fields = { ...spec.makeEmpty(ctx), from: 'Expenses:Groceries' };
+    expect(spec.resolvePayee?.(fields)).toBe('Refund: Groceries');
+  });
+
+  it('rejects a missing category', () => {
+    const fields = {
+      ...spec.makeEmpty(ctx),
+      amount: '20',
+      receivedInto: 'Assets:Checking',
+    };
+    expect(spec.validate(fields)).toBe('Pick the category being refunded.');
+  });
+});
+
 describe('debt spec compiles to the right accounts', () => {
   const debt = specOf('debt');
   const fields = (patch: Record<string, string>) => ({

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -185,6 +185,56 @@ const incomeSpec: QuickEntrySpec<IncomeFields> = {
   ),
 };
 
+// A refund is money coming back into an account and crediting a category back
+// down (a returned purchase). That is exactly an income entry whose "source" is
+// an expense account rather than an income one, so it compiles through
+// incomeAdapter unchanged — money into `receivedInto`, the same amount negated
+// on the expense category. No new adapter, no negative-amount input to fat-finger.
+const refundSpec: QuickEntrySpec<IncomeFields> = {
+  kind: 'refund',
+  label: 'Refund',
+  icon: '↩️',
+  compile: incomeAdapter.compile,
+  makeEmpty: (ctx) => ({
+    ...seed(incomeAdapter, ctx),
+    receivedInto: firstMoneyAccount(ctx.accounts),
+  }),
+  validate: (f) =>
+    !isPositive(f.amount)
+      ? 'Enter an amount.'
+      : !f.receivedInto.trim()
+        ? 'Pick where the money went back.'
+        : !f.from.trim()
+          ? 'Pick the category being refunded.'
+          : null,
+  resolvePayee: (f) => `Refund: ${leafOf(f.from)}`,
+  Fields: ({ fields, update, accounts }) => (
+    <>
+      <AmountRow
+        label="Amount"
+        amount={fields.amount}
+        currency={fields.currency}
+        onAmount={(amount) => update({ amount })}
+        onCurrency={(currency) => update({ currency })}
+      />
+      <AccountField
+        label="Refunded to"
+        role={['asset', 'liability']}
+        accounts={accounts}
+        value={fields.receivedInto}
+        onChange={(receivedInto) => update({ receivedInto })}
+      />
+      <AccountField
+        label="Category"
+        role="expense"
+        accounts={accounts}
+        value={fields.from}
+        onChange={(from) => update({ from })}
+      />
+    </>
+  ),
+};
+
 const transferSpec: QuickEntrySpec<TransferFields> = {
   kind: 'transfer',
   label: 'Transfer',
@@ -482,6 +532,7 @@ const debtSpec: QuickEntrySpec<DebtFields> = {
 export const QUICK_ENTRY_SPECS = [
   expenseSpec,
   incomeSpec,
+  refundSpec,
   transferSpec,
   exchangeSpec,
   debtSpec,


### PR DESCRIPTION
Adds a **Refund** entry type for money returning into an account from an expense
category (a returned purchase).

## Cleanest path: reuse the income adapter
A refund posts `Assets:… +amount` / `Expenses:Category −amount` — which is exactly
what `incomeAdapter.compile` produces when the "source" is an expense account. So
Refund is a thin spec over the **existing** income adapter:
- No new adapter.
- No negative-amount input for the user to fat-finger — the amount is entered
  positive and the adapter negates the category side.

Ledger remains the authority on the resulting balance.

## Tests
`quickEntrySpecs.test.tsx` covers the compiled postings, the `Refund: <category>`
payee, and the missing-category guard. `tsc --noEmit` + `vitest run features/transactions` green.