### PR TITLE
feat(journal): migrate Assets:Credited to the receivable/payable debts model

### DIFF
--- a/app/api/maintenance/migrate-credited-debts/route.ts
+++ b/app/api/maintenance/migrate-credited-debts/route.ts
@@ -14,6 +14,10 @@ const log = createLogger('migrate-credited-debts');
  * rewritten journal parses, and rolls back every touched file on failure, so a
  * bad migration is fully reversible. We surface a rollback as a structured
  * `failed` result rather than an opaque 500.
+ *
+ * Returns a `manual` result (200) listing any legacy person accounts whose net
+ * spans multiple commodities: those have no single receivable/payable sign and
+ * must be resolved by hand before the migration can run.
  */
 export async function POST(): Promise<NextResponse> {
   const user = await requireUser();

--- a/app/api/maintenance/migrate-credited-debts/route.ts
+++ b/app/api/maintenance/migrate-credited-debts/route.ts
@@ -22,8 +22,10 @@ const log = createLogger('migrate-credited-debts');
 export async function POST(): Promise<NextResponse> {
   const user = await requireUser();
   try {
-    const result = await migrateCreditedToDebts(user.id);
-    return NextResponse.json({ result });
+    const { status, ...details } = await migrateCreditedToDebts(user.id);
+    // Keep `result` a flat string (like the relocate-definitions sibling and
+    // the `failed` error branch); spread any extras alongside it.
+    return NextResponse.json({ result: status, ...details });
   } catch (error) {
     log.error({ err: error }, 'credited debts migration failed');
     return NextResponse.json(

--- a/app/api/maintenance/migrate-credited-debts/route.ts
+++ b/app/api/maintenance/migrate-credited-debts/route.ts
@@ -1,0 +1,30 @@
+import { requireUser } from '@/lib/auth/require-user';
+import { migrateCreditedToDebts } from '@/lib/journal/creditedMigration';
+import { createLogger } from '@/lib/log';
+import { NextResponse } from 'next/server';
+
+const log = createLogger('migrate-credited-debts');
+
+/**
+ * One-shot migration of the legacy `Assets:Credited:<person>` debts model to the
+ * current `Assets:Receivable` / `Liabilities:Payable` split. Operates only on the
+ * caller's own journal. Idempotent — returns `skipped` once nothing remains.
+ *
+ * The service takes the per-user lock and pulls fresh under it, verifies the
+ * rewritten journal parses, and rolls back every touched file on failure, so a
+ * bad migration is fully reversible. We surface a rollback as a structured
+ * `failed` result rather than an opaque 500.
+ */
+export async function POST(): Promise<NextResponse> {
+  const user = await requireUser();
+  try {
+    const result = await migrateCreditedToDebts(user.id);
+    return NextResponse.json({ result });
+  } catch (error) {
+    log.error({ err: error }, 'credited debts migration failed');
+    return NextResponse.json(
+      { result: 'failed', message: 'Could not migrate your journal' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/journal/creditedMigration.test.ts
+++ b/lib/journal/creditedMigration.test.ts
@@ -30,25 +30,45 @@ describe('targetAccount', () => {
 
 describe('planRenames', () => {
   it('maps each legacy account by the sign of its net', () => {
-    const map = planRenames(
+    const { renames, manual } = planRenames(
       [
-        'Assets:Credited:Alex|30',
-        'Assets:Credited:Bob|-30',
+        'Assets:Credited:Alex|$ 30.00',
+        'Assets:Credited:Bob|$ -30.00',
         'Assets:Credited:Zero|0',
-        'Assets:Checking|500', // ignored: not a legacy account
-        '|750', // ignored: footer Total row
+        'Assets:Checking|$ 500.00', // ignored: not a legacy account
+        '|$ 750.00', // ignored: footer Total row
       ].join('\n')
     );
-    expect(map.get('Assets:Credited:Alex')).toBe('Assets:Receivable:Alex');
-    expect(map.get('Assets:Credited:Bob')).toBe('Liabilities:Payable:Bob');
-    expect(map.get('Assets:Credited:Zero')).toBe('Assets:Receivable:Zero');
-    expect(map.has('Assets:Checking')).toBe(false);
-    expect(map.size).toBe(3);
+    expect(renames.get('Assets:Credited:Alex')).toBe('Assets:Receivable:Alex');
+    expect(renames.get('Assets:Credited:Bob')).toBe('Liabilities:Payable:Bob');
+    expect(renames.get('Assets:Credited:Zero')).toBe('Assets:Receivable:Zero');
+    expect(renames.has('Assets:Checking')).toBe(false);
+    expect(renames.size).toBe(3);
+    expect(manual).toEqual([]);
   });
 
   it('handles comma-grouped amounts', () => {
-    const map = planRenames('Assets:Credited:Big|-1,200.00\n');
-    expect(map.get('Assets:Credited:Big')).toBe('Liabilities:Payable:Big');
+    const { renames } = planRenames('Assets:Credited:Big|$ -1,200.00\n');
+    expect(renames.get('Assets:Credited:Big')).toBe('Liabilities:Payable:Big');
+  });
+
+  it('collects a multi-commodity net as manual and never renames it', () => {
+    // Ledger emits the second commodity on a continuation line (no `|`).
+    const { renames, manual } = planRenames(
+      [
+        'Assets:Credited:Alex|$ 30.00',
+        'Assets:Credited:Bob|$ 50.00',
+        '                   €30.00',
+        'Assets:Credited:Carol|$ 100.00',
+      ].join('\n')
+    );
+    expect(manual).toEqual(['Assets:Credited:Bob']);
+    expect(renames.has('Assets:Credited:Bob')).toBe(false);
+    expect(renames.get('Assets:Credited:Alex')).toBe('Assets:Receivable:Alex');
+    expect(renames.get('Assets:Credited:Carol')).toBe(
+      'Assets:Receivable:Carol'
+    );
+    expect(renames.size).toBe(2);
   });
 });
 

--- a/lib/journal/creditedMigration.test.ts
+++ b/lib/journal/creditedMigration.test.ts
@@ -52,6 +52,19 @@ describe('planRenames', () => {
     expect(renames.get('Assets:Credited:Big')).toBe('Liabilities:Payable:Big');
   });
 
+  it('reads the sign from the number, not a hyphen in a quoted commodity', () => {
+    // A positive net of a hyphenated commodity renders `10 "AK-47"`; the
+    // hyphen is part of the name, not a sign, so it must route to receivable.
+    const { renames } = planRenames(
+      [
+        'Assets:Credited:Gun|10 "AK-47"',
+        'Assets:Credited:Owe|-3 "T-BILL"',
+      ].join('\n')
+    );
+    expect(renames.get('Assets:Credited:Gun')).toBe('Assets:Receivable:Gun');
+    expect(renames.get('Assets:Credited:Owe')).toBe('Liabilities:Payable:Owe');
+  });
+
   it('collects a multi-commodity net as manual and never renames it', () => {
     // Ledger emits the second commodity on a continuation line (no `|`).
     const { renames, manual } = planRenames(

--- a/lib/journal/creditedMigration.test.ts
+++ b/lib/journal/creditedMigration.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  planRenames,
+  rewriteAccounts,
+  targetAccount,
+} from './creditedMigration';
+
+describe('targetAccount', () => {
+  it('routes a non-negative net to receivable', () => {
+    expect(targetAccount('Assets:Credited:Alex', 30)).toBe(
+      'Assets:Receivable:Alex'
+    );
+    expect(targetAccount('Assets:Credited:Alex', 0)).toBe(
+      'Assets:Receivable:Alex'
+    );
+  });
+
+  it('routes a negative net to payable', () => {
+    expect(targetAccount('Assets:Credited:Bob', -30)).toBe(
+      'Liabilities:Payable:Bob'
+    );
+  });
+
+  it('preserves a deeper person path', () => {
+    expect(targetAccount('Assets:Credited:Family:Alex', 5)).toBe(
+      'Assets:Receivable:Family:Alex'
+    );
+  });
+});
+
+describe('planRenames', () => {
+  it('maps each legacy account by the sign of its net', () => {
+    const map = planRenames(
+      [
+        'Assets:Credited:Alex|30',
+        'Assets:Credited:Bob|-30',
+        'Assets:Credited:Zero|0',
+        'Assets:Checking|500', // ignored: not a legacy account
+        '|750', // ignored: footer Total row
+      ].join('\n')
+    );
+    expect(map.get('Assets:Credited:Alex')).toBe('Assets:Receivable:Alex');
+    expect(map.get('Assets:Credited:Bob')).toBe('Liabilities:Payable:Bob');
+    expect(map.get('Assets:Credited:Zero')).toBe('Assets:Receivable:Zero');
+    expect(map.has('Assets:Checking')).toBe(false);
+    expect(map.size).toBe(3);
+  });
+
+  it('handles comma-grouped amounts', () => {
+    const map = planRenames('Assets:Credited:Big|-1,200.00\n');
+    expect(map.get('Assets:Credited:Big')).toBe('Liabilities:Payable:Big');
+  });
+});
+
+describe('rewriteAccounts', () => {
+  const renames = new Map([
+    ['Assets:Credited:Alex', 'Assets:Receivable:Alex'],
+    ['Assets:Credited:Bob', 'Liabilities:Payable:Bob'],
+  ]);
+
+  it('rewrites whole-account occurrences and counts them', () => {
+    const journal = [
+      '2026-01-01 Lent to Alex',
+      '    Assets:Credited:Alex      $50',
+      '    Assets:Checking          $-50',
+      '',
+      '2026-02-01 Borrowed from Bob',
+      '    Assets:Checking           $30',
+      '    Assets:Credited:Bob      $-30',
+      '',
+    ].join('\n');
+    const { text, count } = rewriteAccounts(journal, renames);
+    expect(count).toBe(2);
+    expect(text).toContain('    Assets:Receivable:Alex      $50');
+    expect(text).toContain('    Liabilities:Payable:Bob      $-30');
+    expect(text).not.toContain('Assets:Credited');
+  });
+
+  it('does not match a shorter name inside a longer no-space sibling', () => {
+    // "Assets:Credited:Al" must not corrupt "Assets:Credited:Alex".
+    const map = new Map([['Assets:Credited:Al', 'Assets:Receivable:Al']]);
+    const { text, count } = rewriteAccounts(
+      '    Assets:Credited:Alex   $1\n',
+      map
+    );
+    expect(count).toBe(0);
+    expect(text).toContain('Assets:Credited:Alex');
+  });
+
+  it('does not partially match a space-separated sibling (longest-first)', () => {
+    // Both siblings present; "Bob" must not eat into "Bob Smith".
+    const map = new Map([
+      ['Assets:Credited:Bob', 'Liabilities:Payable:Bob'],
+      ['Assets:Credited:Bob Smith', 'Assets:Receivable:Bob Smith'],
+    ]);
+    const journal = [
+      '    Assets:Credited:Bob Smith   $10',
+      '    Assets:Credited:Bob         $-5',
+    ].join('\n');
+    const { text } = rewriteAccounts(journal, map);
+    expect(text).toContain('    Assets:Receivable:Bob Smith   $10');
+    expect(text).toContain('    Liabilities:Payable:Bob         $-5');
+    expect(text).not.toContain('Assets:Credited');
+  });
+
+  it('leaves an unrelated account untouched', () => {
+    const { text, count } = rewriteAccounts(
+      '    Assets:Checking   $5\n',
+      renames
+    );
+    expect(count).toBe(0);
+    expect(text).toBe('    Assets:Checking   $5\n');
+  });
+});

--- a/lib/journal/creditedMigration.ts
+++ b/lib/journal/creditedMigration.ts
@@ -4,7 +4,6 @@ import 'server-only';
 import { VALID_EXTS, GENERATED_PRICE_DB_NAME, PRICE_DB_NAME } from './layout';
 import { withUserLock } from './mutex';
 import { verifyJournalParseable } from './verify';
-import { parseBalanceRows } from '@/lib/balance/parse';
 import { journalRepository } from '@/lib/journal';
 import { pull, push, StorageConflictError } from '@/lib/storage';
 import { runLedgerForUser } from '@/utils/runLedgerForUser';
@@ -31,21 +30,51 @@ export const targetAccount = (account: string, netSign: number): string => {
 
 /**
  * Build the rename map from `ledger balance Assets:Credited` output formatted
- * `<account>|<signed-quantity>`. Each legacy account maps to its receivable or
- * payable target. Rows whose amount is empty (or the footer Total row) are
- * skipped. Ledger did the netting; this only reads the sign.
+ * `<account>|%(scrub(total))`. Each legacy account maps to its receivable or
+ * payable target, keyed by the sign of its net.
+ *
+ * `%(scrub(total))` (not `%(quantity(...))`) is used because `quantity()`
+ * aborts the whole `ledger` invocation on any account whose net spans more than
+ * one commodity — `Cannot convert a balance with multiple commodities to an
+ * amount` (ledger 3.4.1). Such an account has no single sign, so picking
+ * receivable vs payable would be a valuation guess; instead its rows arrive as a
+ * commodity amount on the `|` line followed by continuation lines (no `|`), and
+ * we collect it into `manual` for the caller to surface rather than migrate.
+ *
+ * Footer Total and non-legacy accounts are skipped. Ledger did the netting;
+ * this only reads the sign of a single-commodity net.
  */
-export const planRenames = (balanceOutput: string): Map<string, string> => {
+export const planRenames = (
+  balanceOutput: string
+): { renames: Map<string, string>; manual: string[] } => {
   const renames = new Map<string, string>();
-  for (const row of parseBalanceRows(balanceOutput)) {
-    if (row.account === 'Total' || !row.account.startsWith(`${LEGACY_ROOT}:`)) {
+  const manual: string[] = [];
+  let current: string | null = null;
+
+  for (const line of balanceOutput.split('\n')) {
+    if (!line.includes('|')) {
+      // Continuation line: a second commodity for the account on the line
+      // above. That account's net is multi-commodity — hand it off to `manual`.
+      if (current && line.trim() && !manual.includes(current)) {
+        renames.delete(current);
+        manual.push(current);
+      }
       continue;
     }
-    const sign = Number(row.amount.replace(/,/g, ''));
-    if (!Number.isFinite(sign)) continue;
-    renames.set(row.account, targetAccount(row.account, sign));
+    const [accountRaw, amountRaw] = line.split('|');
+    const account = accountRaw.trim();
+    const amount = (amountRaw ?? '').trim();
+    current = null;
+    if (!account || account === 'Total' || !amount) continue;
+    if (!account.startsWith(`${LEGACY_ROOT}:`)) continue;
+    current = account;
+    if (manual.includes(account)) continue;
+    // A single-commodity net: negative iff a minus sign appears before the
+    // number (ledger renders `$ -20.00` / `-20.00 EUR`). Zero renders as `0`.
+    const sign = amount.includes('-') ? -1 : 1;
+    renames.set(account, targetAccount(account, sign));
   }
-  return renames;
+  return { renames, manual };
 };
 
 const escapeRegExp = (value: string): string =>
@@ -80,6 +109,7 @@ export const rewriteAccounts = (
 
 export type MigrateResult =
   | { status: 'skipped' }
+  | { status: 'manual'; accounts: string[] }
   | { status: 'migrated'; renamed: string[]; occurrences: number };
 
 /**
@@ -93,6 +123,10 @@ export type MigrateResult =
  * snapshots every touched file, rewrites, verifies the result parses, and rolls
  * back on any failure before pushing. Idempotent — `skipped` once no
  * `Assets:Credited` account remains.
+ *
+ * Returns `manual` (touching nothing) if any legacy person account nets across
+ * more than one commodity: that net has no single sign, so routing it to
+ * receivable vs payable is a valuation decision the user must make by hand.
  */
 export const migrateCreditedToDebts = async (
   userId: string,
@@ -118,10 +152,17 @@ export const migrateCreditedToDebts = async (
       '--flat',
       '--no-total',
       '--format',
-      '%(account)|%(quantity(scrub(total)))\n',
+      // Raw `scrub(total)`, not `quantity(...)`: quantity() aborts the whole
+      // invocation on a multi-commodity net. planRenames reads the sign of the
+      // single-commodity nets and collects any multi-commodity ones as manual.
+      '%(account)|%(scrub(total))\n',
       LEGACY_ROOT,
     ]);
-    const renames = planRenames(balance);
+    const { renames, manual } = planRenames(balance);
+    // A person whose net spans multiple commodities has no single sign; surface
+    // it for manual resolution rather than guess receivable vs payable. Touch
+    // nothing so the user can fix those accounts and re-run cleanly.
+    if (manual.length > 0) return { status: 'manual', accounts: manual };
     if (renames.size === 0) return { status: 'skipped' };
 
     // Rewrite every journal file in the dir (main + includes), skipping the

--- a/lib/journal/creditedMigration.ts
+++ b/lib/journal/creditedMigration.ts
@@ -71,7 +71,10 @@ export const planRenames = (
     if (manual.includes(account)) continue;
     // A single-commodity net: negative iff a minus sign appears before the
     // number (ledger renders `$ -20.00` / `-20.00 EUR`). Zero renders as `0`.
-    const sign = amount.includes('-') ? -1 : 1;
+    // Strip any quoted commodity name first — `"AK-47"` / `"T-BILL"` carry a
+    // hyphen that is not a sign, and a positive net of one (`10 "AK-47"`) would
+    // otherwise read as negative and route to the wrong account.
+    const sign = amount.replace(/"[^"]*"/g, '').includes('-') ? -1 : 1;
     renames.set(account, targetAccount(account, sign));
   }
   return { renames, manual };

--- a/lib/journal/creditedMigration.ts
+++ b/lib/journal/creditedMigration.ts
@@ -1,0 +1,179 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import 'server-only';
+import { VALID_EXTS, GENERATED_PRICE_DB_NAME, PRICE_DB_NAME } from './layout';
+import { withUserLock } from './mutex';
+import { verifyJournalParseable } from './verify';
+import { parseBalanceRows } from '@/lib/balance/parse';
+import { journalRepository } from '@/lib/journal';
+import { pull, push, StorageConflictError } from '@/lib/storage';
+import { runLedgerForUser } from '@/utils/runLedgerForUser';
+import { revalidatePath } from 'next/cache';
+
+// Legacy debts lived under one signed account per person. The current model
+// splits them: money owed TO you is an asset, money you owe is a liability.
+export const LEGACY_ROOT = 'Assets:Credited';
+export const RECEIVABLE_ROOT = 'Assets:Receivable';
+export const PAYABLE_ROOT = 'Liabilities:Payable';
+
+/**
+ * Target account for a legacy `Assets:Credited:<rest>` account, keyed by the
+ * SIGN of its net balance (from ledger — never summed here). A non-negative net
+ * means the balance is owed to you → receivable; a negative net means you owe
+ * it → payable. Only the `Assets:Credited` prefix is swapped; the person path
+ * (`<rest>`, any depth) is preserved.
+ */
+export const targetAccount = (account: string, netSign: number): string => {
+  const rest = account.slice(LEGACY_ROOT.length); // includes the leading ':'
+  const root = netSign < 0 ? PAYABLE_ROOT : RECEIVABLE_ROOT;
+  return `${root}${rest}`;
+};
+
+/**
+ * Build the rename map from `ledger balance Assets:Credited` output formatted
+ * `<account>|<signed-quantity>`. Each legacy account maps to its receivable or
+ * payable target. Rows whose amount is empty (or the footer Total row) are
+ * skipped. Ledger did the netting; this only reads the sign.
+ */
+export const planRenames = (balanceOutput: string): Map<string, string> => {
+  const renames = new Map<string, string>();
+  for (const row of parseBalanceRows(balanceOutput)) {
+    if (row.account === 'Total' || !row.account.startsWith(`${LEGACY_ROOT}:`)) {
+      continue;
+    }
+    const sign = Number(row.amount.replace(/,/g, ''));
+    if (!Number.isFinite(sign)) continue;
+    renames.set(row.account, targetAccount(row.account, sign));
+  }
+  return renames;
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Replace whole-account occurrences of each legacy account in the journal text,
+ * preserving everything else. The boundaries `(?<![\w:])`/`(?![\w:])` stop a
+ * shorter name from matching inside a longer sibling (`:Alex` inside
+ * `:Alexander`); longest names are rewritten first for the same reason. Returns
+ * the new text and how many occurrences changed.
+ */
+export const rewriteAccounts = (
+  text: string,
+  renames: Map<string, string>
+): { text: string; count: number } => {
+  let count = 0;
+  let output = text;
+  const accounts = [...renames.keys()].sort((a, b) => b.length - a.length);
+  for (const account of accounts) {
+    const pattern = new RegExp(
+      `(?<![\\w:])${escapeRegExp(account)}(?![\\w:])`,
+      'g'
+    );
+    output = output.replace(pattern, () => {
+      count += 1;
+      return renames.get(account)!;
+    });
+  }
+  return { text: output, count };
+};
+
+export type MigrateResult =
+  | { status: 'skipped' }
+  | { status: 'migrated'; renamed: string[]; occurrences: number };
+
+/**
+ * One-shot migration of the legacy `Assets:Credited:<person>` debts model to
+ * the current split model: each person account becomes `Assets:Receivable` (net
+ * owed to you) or `Liabilities:Payable` (net you owe), decided by ledger's net
+ * sign — no summation here. A pure account rename, so every transaction stays
+ * balanced and the change is reversible.
+ *
+ * Mirrors relocateLegacyDefinitions: takes the per-user lock, pulls fresh,
+ * snapshots every touched file, rewrites, verifies the result parses, and rolls
+ * back on any failure before pushing. Idempotent — `skipped` once no
+ * `Assets:Credited` account remains.
+ */
+export const migrateCreditedToDebts = async (
+  userId: string,
+  repo = journalRepository
+): Promise<MigrateResult> => {
+  return withUserLock(userId, async () => {
+    try {
+      await pull(userId);
+    } catch {
+      // Locked/encrypted (no DEK) or transient storage error: never write
+      // plaintext over ciphertext. A later attempt retries once decryptable.
+      return { status: 'skipped' };
+    }
+
+    const layout = await repo.ensureLayout(userId);
+    // `--empty` includes zero-balance accounts so every posting-bearing legacy
+    // account is in the rename map — otherwise a hidden zero sibling like
+    // `Assets:Credited:Bob Smith` could be partially matched by an
+    // `Assets:Credited:Bob` rule.
+    const balance = await runLedgerForUser(userId, [
+      'balance',
+      '--empty',
+      '--flat',
+      '--no-total',
+      '--format',
+      '%(account)|%(quantity(scrub(total)))\n',
+      LEGACY_ROOT,
+    ]);
+    const renames = planRenames(balance);
+    if (renames.size === 0) return { status: 'skipped' };
+
+    // Rewrite every journal file in the dir (main + includes), skipping the
+    // price DBs. Snapshot originals so a failed verify restores all of them.
+    const entries = await fs.readdir(layout.dir);
+    const priceFiles = new Set([PRICE_DB_NAME, GENERATED_PRICE_DB_NAME]);
+    const targets = entries.filter(
+      (name) =>
+        VALID_EXTS.includes(path.extname(name).toLowerCase()) &&
+        !priceFiles.has(name)
+    );
+
+    const snapshots = new Map<string, string>();
+    let occurrences = 0;
+    try {
+      for (const name of targets) {
+        const absPath = path.join(layout.dir, name);
+        const original = await repo.readFile(absPath);
+        const { text, count } = rewriteAccounts(original, renames);
+        if (count === 0) continue;
+        snapshots.set(absPath, original);
+        occurrences += count;
+        await repo.writeFileAtomic(absPath, text);
+      }
+
+      if (occurrences === 0) return { status: 'skipped' };
+
+      const verify = await verifyJournalParseable(layout.mainPath);
+      if (!verify.ok) {
+        throw new Error(
+          `ledger rejected the migrated journal: ${verify.message}`
+        );
+      }
+      await push(userId);
+    } catch (error) {
+      // Restore every file we touched so the journal is exactly as before.
+      for (const [absPath, original] of snapshots) {
+        await repo.writeFileAtomic(absPath, original);
+      }
+      if (error instanceof StorageConflictError) return { status: 'skipped' };
+      throw error;
+    }
+
+    try {
+      revalidatePath('/', 'layout');
+    } catch {
+      // no-op outside the Next.js runtime
+    }
+    return {
+      status: 'migrated',
+      renamed: [...renames.keys()],
+      occurrences,
+    };
+  });
+};


### PR DESCRIPTION
Companion to #99. Migrates the legacy single-account debts model
(`Assets:Credited:<person>`, one signed account) to the split model the
quick-entry **Debt** / **Settle up** features and the new debts page use.

## What it does
For each `Assets:Credited:<person>` account:
- net **≥ 0** (owed to you) → `Assets:Receivable:<person>`
- net **< 0** (you owe) → `Liabilities:Payable:<person>`

Ledger computes each account's net; the code only reads the **sign** to pick the
root — no summation (CLAUDE.md hard rule). It's a pure account **rename**, so
every transaction stays balanced and the change is reversible.

## Safety
- **Whole-account rewrite only**: boundary-guarded (`(?<![\w:]) … (?![\w:])`) and
  applied **longest-first**, so `Assets:Credited:Bob` can't corrupt
  `Assets:Credited:Bob Smith`, and `…:Al` can't corrupt `…:Alex`.
- **`balance --empty`** pulls zero-net accounts into the rename map, so a hidden
  zero-balance sibling is never left half-matched.
- Mirrors `relocateLegacyDefinitions`: per-user lock, pull fresh, **snapshot every
  touched file** (main + includes), verify the result parses, **roll back all** on
  any failure before pushing. Bails to `skipped` on an encrypted/locked journal so
  plaintext never overwrites ciphertext.
- **Idempotent** — `skipped` once no `Assets:Credited` account remains.

## Trigger
`POST /api/maintenance/migrate-credited-debts` (no UI, like the other
`/api/maintenance/*` repairs). Returns `{ result: 'migrated' | 'skipped' | 'failed' }`;
`migrated` includes the renamed accounts and occurrence count.

## Verification
Unit tests cover `targetAccount`, `planRenames`, and the boundary/longest-first
rewrite cases. Verified end-to-end against **ledger 3.4.1** on a synthetic legacy
journal (including a spaced name `Bob Smith` and a zero-net account): the result
parses, every transaction still balances, and it feeds the #99 debts view correctly
(owes-you / you-owe / hidden). `tsc --noEmit` + `vitest run lib/journal` green (98).

> Run this once after merging #99 if you have legacy `Assets:Credited` data.