### PR TITLE
feat(transactions): repeat a saved template from quick-entry

### DIFF
--- a/features/transactions/QuickEntry.tsx
+++ b/features/transactions/QuickEntry.tsx
@@ -162,7 +162,10 @@ function RepeatTemplate({
         onDone();
         router.refresh();
       } else {
-        setError(result.formError ?? 'Could not save.');
+        const fieldError = result.fieldErrors
+          ? Object.values(result.fieldErrors).flat()[0]
+          : undefined;
+        setError(result.formError ?? fieldError ?? 'Could not save.');
       }
     });
 

--- a/features/transactions/QuickEntry.tsx
+++ b/features/transactions/QuickEntry.tsx
@@ -6,7 +6,11 @@ import { createTransactionAction } from './actions';
 import { serializeDraftJson } from './entry/draftReducer';
 import { Field } from './entry/typeForms/fields';
 import type { HeaderFields } from './entry/types/adapter';
-import { QUICK_ENTRY_SPECS, type QuickEntrySpec } from './quickEntrySpecs';
+import {
+  QUICK_ENTRY_SPECS,
+  todayLocal,
+  type QuickEntrySpec,
+} from './quickEntrySpecs';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -33,8 +37,6 @@ type Props = {
   defaultCurrency: string;
   templates?: Template[];
 };
-
-const todayLocal = () => new Date().toLocaleDateString('en-CA');
 
 /**
  * The dialog body for one entry type. Owns the field state and the save path

--- a/features/transactions/QuickEntry.tsx
+++ b/features/transactions/QuickEntry.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDownIcon, PlusIcon } from 'lucide-react';
+import { ChevronDownIcon, PlusIcon, RepeatIcon } from 'lucide-react';
 import { useState, useTransition } from 'react';
 import { createTransactionAction } from './actions';
 import { serializeDraftJson } from './entry/draftReducer';
@@ -19,13 +19,22 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import type { Template } from '@/db/schema/template';
+import { Transaction } from '@/lib/transactions/model';
 import { useRouter } from 'next/navigation';
 
-type Props = { accounts: string[]; defaultCurrency: string };
+type Props = {
+  accounts: string[];
+  defaultCurrency: string;
+  templates?: Template[];
+};
+
+const todayLocal = () => new Date().toLocaleDateString('en-CA');
 
 /**
  * The dialog body for one entry type. Owns the field state and the save path
@@ -121,12 +130,78 @@ function QuickEntryContent({
 }
 
 /**
+ * One-click repeat of a saved template with today's date — so a daily recurring
+ * entry isn't retyped. Reuses the same compile → create action path as the type
+ * forms (via Transaction.fromTemplate), so ledger validates the posted result.
+ */
+function RepeatTemplate({
+  templates,
+  defaultCurrency,
+  onDone,
+}: {
+  templates: Template[];
+  defaultCurrency: string;
+  onDone: () => void;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string>();
+
+  const repeat = (template: Template) =>
+    startTransition(async () => {
+      const draft = Transaction.fromTemplate(
+        template.draft,
+        defaultCurrency
+      ).withField('date', todayLocal());
+      const formData = new FormData();
+      formData.set('draft', serializeDraftJson(draft, 'create'));
+      const result = await createTransactionAction(null, formData);
+      if (result.ok) {
+        onDone();
+        router.refresh();
+      } else {
+        setError(result.formError ?? 'Could not save.');
+      }
+    });
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Repeat a template</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-2">
+        {templates.map((template) => (
+          <Button
+            key={template.id}
+            variant="outline"
+            disabled={pending}
+            className="h-auto justify-between py-2 text-left"
+            onClick={() => repeat(template)}
+          >
+            <span className="font-medium">{template.name}</span>
+            <span className="text-muted-foreground">
+              {template.draft.payee}
+            </span>
+          </Button>
+        ))}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+    </DialogContent>
+  );
+}
+
+/**
  * Split button in the app header: the primary click logs an expense; the caret
  * opens a menu for the other entry types. Mounted globally so it's reachable
  * from every page.
  */
-export default function QuickEntry({ accounts, defaultCurrency }: Props) {
+export default function QuickEntry({
+  accounts,
+  defaultCurrency,
+  templates = [],
+}: Props) {
   const [active, setActive] = useState<string | null>(null);
+  const [templateOpen, setTemplateOpen] = useState(false);
   const [primary, ...rest] = QUICK_ENTRY_SPECS;
   const spec = QUICK_ENTRY_SPECS.find((s) => s.kind === active) ?? null;
 
@@ -162,6 +237,15 @@ export default function QuickEntry({ accounts, defaultCurrency }: Props) {
                 {s.label}
               </DropdownMenuItem>
             ))}
+            {templates.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setTemplateOpen(true)}>
+                  <RepeatIcon />
+                  Repeat a template
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -179,6 +263,16 @@ export default function QuickEntry({ accounts, defaultCurrency }: Props) {
             accounts={accounts}
             defaultCurrency={defaultCurrency}
             onDone={() => setActive(null)}
+          />
+        )}
+      </Dialog>
+
+      <Dialog open={templateOpen} onOpenChange={setTemplateOpen}>
+        {templateOpen && (
+          <RepeatTemplate
+            templates={templates}
+            defaultCurrency={defaultCurrency}
+            onDone={() => setTemplateOpen(false)}
           />
         )}
       </Dialog>

