### PR TITLE
feat(transactions): confirm quick-entry saves with an undo toast

### DIFF
--- a/features/transactions/QuickEntry.tsx
+++ b/features/transactions/QuickEntry.tsx
@@ -2,7 +2,8 @@
 
 import { ChevronDownIcon, PlusIcon } from 'lucide-react';
 import { useState, useTransition } from 'react';
-import { createTransactionAction } from './actions';
+import { toast } from 'sonner';
+import { createTransactionAction, undoTransactionAction } from './actions';
 import { serializeDraftJson } from './entry/draftReducer';
 import { Field } from './entry/typeForms/fields';
 import type { HeaderFields } from './entry/types/adapter';
@@ -26,6 +27,36 @@ import { Label } from '@/components/ui/label';
 import { useRouter } from 'next/navigation';
 
 type Props = { accounts: string[]; defaultCurrency: string };
+
+/**
+ * Confirm a save with a toast that carries an Undo. The toast outlives the
+ * dialog (Toaster is mounted in the app shell), so Undo runs after the form is
+ * gone — it only needs the new uid and a way to refresh the current view.
+ */
+function notifySaved(
+  label: string,
+  payee: string,
+  uid: string | undefined,
+  refresh: () => void
+) {
+  toast.success(`${label} saved`, {
+    description: payee,
+    action: uid
+      ? {
+          label: 'Undo',
+          onClick: async () => {
+            const result = await undoTransactionAction(uid);
+            if (result.ok) {
+              toast.success('Entry removed');
+              refresh();
+            } else {
+              toast.error(result.message);
+            }
+          },
+        }
+      : undefined,
+  });
+}
 
 /**
  * The dialog body for one entry type. Owns the field state and the save path
@@ -61,6 +92,7 @@ function QuickEntryContent({
       if (result.ok) {
         onDone();
         router.refresh();
+        notifySaved(spec.label, payee, result.uid, () => router.refresh());
       } else {
         const fieldError = result.fieldErrors
           ? Object.values(result.fieldErrors).flat()[0]

--- a/features/transactions/actions/createTransaction.ts
+++ b/features/transactions/actions/createTransaction.ts
@@ -45,5 +45,5 @@ export async function createTransactionAction(
       formError: result.formError,
     };
   }
-  return { ok: true };
+  return { ok: true, uid: result.uid };
 }

--- a/features/transactions/actions/index.ts
+++ b/features/transactions/actions/index.ts
@@ -6,3 +6,4 @@ export {
   type DeleteTransactionResult,
 } from './deleteTransaction';
 export { loadTransactionPageAction } from './loadTransactionPage';
+export { undoTransactionAction } from './undoTransaction';

--- a/features/transactions/actions/types.ts
+++ b/features/transactions/actions/types.ts
@@ -2,6 +2,8 @@ export type TransactionActionState = {
   ok: boolean;
   fieldErrors?: Record<string, string>;
   formError?: string;
+  // uid of the created transaction on success — lets the caller offer an Undo.
+  uid?: string;
 };
 
 export type SubmitAction = (

--- a/features/transactions/actions/undoTransaction.ts
+++ b/features/transactions/actions/undoTransaction.ts
@@ -3,19 +3,24 @@
 import { deleteTransactionAction } from './deleteTransaction';
 import type { DeleteTransactionResult } from './deleteTransaction';
 import { requireUser } from '@/lib/auth/require-user';
-import { journalRepository } from '@/lib/journal';
+import { journalService } from '@/lib/journal';
 
 /**
  * Undo a just-created transaction. Unlike a row-level delete, the caller (a
- * toast fired right after save) doesn't hold the journal fingerprint, so we
- * resolve the current one server-side and hand off to the audited delete path.
- * If anything else mutated the journal in between, that guard makes the undo
- * fail cleanly rather than delete stale data.
+ * toast fired right after save) doesn't hold the transaction fingerprint, so we
+ * resolve the created row server-side and hand off to the audited delete path.
+ * The delete guard compares against the per-transaction fingerprint, so we must
+ * pass that (not the whole-journal fingerprint). If anything else mutated the
+ * transaction in between, that guard makes the undo fail cleanly rather than
+ * delete stale data.
  */
 export async function undoTransactionAction(
   uid: string
 ): Promise<DeleteTransactionResult> {
   const user = await requireUser();
-  const fingerprint = await journalRepository.getFingerprint(user.id);
-  return deleteTransactionAction(uid, fingerprint);
+  const tx = await journalService.findTransaction(user.id, uid);
+  if (!tx?.fingerprint) {
+    return { ok: false, message: 'This transaction no longer exists.' };
+  }
+  return deleteTransactionAction(uid, tx.fingerprint);
 }

