### PR TITLE
feat(transactions): add Settle up quick-entry to pay down a debt

### DIFF
--- a/features/transactions/quickEntrySpecs.test.tsx
+++ b/features/transactions/quickEntrySpecs.test.tsx
@@ -162,3 +162,51 @@ describe('debt spec compiles to the right accounts', () => {
     ).toBe('The cash account must differ from the person.');
   });
 });
+
+describe('settle-up reverses a debt back toward zero', () => {
+  const settle = specOf('settle');
+  const fields = (patch: Record<string, string>) => ({
+    ...settle.makeEmpty(ctx),
+    person: 'Alex',
+    amount: '50',
+    cashAccount: 'Assets:Checking',
+    ...patch,
+  });
+  const postingsOf = (patch: Record<string, string>) =>
+    settle.compile(fields(patch), ctx).toWire('create').postings;
+
+  it('they paid you back: your cash rises, their receivable falls', () => {
+    expect(postingsOf({ direction: 'they-paid-you' })).toEqual([
+      { account: 'Assets:Checking', amount: '50', currency: 'USD' },
+      { account: 'Assets:Receivable:Alex', amount: '-50', currency: 'USD' },
+    ]);
+  });
+
+  it('you paid them back: your payable rises toward zero, your cash falls', () => {
+    expect(postingsOf({ direction: 'you-paid-them' })).toEqual([
+      { account: 'Liabilities:Payable:Alex', amount: '50', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '-50', currency: 'USD' },
+    ]);
+  });
+
+  it('names the payee for each direction', () => {
+    expect(settle.resolvePayee?.(fields({ direction: 'they-paid-you' }))).toBe(
+      'Alex paid you back'
+    );
+    expect(settle.resolvePayee?.(fields({ direction: 'you-paid-them' }))).toBe(
+      'Paid Alex back'
+    );
+  });
+
+  it('rejects the cash account resolving to the person account', () => {
+    expect(
+      settle.validate(
+        fields({
+          direction: 'they-paid-you',
+          person: 'Alex',
+          cashAccount: 'Assets:Receivable:Alex',
+        })
+      )
+    ).toBe('The cash account must differ from the person.');
+  });
+});

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -475,6 +475,129 @@ const debtSpec: QuickEntrySpec<DebtFields> = {
   },
 };
 
