### PR TITLE
fix(transactions): revalidate all routes after transaction writes

### DIFF
--- a/features/transactions/actions/createTransaction.ts
+++ b/features/transactions/actions/createTransaction.ts
@@ -6,6 +6,7 @@ import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
 import { getJournalDirSize } from '@/lib/journal/quota';
 import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
 
 export async function createTransactionAction(
   _prev: TransactionActionState | null,
@@ -45,5 +46,6 @@ export async function createTransactionAction(
       formError: result.formError,
     };
   }
+  revalidatePath('/', 'layout');
   return { ok: true, uid: result.uid };
 }

--- a/features/transactions/actions/deleteTransaction.ts
+++ b/features/transactions/actions/deleteTransaction.ts
@@ -5,6 +5,7 @@ import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
 import { getJournalDirSize } from '@/lib/journal/quota';
 import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
 
 export type DeleteTransactionResult =
   { ok: true } | { ok: false; message: string };
@@ -34,5 +35,6 @@ export async function deleteTransactionAction(
     ...(await auditRequestMeta()),
   });
   if (!result.ok) return { ok: false, message: result.message };
+  revalidatePath('/', 'layout');
   return { ok: true };
 }

--- a/features/transactions/actions/updateTransaction.ts
+++ b/features/transactions/actions/updateTransaction.ts
@@ -7,6 +7,7 @@ import { journalService } from '@/lib/journal';
 import { getJournalDirSize } from '@/lib/journal/quota';
 import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
 import type { TransactionDraft } from '@/lib/transactions/schema';
+import { revalidatePath } from 'next/cache';
 
 export async function updateTransactionAction(
   _prev: TransactionActionState | null,
@@ -62,5 +63,6 @@ export async function updateTransactionAction(
       fieldErrors: result.fieldErrors,
     };
   }
+  revalidatePath('/', 'layout');
   return { ok: true };
 }


### PR DESCRIPTION
## Problem
After adding, editing, or deleting a transaction, the dashboard (and any other previously visited route) showed stale data. The write actions relied on the client calling `router.refresh()`, which only refreshes the current route — Next's client router cache kept serving the old dashboard payload.

## Fix
Call `revalidatePath('/', 'layout')` on success in `createTransactionAction`, `updateTransactionAction`, and `deleteTransactionAction` (undo and delete-by-uid both route through delete), matching the pattern the settings actions already use.

## Verification
- `tsc --noEmit` clean
- transaction action tests pass