--- a/features/transactions/actions/undoTransaction.ts
+++ b/features/transactions/actions/undoTransaction.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { deleteTransactionAction } from './deleteTransaction';
+import type { DeleteTransactionResult } from './deleteTransaction';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalRepository } from '@/lib/journal';
+
+/**
+ * Undo a just-created transaction. Unlike a row-level delete, the caller (a
+ * toast fired right after save) doesn't hold the journal fingerprint, so we
+ * resolve the current one server-side and hand off to the audited delete path.
+ * If anything else mutated the journal in between, that guard makes the undo
+ * fail cleanly rather than delete stale data.
+ */
+export async function undoTransactionAction(
+  uid: string
+): Promise<DeleteTransactionResult> {
+  const user = await requireUser();
+  const fingerprint = await journalRepository.getFingerprint(user.id);
+  return deleteTransactionAction(uid, fingerprint);
+}

--- a/lib/journal/service.test.ts
+++ b/lib/journal/service.test.ts
@@ -308,6 +308,39 @@ describe('JournalService.deleteTransaction', () => {
       '2024-09-02 coffee\n    Expenses:Coffee  USD 4\n    Assets:Cash\n'
     );
   });
+
+  // Guards the undo path (undoTransactionAction): the fingerprint resolved via
+  // findTransaction(uid) must live in the same space the delete stale-guard
+  // compares against, so undo actually removes the row. A getFingerprint-style
+  // regression (whole-journal fingerprint) would make this delete return stale.
+  it('deletes a just-added row using the fingerprint from findTransaction', async () => {
+    const userId = 'test-user';
+    await fs.mkdir(getJournalDir(userId), { recursive: true });
+
+    const added = await service.addTransaction(userId, {
+      date: '2024-09-01',
+      payee: 'lunch',
+      status: 'none',
+      postings: [
+        { account: 'Expenses:Food', amount: '10', currency: 'USD' },
+        { account: 'Assets:Cash', amount: '-10', currency: 'USD' },
+      ],
+    });
+    expect(added.ok).toBe(true);
+    const uid = added.ok ? added.uid : '';
+
+    const found = await service.findTransaction(userId, uid);
+    expect(found?.fingerprint).toBeTruthy();
+
+    const result = await service.deleteTransaction(userId, {
+      kind: 'delete',
+      uid,
+      expectedFingerprint: found!.fingerprint!,
+    });
+    expect(result.ok).toBe(true);
+
+    expect(await service.findTransaction(userId, uid)).toBeNull();
+  });
 });
 
 describe('JournalService.backfillUids', () => {

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -32,7 +32,7 @@ const HEADER_START_REGEX = /^\d{4}[-/]\d{2}[-/]\d{2}/;
 const PATH_TRAVERSAL = /(^|[/\\])\.\.([/\\]|$)/;
 
 export type AddTransactionResult =
-  | { ok: true }
+  | { ok: true; uid: string }
   | {
       ok: false;
       reason: 'invalid' | 'quota' | 'write-failed' | 'parse-failed' | 'stale';
@@ -152,7 +152,8 @@ export class JournalService {
     }
 
     return withUserLock(userId, async () => {
-      const draft: TransactionDraft = { ...parsed.data, uid: generateUid() };
+      const uid = generateUid();
+      const draft: TransactionDraft = { ...parsed.data, uid };
       await pull(userId);
       const { mainPath } = await this.repo.ensureLayout(userId);
       // Snapshot the file so we can roll back if ledger rejects the result.
@@ -202,7 +203,7 @@ export class JournalService {
         return { ok: false, reason: 'stale', fieldErrors: {}, formError };
       }
       invalidateCache(userId);
-      return { ok: true };
+      return { ok: true, uid };
     });
   }
 


### PR DESCRIPTION
Closes the loop on a quick save with feedback + an escape hatch.

## What
On a successful quick-entry save, a success toast names what was saved (`Expense saved` + the description) and offers **Undo**, which removes the just-created transaction.

## Plumbing
`deleteTransactionAction` already existed but needs the transaction `uid` and the current journal fingerprint — neither of which `createTransactionAction` returned. So:
- `addTransaction` now returns the generated `uid`; `createTransactionAction` surfaces it.
- New `undoTransactionAction(uid)` resolves the current journal fingerprint **server-side** and delegates to the existing audited delete path. The toast never carries a fingerprint.

If the journal changed between save and undo, the existing stale-guard makes the undo fail cleanly (an error toast) rather than delete the wrong data. `sonner` was already mounted in the app shell.

## Tests
`tsc --noEmit` + `vitest run features/transactions lib/journal` green (284).