### PR TITLE
feat(transactions): one flow-oriented row per transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,65 @@ on:
   pull_request:
 
 jobs:
-  check:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm type-check
+
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install ledger
+        run: sudo apt-get update && sudo apt-get install -y ledger
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  build:
     runs-on: ubuntu-latest
     env:
       BETTER_AUTH_SECRET: ci-dummy-secret-32-chars-minimum-XX
@@ -26,27 +84,14 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Install ledger
-        run: sudo apt-get update && sudo apt-get install -y ledger
-
       - run: pnpm install --frozen-lockfile
-
-      - run: pnpm lint
-
-      - run: pnpm type-check
-
-      - run: pnpm test
-
       # Production build — catches client/server import violations (e.g. a
       # `'use client'` component pulling in a `server-only` module) that lint,
       # type-check, and unit tests do not. Runs migrations against the Postgres

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -1,8 +1,4 @@
-import {
-  getHighestExpense,
-  getJournalStats,
-  getRecentTransactions,
-} from './Dashboard.utils';
+import { getHighestExpense, getJournalStats } from './Dashboard.utils';
 import EmptyJournal from './EmptyJournal';
 import SavedViewsCard from './SavedViewsCard';
 import Card from '@/components/Card';
@@ -10,7 +6,10 @@ import Help from '@/components/Help';
 import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import { Card as ShadcnCard } from '@/components/ui/card';
+import { loadJournalTransactions } from '@/features/transactions/loadJournalTransactions';
+import { pageTransactions } from '@/features/transactions/pageTransactions';
 import TransactionRow from '@/features/transactions/row/TransactionRow';
+import { transactionRowToView } from '@/features/transactions/row/rowView';
 import { requireUser } from '@/lib/auth/require-user';
 import { savedViewService } from '@/lib/savedViews';
 import { getBaseCurrency } from '@/lib/settings';
@@ -95,7 +94,9 @@ const Dashboard = async () => {
       '--format',
       '%A|%t\n',
     ]),
-    getRecentTransactions(RECENT_LIMIT),
+    loadJournalTransactions(user.id).then((all) =>
+      pageTransactions(all, {}, 0, RECENT_LIMIT).rows.map(transactionRowToView)
+    ),
     getJournalStats(),
     savedViewService.list(user.id),
   ]);
