### PR TITLE
fix(transactions): open the type form for round-trippable splits

### DIFF
--- a/features/transactions/editSurface.test.ts
+++ b/features/transactions/editSurface.test.ts
@@ -22,7 +22,10 @@ describe('pickEditSurface', () => {
     if (surface.kind === 'type') expect(surface.spec.kind).toBe('expense');
   });
 
-  it('routes a split expense to raw (simple form would hide the split)', () => {
+  it('routes a split expense with an EXPLICIT paying amount to raw', () => {
+    // Split compile leaves the paying line amount-less, so it cannot reproduce
+    // this explicit `-12` — round-trip fails and it falls back to raw rather
+    // than silently rewriting that posting.
     const surface = pickEditSurface(
       draftOf([
         { account: 'Expenses:Food', amount: '10', currency: 'USD' },
@@ -31,6 +34,21 @@ describe('pickEditSurface', () => {
       ])
     );
     expect(surface.kind).toBe('raw');
+  });
+
+  it('routes a split expense with an amount-less paying line to the expense form', () => {
+    // Exactly what the entry form writes for a split: two expense postings and
+    // an amount-less paying line for ledger to balance. This round-trips, so it
+    // belongs in the expense form (with its ExtraItemsField), not raw.
+    const surface = pickEditSurface(
+      draftOf([
+        { account: 'Expenses:Cigarette', amount: '300', currency: 'KIRT' },
+        { account: 'Expenses:Wage', amount: '0.9', currency: 'KIRT' },
+        { account: 'Assets:Bank:Blubank', amount: '', currency: '' },
+      ])
+    );
+    expect(surface.kind).toBe('type');
+    if (surface.kind === 'type') expect(surface.spec.kind).toBe('expense');
   });
 
   it('routes a clean 2-posting exchange to the exchange form', () => {

--- a/features/transactions/editSurface.ts
+++ b/features/transactions/editSurface.ts
@@ -1,32 +1,68 @@
 import type { DraftState } from './entry/draftReducer';
-import type { HeaderFields } from './entry/types/adapter';
+import type { HeaderFields, TypeContext } from './entry/types/adapter';
+import { fixBalanceAdapter } from './entry/types/fixBalance';
 import { detectType } from './entry/types/registry';
 import { QUICK_ENTRY_SPECS, type QuickEntrySpec } from './quickEntrySpecs';
+import type { Posting } from '@/lib/transactions/posting';
 
 export type EditSurface =
   | { kind: 'type'; spec: QuickEntrySpec<HeaderFields>; fields: HeaderFields }
   | { kind: 'raw'; seed?: DraftState };
 
-// A detected shape carrying splits (`extraItems`) is routed to Raw. Not because
-// the simple forms can't show splits — the expense/income forms both render
-// `ExtraItemsField` — but because the split `compile` path emits an amount-less
-// auto-balance line (extraItems.ts `balancingPostings`) where a parsed journal
-// transaction carries an explicit paying amount. So `detect → compile` is *not*
-// a pure inverse for splits (compile drops the paying amount and leaves it to
-// ledger), the same reason fixBalance is excluded from roundTrip.test.ts. Until
-// that path is verified against a real saved+parsed split, Raw is the safe
-// default. Costs/assertions need no separate guard: every adapter's `detect`
-// already rejects them, except the exchange adapter, which represents its cost
-// faithfully — a blanket cost guard would wrongly force every exchange to Raw.
-const hasSplits = (fields: unknown): boolean => {
-  const extraItems = (fields as { extraItems?: unknown[] }).extraItems;
-  return Array.isArray(extraItems) && extraItems.length > 0;
+const annotationsMatch = (a: Posting['cost'], b: Posting['cost']): boolean =>
+  (a?.amount ?? '') === (b?.amount ?? '') &&
+  (a?.currency ?? '') === (b?.currency ?? '');
+
+const postingsMatch = (a: readonly Posting[], b: readonly Posting[]): boolean =>
+  a.length === b.length &&
+  a.every((p, i) => {
+    const q = b[i];
+    return (
+      p.account === q.account &&
+      p.amount === q.amount &&
+      p.currency === q.currency &&
+      annotationsMatch(p.cost, q.cost) &&
+      annotationsMatch(p.assertion, q.assertion)
+    );
+  });
+
+// True when compiling the detected fields reproduces the draft's postings
+// exactly — the guarantee that opening the simple form and re-saving unchanged
+// leaves the journal identical. This is what makes splits safe to route to a
+// form: a split whose paying line is already amount-less (as the entry form
+// writes it) round-trips, so its `extraItems` survive; a split whose paying
+// line carries an *explicit* amount does NOT (split compile leaves that line
+// amount-less for ledger to fill), so it correctly falls back to Raw rather
+// than silently rewriting that posting. Ordering is significant on purpose:
+// compile emits a canonical posting order, so a differently-ordered hand-edited
+// transaction also falls to Raw instead of being reshuffled on save.
+const roundTrips = (
+  spec: QuickEntrySpec<HeaderFields>,
+  fields: HeaderFields,
+  draft: DraftState
+): boolean => {
+  try {
+    const ctx: TypeContext = {
+      defaultCurrency: draft.postings.find((p) => p.currency)?.currency ?? '',
+    };
+    return postingsMatch(spec.compile(fields, ctx).postings, draft.postings);
+  } catch {
+    return false;
+  }
 };
 
 export function pickEditSurface(draft: DraftState): EditSurface {
   const detected = detectType(draft);
-  if (!detected || hasSplits(detected.fields)) return { kind: 'raw' };
+  if (!detected) return { kind: 'raw' };
   const spec = QUICK_ENTRY_SPECS.find((entry) => entry.kind === detected.id);
   if (!spec) return { kind: 'raw' };
-  return { kind: 'type', spec, fields: detected.fields as HeaderFields };
+  const fields = detected.fields as HeaderFields;
+  // fix-balance's form re-derives the balance from a target rather than
+  // reproducing the postings, so compile is intentionally not its inverse
+  // (see fixBalance.ts / roundTrip.test.ts) — exempt it. Every other type must
+  // round-trip losslessly, or editing through the simple form could silently
+  // rewrite a posting the form can't represent.
+  if (detected.id !== fixBalanceAdapter.id && !roundTrips(spec, fields, draft))
+    return { kind: 'raw' };
+  return { kind: 'type', spec, fields };
 }


### PR DESCRIPTION
## Problem

Editing a split transaction (e.g. an expense with a second `Expenses:` category) always opened the **raw** editor instead of the Expense form. Reported case:

```
2026-07-14 cigarette
    ; :uid: 01KXJPPMZYQ4VZTVNTEHCV5DA1
    Expenses:Cigarette_Alcohol   Kirt 300
    Expenses:Wage                Kirt 0.9
    Assets:Bank:Blubank
```

`pickEditSurface` detected it correctly as an expense, then a blanket `hasSplits` fallback routed every split to raw.

## Fix

The blanket fallback was a proxy for "compile can't round-trip this." Replace it with the real check: route to the type form only when `compile(detect(draft))` reproduces the draft's postings **exactly**.

- A split written by the entry form leaves its paying line **amount-less** (ledger balances it), and `detect → compile` reproduces that shape byte-for-byte → safe to edit in the Expense/Income form (both render `ExtraItemsField`).
- A split whose paying line carries an **explicit** amount still falls back to raw — split compile would rewrite it amount-less, so the exact round-trip fails.
- Ordering is significant on purpose: a differently-ordered hand-edited transaction also falls to raw instead of being reshuffled on save.
- `fix-balance` stays exempt — its form re-derives the balance from a target rather than reproducing postings (see `fixBalance.ts` / `roundTrip.test.ts`).

No corruption is possible: if the exact round-trip doesn't hold, it goes to raw.

## Tests

- New: amount-less split expense → Expense form (the reported case).
- Kept: explicit-paying-amount split → raw.
- All existing `editSurface` / `roundTrip` routing tests unchanged and green (236 transaction tests pass).