+// --- Settle up (pay down a debt) -------------------------------------------
+// The follow-up the debt account model was designed for: reduce an existing
+// Assets:Receivable:<Name> / Liabilities:Payable:<Name> balance. Settling moves
+// money the opposite way to creating the debt, so the two accounts are exactly
+// debtAccounts' pair swapped — still a transfer, still ledger's math. We do not
+// look up the outstanding balance in JS (that's a ledger query); over- or
+// under-settling is the user's call and ledger records whatever remains.
+type SettleDirection = 'they-paid-you' | 'you-paid-them';
+
+type SettleFields = HeaderFields & {
+  direction: SettleDirection;
+  person: string;
+  amount: string;
+  currency: string;
+  cashAccount: string;
+};
+
+const settleAccounts = (
+  person: string,
+  f: SettleFields
+): [to: string, from: string] =>
+  f.direction === 'they-paid-you'
+    ? [f.cashAccount, `${RECEIVABLE_ROOT}:${person}`]
+    : [`${PAYABLE_ROOT}:${person}`, f.cashAccount];
+
+const settleSpec: QuickEntrySpec<SettleFields> = {
+  kind: 'settle',
+  label: 'Settle up',
+  icon: '✅',
+  makeEmpty: (ctx) => ({
+    date: todayLocal(),
+    payee: '',
+    status: 'none',
+    note: '',
+    direction: 'they-paid-you',
+    person: '',
+    amount: '',
+    currency: ctx.defaultCurrency,
+    cashAccount: firstMoneyAccount(ctx.accounts),
+  }),
+  validate: (f) => {
+    const person = cleanPerson(f.person);
+    if (!person) return 'Enter a name.';
+    if (!isPositive(f.amount)) return 'Enter an amount.';
+    if (!f.cashAccount.trim()) return 'Pick an account.';
+    const [to, from] = settleAccounts(person, f);
+    if (from === to) return 'The cash account must differ from the person.';
+    return null;
+  },
+  resolvePayee: (f) =>
+    f.direction === 'they-paid-you'
+      ? `${cleanPerson(f.person)} paid you back`
+      : `Paid ${cleanPerson(f.person)} back`,
+  compile: (f, ctx) => {
+    const person = cleanPerson(f.person);
+    // Swap of debtAccounts: `to` gets +amount, `from` gets −amount.
+    // They paid you back: your cash rises, their receivable falls toward zero.
+    // You paid them back: your payable rises toward zero, your cash falls.
+    const [to, from] = settleAccounts(person, f);
+    const transferFields: TransferFields = {
+      date: f.date,
+      payee: f.payee,
+      status: f.status,
+      note: f.note,
+      uid: f.uid,
+      amount: f.amount,
+      currency: f.currency,
+      from,
+      to,
+      extraItems: [],
+    };
+    return transferAdapter.compile(transferFields, ctx);
+  },
+  Fields: ({ fields, update, accounts, defaultCurrency }) => {
+    const theyPaid = fields.direction === 'they-paid-you';
+    return (
+      <>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            type="button"
+            variant={theyPaid ? 'default' : 'outline'}
+            onClick={() => update({ direction: 'they-paid-you' })}
+          >
+            They paid you back
+          </Button>
+          <Button
+            type="button"
+            variant={theyPaid ? 'outline' : 'default'}
+            onClick={() => update({ direction: 'you-paid-them' })}
+          >
+            You paid them back
+          </Button>
+        </div>
+
+        <Field label="Name">
+          <Combobox
+            value={fields.person}
+            onChange={(person) => update({ person })}
+            options={knownPeople(accounts)}
+            placeholder="e.g. Alex"
+          />
+        </Field>
+
+        <AmountRow
+          label="Amount"
+          amount={fields.amount}
+          currency={fields.currency || defaultCurrency}
+          onAmount={(amount) => update({ amount })}
+          onCurrency={(currency) => update({ currency })}
+        />
+
+        <AccountField
+          label={theyPaid ? 'Received into' : 'Paid from'}
+          role={['asset', 'liability']}
+          accounts={accounts}
+          value={fields.cashAccount}
+          onChange={(cashAccount) => update({ cashAccount })}
+        />
+      </>
+    );
+  },
+};
+
 // Order shown in the dropdown; expense is the primary split-button action.
 // Erased to a uniform field type at the boundary (like registry.ts does with
 // its adapters) so the engine can treat every spec identically — each spec is
@@ -485,5 +608,6 @@ export const QUICK_ENTRY_SPECS = [
   transferSpec,
   exchangeSpec,
   debtSpec,
+  settleSpec,
   fixBalanceSpec,
 ] as unknown as readonly QuickEntrySpec<HeaderFields>[];


### PR DESCRIPTION
The follow-up the debt account model was designed for.

## What
A **Settle up** entry that reduces an existing `Assets:Receivable:<Name>` or
`Liabilities:Payable:<Name>` balance — previously only doable as a manual Transfer.

- **They paid you back** → your cash rises, their receivable falls toward zero.
- **You paid them back** → your payable rises toward zero, your cash falls.

## Reuses the debt model
Settling moves money the *opposite* way to creating the debt, so the two accounts
are `debtAccounts`' pair **swapped**. Still a transfer compiled by `transferAdapter`,
still ledger's math. Reuses `cleanPerson`, `knownPeople`, and the receivable/payable
roots from the debt spec — no duplicated account logic.

The outstanding balance is never summed in JS (CLAUDE.md hard rule); ledger records
whatever remains, so over-/under-settling is handled correctly.

## Tests
Both directions' postings, per-direction payee, and the cash≠person guard.
`tsc --noEmit` + `vitest run features/transactions` green (200).