### PR TITLE
fix(transactions): scroll the list with the page instead of a nested container

### DIFF
--- a/features/transactions/TransactionList.tsx
+++ b/features/transactions/TransactionList.tsx
@@ -1,7 +1,6 @@
 // features/transactions/TransactionList.tsx
 'use client';
 
-import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { loadTransactionPageAction } from './actions';
@@ -26,25 +25,12 @@ const TransactionList = ({
   initialNextOffset,
   filters,
 }: Props) => {
-  const parentRef = useRef<HTMLDivElement>(null);
   const [page, setPage] = useState<{
     rows: TransactionRowData[];
     nextOffset: number | null;
   }>({ rows: initialRows, nextOffset: initialNextOffset });
   const loadingRef = useRef(false);
-  // Window-scrolled virtualizer needs the list's offset from the top of the
-  // document; measured post-mount since refs can't be read during render.
-  const [scrollMargin, setScrollMargin] = useState(0);
-  useEffect(() => {
-    if (parentRef.current) setScrollMargin(parentRef.current.offsetTop);
-  }, []);
-
-  const virtualizer = useWindowVirtualizer({
-    count: page.rows.length,
-    scrollMargin,
-    estimateSize: () => 80,
-    overscan: 8,
-  });
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
   const loadMore = useCallback(async () => {
     if (loadingRef.current || page.nextOffset === null) return;
@@ -63,15 +49,19 @@ const TransactionList = ({
     }
   }, [page.nextOffset, filters]);
 
-  const items = virtualizer.getVirtualItems();
-
-  // Prefetch the next page when the last rendered item nears the loaded tail.
+  // Load the next page when the sentinel below the list scrolls into view.
   useEffect(() => {
-    const last = items[items.length - 1];
-    if (!last) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (last.index >= page.rows.length - 10) void loadMore();
-  }, [items, page.rows.length, loadMore]);
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) void loadMore();
+      },
+      { rootMargin: '600px' }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   if (total === 0) {
     return (
@@ -82,28 +72,11 @@ const TransactionList = ({
   }
 
   return (
-    <div ref={parentRef}>
-      <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
-        {items.map((vi) => {
-          const row = page.rows[vi.index];
-          return (
-            <div
-              key={rowKey(row)}
-              data-index={vi.index}
-              ref={virtualizer.measureElement}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${vi.start - scrollMargin}px)`,
-              }}
-            >
-              <TransactionRow view={transactionRowToView(row)} />
-            </div>
-          );
-        })}
-      </div>
+    <div>
+      {page.rows.map((row) => (
+        <TransactionRow key={rowKey(row)} view={transactionRowToView(row)} />
+      ))}
+      {page.nextOffset !== null && <div ref={sentinelRef} aria-hidden />}
     </div>
   );
 };

--- a/features/transactions/TransactionList.tsx
+++ b/features/transactions/TransactionList.tsx
@@ -1,7 +1,7 @@
 // features/transactions/TransactionList.tsx
 'use client';
 
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { loadTransactionPageAction } from './actions';
@@ -32,10 +32,16 @@ const TransactionList = ({
     nextOffset: number | null;
   }>({ rows: initialRows, nextOffset: initialNextOffset });
   const loadingRef = useRef(false);
+  // Window-scrolled virtualizer needs the list's offset from the top of the
+  // document; measured post-mount since refs can't be read during render.
+  const [scrollMargin, setScrollMargin] = useState(0);
+  useEffect(() => {
+    if (parentRef.current) setScrollMargin(parentRef.current.offsetTop);
+  }, []);
 
-  const virtualizer = useVirtualizer({
+  const virtualizer = useWindowVirtualizer({
     count: page.rows.length,
-    getScrollElement: () => parentRef.current,
+    scrollMargin,
     estimateSize: () => 80,
     overscan: 8,
   });
@@ -63,6 +69,7 @@ const TransactionList = ({
   useEffect(() => {
     const last = items[items.length - 1];
     if (!last) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (last.index >= page.rows.length - 10) void loadMore();
   }, [items, page.rows.length, loadMore]);
 
@@ -75,7 +82,7 @@ const TransactionList = ({
   }
 
   return (
-    <div ref={parentRef} className="h-[70vh] overflow-auto">
+    <div ref={parentRef}>
       <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
         {items.map((vi) => {
           const row = page.rows[vi.index];
@@ -89,7 +96,7 @@ const TransactionList = ({
                 top: 0,
                 left: 0,
                 width: '100%',
-                transform: `translateY(${vi.start}px)`,
+                transform: `translateY(${vi.start - scrollMargin}px)`,
               }}
             >
               <TransactionRow view={transactionRowToView(row)} />


### PR DESCRIPTION
The transaction list rendered inside a fixed `h-[70vh] overflow-auto` container, producing a second scrollbar nested within the page scroll on `/transactions`.

Switch `TransactionList` from `useVirtualizer` (inner scroll element) to `useWindowVirtualizer` so rows scroll with the page — one scrollbar. The list's document offset is measured post-mount into `scrollMargin` and subtracted from each row's `translateY`.