### PR TITLE
fix(storage): unique tmp name for atomic manifest write

### DIFF
--- a/lib/storage/manifest.ts
+++ b/lib/storage/manifest.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { getJournalDir } from '@/lib/journal/layout';
@@ -50,7 +50,9 @@ export const writeManifest = async (
   // concurrent reader never sees a half-written manifest — a torn manifest
   // would fail JSON.parse, reset to {}, and silently disable the conflict guard.
   const dest = manifestPath(userId);
-  const tmp = dest + '.tmp';
+  // Unique tmp name per write so concurrent writers never share (and rename
+  // away) each other's scratch file — a fixed name races to ENOENT on rename.
+  const tmp = `${dest}.${randomUUID()}.tmp`;
   await fs.writeFile(tmp, JSON.stringify(m, null, 2), 'utf-8');
   await fs.rename(tmp, dest);
 };


### PR DESCRIPTION
## Problem

`writeManifest` writes to a **fixed** `.manifest.json.tmp` then renames it to `.manifest.json`. When two writes for the same user overlap (a push via `save.ts:67` and a pull via `download.ts:89`, or a retry firing before the first completes), they share the one tmp path and race:

1. Write A creates the tmp file
2. Write B overwrites the same tmp
3. Write A renames it away → succeeds
4. Write B renames → **ENOENT: the tmp is already gone**

This surfaced as the runtime crash:

```
Error: ENOENT: no such file or directory, rename '.../.manifest.json.tmp' -> '.../.manifest.json'
```

## Fix

Suffix the tmp filename with a UUID so each writer owns its own scratch file. The existing `*.tmp` filter in `listLocalRelPaths` already ignores the suffixed names, so no other change is needed.

## Not covered

Unique tmp names stop the ENOENT but don't order the two renames — the last writer still wins the manifest. A per-user lock is only warranted if last-write-wins is itself a correctness problem, which is out of scope here.