--- a/features/transactions/QuickEntrySlot.tsx
+++ b/features/transactions/QuickEntrySlot.tsx
@@ -1,15 +1,25 @@
 import QuickEntry from './QuickEntry';
+import { requireUser } from '@/lib/auth/require-user';
 import { getAvailableCurrencies } from '@/lib/settings';
+import { templateRepository } from '@/lib/templates';
 import { getAccountSuggestions } from '@/lib/transactions/suggestions';
 
-// Server wrapper: loads the account list + base currency and hands them to the
-// client quick-entry split button. Placed in the app header slot so it's
-// reachable from every page. ponytail: re-runs `ledger accounts` per page
-// render; add a cache wrapper if it shows up in profiling.
+// Server wrapper: loads the account list + base currency + saved templates and
+// hands them to the client quick-entry split button. Placed in the app header
+// slot so it's reachable from every page. ponytail: re-runs `ledger accounts`
+// per page render; add a cache wrapper if it shows up in profiling.
 export default async function QuickEntrySlot() {
-  const [accounts, { base }] = await Promise.all([
+  const user = await requireUser();
+  const [accounts, { base }, templates] = await Promise.all([
     getAccountSuggestions(),
     getAvailableCurrencies(),
+    templateRepository.list(user.id),
   ]);
-  return <QuickEntry accounts={accounts} defaultCurrency={base} />;
+  return (
+    <QuickEntry
+      accounts={accounts}
+      defaultCurrency={base}
+      templates={templates}
+    />
+  );
 }

--- a/features/transactions/QuickEntrySlot.tsx
+++ b/features/transactions/QuickEntrySlot.tsx
@@ -1,5 +1,5 @@
 import QuickEntry from './QuickEntry';
-import { requireUser } from '@/lib/auth/require-user';
+import { getOptionalUser } from '@/lib/auth/require-user';
 import { getAvailableCurrencies } from '@/lib/settings';
 import { templateRepository } from '@/lib/templates';
 import { getAccountSuggestions } from '@/lib/transactions/suggestions';
@@ -9,7 +9,8 @@ import { getAccountSuggestions } from '@/lib/transactions/suggestions';
 // slot so it's reachable from every page. ponytail: re-runs `ledger accounts`
 // per page render; add a cache wrapper if it shows up in profiling.
 export default async function QuickEntrySlot() {
-  const user = await requireUser();
+  const user = await getOptionalUser();
+  if (!user) return null;
   const [accounts, { base }, templates] = await Promise.all([
     getAccountSuggestions(),
     getAvailableCurrencies(),

--- a/features/transactions/quickEntrySpecs.tsx
+++ b/features/transactions/quickEntrySpecs.tsx
@@ -50,7 +50,7 @@ export type QuickEntrySpec<F extends HeaderFields> = {
   Fields: (props: FieldsProps<F>) => React.JSX.Element;
 };
 
-const todayLocal = () => new Date().toLocaleDateString('en-CA');
+export const todayLocal = () => new Date().toLocaleDateString('en-CA');
 const leafOf = (account: string) => account.split(':').pop()?.trim() ?? '';
 const firstMoneyAccount = (accounts: string[]) =>
   optionsForRoles(accounts, ['asset', 'liability'])[0] ?? '';

--- a/lib/transactions/model.test.ts
+++ b/lib/transactions/model.test.ts
@@ -168,6 +168,17 @@ describe('Transaction.fromTemplate', () => {
     );
     expect(t.postings[0].currency).toBe('JPY');
   });
+
+  // The quick-entry "Repeat a template" path: hydrate, stamp today's date,
+  // and serialize for the create action.
+  it('stamps a date onto a repeated template for a create draft', () => {
+    const wire = Transaction.fromTemplate(tmpl, 'USD')
+      .withField('date', '2026-07-13')
+      .toWire('create');
+    expect(wire.date).toBe('2026-07-13');
+    expect(wire.payee).toBe('Groceries');
+    expect(wire.postings).toHaveLength(2);
+  });
 });
 
 describe('Transaction immutable updates', () => {


### PR DESCRIPTION
Gives quick-entry a **Repeat a template** shortcut so a daily recurring entry
isn't retyped.

## What
A menu item (shown only when the user has ≥1 saved template) opens a picker;
clicking a template posts it **immediately** with today's date.

The existing `TemplatePicker` opens the *full* form pre-filled — this adds the
instant one-click repeat that quick-entry is for.

## Reuse
- `Transaction.fromTemplate(draft, currency).withField('date', today)` → the same
  `createTransactionAction` the type forms use, so ledger validates the result.
- `QuickEntrySlot` loads the user's templates alongside accounts/currency (same
  pattern as `NewTransaction`).

## Tests
Added a model test for the hydrate → stamp-date → create-wire composition.
`tsc --noEmit` + `vitest run lib/transactions/model features/transactions` green (214).