@@ -176,9 +177,9 @@ const Dashboard = async () => {
               Recent transactions
             </h2>
             <Help label="About recent transactions">
-              The {RECENT_LIMIT} most recently dated postings across your
-              journal. A single transaction typically produces multiple postings
-              (e.g. a debit and matching credit).
+              The {RECENT_LIMIT} most recently dated transactions across your
+              journal. Each row is one transaction; its postings (e.g. a debit
+              and matching credit) are summarized as the accounts it touches.
             </Help>
           </div>
           <div className="flex items-center gap-2">
@@ -202,17 +203,8 @@ const Dashboard = async () => {
           </ShadcnCard>
         ) : (
           <div className="flex flex-col">
-            {recent.map((posting, i) => (
-              <TransactionRow
-                key={`${posting.uid ?? 'nouid'}:${i}`}
-                view={{
-                  date: posting.date,
-                  payee: posting.payee,
-                  amount: posting.amount,
-                  account: posting.account,
-                  uid: posting.uid,
-                }}
-              />
+            {recent.map((view, i) => (
+              <TransactionRow key={`${view.uid ?? 'nouid'}:${i}`} view={view} />
             ))}
           </div>
         )}

--- a/features/dashboard/Dashboard.utils.test.ts
+++ b/features/dashboard/Dashboard.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getHighestExpense, parseRecentPostings } from './Dashboard.utils';
+import { getHighestExpense } from './Dashboard.utils';
 
 describe('getHighestExpense', () => {
   it('picks the largest row by amount', () => {
@@ -31,37 +31,5 @@ describe('getHighestExpense', () => {
       '\n'
     );
     expect(getHighestExpense(stdout)).toBe('Expenses:Rent|USD 100');
-  });
-});
-
-describe('parseRecentPostings', () => {
-  it('extracts date/payee/account/amount and uid from the note', () => {
-    const stdout =
-      'NNN2026/01/01|Coffee|Assets:Checking|$ -5.00| :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z\n';
-    const [row] = parseRecentPostings(stdout);
-    expect(row).toEqual({
-      date: '2026/01/01',
-      payee: 'Coffee',
-      account: 'Assets:Checking',
-      amount: '$ -5.00',
-      uid: '01HZY0Z9QK8G7F6E5D4C3B2A1Z',
-    });
-  });
-
-  it('leaves uid undefined when the note has no uid tag', () => {
-    const stdout = 'NNN2026/01/01|Coffee|Assets:Checking|$ -5.00|\n';
-    const [row] = parseRecentPostings(stdout);
-    expect(row.uid).toBeUndefined();
-  });
-
-  it('rejoins note columns so a pipe inside the note cannot drop the uid', () => {
-    const stdout =
-      'NNN2026/01/01|Coffee|Assets:Checking|$ -5.00|a|b| :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z\n';
-    const [row] = parseRecentPostings(stdout);
-    expect(row.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
-  });
-
-  it('returns an empty array for empty stdout', () => {
-    expect(parseRecentPostings('')).toEqual([]);
   });
 });

--- a/features/dashboard/Dashboard.utils.ts
+++ b/features/dashboard/Dashboard.utils.ts
@@ -1,4 +1,3 @@
-import { splitRegisterRows } from '@/features/transactions/row/registerRows';
 import { parseAmountParts } from '@/utils/amountParts';
 import runLedger from '@/utils/runLedger';
 
@@ -14,40 +13,6 @@ export const getHighestExpense = (stdout: string): string => {
     }
   });
   return highestExpense.str;
-};
-
-export type RecentPosting = {
-  date: string;
-  payee: string;
-  account: string;
-  amount: string;
-  uid?: string;
-};
-
-/**
- * Parses the `NNN%D|%P|%A|%t|%(note)\n` output of `ledger reg --head N` into
- * typed rows, dropping malformed lines.
- */
-export const parseRecentPostings = (stdout: string): RecentPosting[] =>
-  splitRegisterRows(stdout).map(({ cols, uid }) => ({
-    date: cols[0],
-    payee: cols[1],
-    account: cols[2],
-    amount: cols[3],
-    uid,
-  }));
-
-export const getRecentTransactions = async (
-  limit: number
-): Promise<RecentPosting[]> => {
-  const stdout = await runLedger([
-    'reg',
-    '--head',
-    String(limit),
-    '--format',
-    'NNN%D|%P|%A|%t|%(note)\n',
-  ]);
-  return parseRecentPostings(stdout);
 };
 
 export type JournalStats = {

--- a/features/transactions/row/TransactionRow.test.tsx
+++ b/features/transactions/row/TransactionRow.test.tsx
@@ -35,7 +35,7 @@ describe('TransactionRow', () => {
   it('renders the account summary in the descriptor', () => {
     const view = transactionRowToView(row);
     const out = html(view);
-    expect(out).toContain('Expenses:Food');
+    expect(out).toContain('Cash → Food');
   });
 
   it('renders the payee as an edit trigger button when the view has a uid', () => {

--- a/features/transactions/row/rowView.test.ts
+++ b/features/transactions/row/rowView.test.ts
@@ -24,7 +24,7 @@ describe('transactionRowToView', () => {
     expect(view.payee).toBe('Coffee Shop');
     expect(view.status).toBe('cleared');
     expect(view.uid).toBe('u1');
-    expect(view.accountsSummary).toContain('Expenses:Coffee');
+    expect(view.accountsSummary).toBe('Checking → Coffee');
     expect(view.amount).toContain('USD');
     expect(view.templateDraft).toBeDefined();
     expect(view.templateDraft?.payee).toBe('Coffee Shop');

--- a/features/transactions/row/rowView.ts
+++ b/features/transactions/row/rowView.ts
@@ -14,7 +14,7 @@ export type TransactionRowView = {
   uid?: string;
 
   // Optional extras — each rendered in a consistent slot when present.
-  accountsSummary?: string; // main list: "Expenses:Coffee → Assets:Checking"
+  accountsSummary?: string; // main list: "Checking → Coffee" (source → dest)
   account?: string; // dashboard / reconcile single-account context
   runningTotal?: string; // account register (same '\n' shape as amount)
   age?: number; // reconcile (days)

--- a/lib/transactions/model.test.ts
+++ b/lib/transactions/model.test.ts
@@ -234,6 +234,51 @@ describe('Transaction immutable updates', () => {
   });
 });
 
+describe('Transaction.accountsSummary', () => {
+  const summary = (postings: TransactionData['postings']) =>
+    Transaction.from(transactionFixture({ postings })).accountsSummary();
+
+  it('splits source → destination by sign using leaf names', () => {
+    expect(
+      summary([
+        {
+          account: 'Expenses:Cigarette_Alcohol',
+          amount: '300.00',
+          currency: 'KIRT',
+        },
+        { account: 'Expenses:Wage', amount: '0.90', currency: 'KIRT' },
+        { account: 'Assets:Bank:Blubank', amount: '-300.90', currency: 'KIRT' },
+      ])
+    ).toBe('Blubank → Cigarette_Alcohol, Wage');
+  });
+
+  it('reads a transfer as from → to', () => {
+    expect(
+      summary([
+        { account: 'Assets:Bank:Blubank', amount: '100', currency: 'KIRT' },
+        { account: 'Assets:Crypto:Tabdeal', amount: '-100', currency: 'KIRT' },
+      ])
+    ).toBe('Tabdeal → Blubank');
+  });
+
+  it('caps each side at two names with +N overflow', () => {
+    expect(
+      summary([
+        { account: 'Expenses:A', amount: '1', currency: 'USD' },
+        { account: 'Expenses:B', amount: '1', currency: 'USD' },
+        { account: 'Expenses:C', amount: '1', currency: 'USD' },
+        { account: 'Assets:Cash', amount: '-3', currency: 'USD' },
+      ])
+    ).toBe('Cash → A, B +1');
+  });
+
+  it('falls back to a plain list when there is no clear two sides', () => {
+    expect(
+      summary([{ account: 'Equity:Opening', amount: '0', currency: 'USD' }])
+    ).toBe('Opening');
+  });
+});
+
 describe('Transaction outputs', () => {
   const t = () =>
     Transaction.from({

--- a/lib/transactions/model.test.ts
+++ b/lib/transactions/model.test.ts
@@ -277,6 +277,15 @@ describe('Transaction.accountsSummary', () => {
       summary([{ account: 'Equity:Opening', amount: '0', currency: 'USD' }])
     ).toBe('Opening');
   });
+
+  it('treats a bare auto-balanced posting as the opposite side', () => {
+    expect(
+      summary([
+        { account: 'Expenses:Coffee', amount: '5', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ])
+    ).toBe('Checking → Coffee');
+  });
 });
 
 describe('Transaction outputs', () => {

--- a/lib/transactions/model.ts
+++ b/lib/transactions/model.ts
@@ -289,10 +289,35 @@ export class Transaction {
     return computeBalance(this.postings);
   }
 
-  /** First two posting accounts joined for a compact list summary. */
+  /**
+   * Compact `source → destination` summary using leaf account names. Sides are
+   * split by posting sign (money out vs money in) so the arrow reflects the
+   * real flow — `Blubank → Cigarette_Alcohol, Wage` — rather than journal
+   * order. Leaf names keep the useful legs from being truncated away behind
+   * long `Expenses:`/`Assets:Bank:` prefixes. Not accounting math: it only
+   * reads the signs ledger already assigned, and never sums across currencies.
+   */
   accountsSummary(): string {
-    const accounts = this.postings.slice(0, 2).map((p) => p.account);
-    return `${accounts.join(' → ')}${this.postings.length > 2 ? ' …' : ''}`;
+    const leaf = (account: string) => account.split(':').pop() || account;
+    const side = (accounts: string[]) => {
+      const names = accounts.map(leaf);
+      return names.length > 2
+        ? `${names.slice(0, 2).join(', ')} +${names.length - 2}`
+        : names.join(', ');
+    };
+    const sources: string[] = [];
+    const destinations: string[] = [];
+    for (const p of this.postings) {
+      const value = Number(p.amount);
+      if (value < 0) sources.push(p.account);
+      else if (value > 0) destinations.push(p.account);
+    }
+    if (sources.length && destinations.length) {
+      return `${side(sources)} → ${side(destinations)}`;
+    }
+    // No clear two sides (single posting, or amounts that don't parse):
+    // fall back to a plain leaf-name list.
+    return side(this.postings.map((p) => p.account));
   }
 
   /** Sum of positive posting amounts per currency — the transaction magnitude. */

--- a/lib/transactions/model.ts
+++ b/lib/transactions/model.ts
@@ -307,10 +307,23 @@ export class Transaction {
     };
     const sources: string[] = [];
     const destinations: string[] = [];
+    const balancing: string[] = [];
     for (const p of this.postings) {
       const value = Number(p.amount);
       if (value < 0) sources.push(p.account);
       else if (value > 0) destinations.push(p.account);
+      // A bare auto-balanced posting parses to `amount: ''` (→ NaN). It's the
+      // balancing leg, so its sign is opposite the explicit legs — the most
+      // common ledger style elides exactly this side.
+      else if (p.amount.trim() === '' || !Number.isFinite(value))
+        balancing.push(p.account);
+    }
+    // Assign the elided balancing leg to whichever side is empty: if every
+    // explicit posting is money-out it settles as money-in, and vice versa.
+    if (balancing.length) {
+      if (destinations.length && !sources.length) sources.push(...balancing);
+      else if (sources.length && !destinations.length)
+        destinations.push(...balancing);
     }
     if (sources.length && destinations.length) {
       return `${side(sources)} → ${side(destinations)}`;


### PR DESCRIPTION
## Problem

The dashboard's "Recent transactions" list rendered **one row per ledger posting**, so a single transaction showed up as several unrelated rows (a `cigarette` transaction became three rows: two expense legs + the bank leg). And the accounts summary joined the first two postings in journal order with `→`, producing a misleading arrow (`Expenses:Cigarette_Alcohol → Expenses:Wage …`) whose long prefixes truncated away the one leg a human scans for — where the money came from.

## Change

- **Dashboard now shows one row per transaction.** It routes through the same grouped pipeline the main `/transactions` list already uses (`loadJournalTransactions` → `pageTransactions` → `transactionRowToView`) instead of parsing raw `reg` postings. `RECENT_LIMIT` now counts transactions, not postings. Removed the now-dead `getRecentTransactions`/`parseRecentPostings` helpers.
- **Reworked `accountsSummary()`** to split postings into `source → destination` by sign and render **leaf account names**, so the arrow reflects real money flow and the useful legs fit:

  | Before | After |
  |---|---|
  | `Expenses:Cigarette_Alcohol → Expenses:Wage …` | `Blubank → Cigarette_Alcohol, Wage` |
  | `Assets:Crypto:Tabdeal → Assets:Bank:Blubank` | `Tabdeal → Blubank` |

  Overflow beyond two names per side collapses to `+N`; degenerate cases (single posting, unparseable amounts) fall back to a plain leaf list. This flows to every surface using `accountsSummary` (dashboard + main list).

## Ledger safety

Only reads the signs ledger already assigned to parsed postings — no summing across currencies, no conversion in JS.

## Tests

Updated affected assertions; added focused `accountsSummary` cases (multi-destination, transfer, `+N` overflow, fallback). Type-check + suite green.