### PR TITLE
feat(recurring): confirm-to-post occurrences with due queue on dashboard

### DIFF
--- a/LEDGER-AUDIT.md
+++ b/LEDGER-AUDIT.md
@@ -174,3 +174,32 @@ with real ledger runs (none dropped by the verification cap).
 **Biggest single win: the transaction-balancing trio (#1–#3) — one root
 cause, three sites, and the only cluster where divergence corrupts what gets
 written rather than what gets displayed.**
+
+---
+
+## `--forecast` anchor-snapping — 2026-07-16
+
+Found while implementing recurring confirm-to-post (Task 9). Verified against
+ledger 3.4.1-20251025 on synthetic `~` periodic-transaction journals.
+
+1. **No past emission, even `--now` doesn't fill the anchor period.**
+   `--forecast` never emits an occurrence dated before "now" — a rules-only
+   journal with a rule anchored months ago produces zero rows on a plain run.
+   `--now <date>` backdates what ledger treats as "today" and lets earlier
+   occurrences appear, but the anchor period itself is still skipped: asking
+   for occurrences from the rule's own start date via `--now` on that exact
+   date does not emit the occurrence that starts there.
+2. **Date anchors are ignored — ledger snaps to calendar boundaries, not the
+   rule's stated anchor.** `~ Monthly from 2026/05/05` fires on the 1st of
+   each month, not the 5th. `~ every 2 weeks from <a Friday>` fires on
+   Sundays, not Fridays — the weekly cadence snaps to a fixed weekday
+   independent of the anchor's weekday. `~ every 30 days` is the exception:
+   day-count arithmetic is preserved, but it drifts across months of varying
+   length (not a calendar-boundary snap, but not stable either).
+3. **Consequence:** recurring occurrence dates are computed in JS
+   (`lib/journal/schedule.ts`), not by shelling out to `--forecast` — this is
+   dates only, no money; amounts and balance validation still go through
+   ledger. The `; :handled:` and `; :recurring:` comment tags used to track
+   confirm-to-post state are plain ledger comments — `ledger` ignores them
+   entirely (confirmed via `stats`/`bal` on a journal containing both), so
+   journals stay portable to any other ledger-reading tool.

--- a/app/recurring/page.tsx
+++ b/app/recurring/page.tsx
@@ -1,9 +1,13 @@
 import Help from '@/components/Help';
 import PageContainer from '@/components/PageContainer';
 import RecurringView from '@/features/recurring/RecurringView';
+import { buildDueList } from '@/features/recurring/dueList';
 import { requireUser } from '@/lib/auth/require-user';
 import { journalService } from '@/lib/journal';
 import { getBaseCurrency } from '@/lib/settings';
+import { toISODate } from '@/utils/date';
+
+const HORIZON_DAYS = 30;
 
 const RecurringPage = async () => {
   const user = await requireUser();
@@ -11,6 +15,22 @@ const RecurringPage = async () => {
     journalService.listRecurring(user.id),
     getBaseCurrency(),
   ]);
+
+  const now = new Date();
+  const todayIso = toISODate(now);
+  const horizonIso = toISODate(
+    new Date(now.getTime() + HORIZON_DAYS * 24 * 60 * 60 * 1000)
+  );
+  const dueList = buildDueList(recurring, todayIso, horizonIso);
+  const unsupportedUids = new Set(
+    dueList.unsupported.map((rule) => rule.ruleUid)
+  );
+  const nextDueByUid = new Map<string, string>();
+  for (const occurrence of [...dueList.due, ...dueList.upcoming]) {
+    if (!nextDueByUid.has(occurrence.ruleUid)) {
+      nextDueByUid.set(occurrence.ruleUid, occurrence.date);
+    }
+  }
 
   return (
     <PageContainer>
@@ -43,6 +63,8 @@ const RecurringPage = async () => {
             amount,
             currency,
           })),
+          nextDue: uid ? nextDueByUid.get(uid) : undefined,
+          unsupported: !uid || unsupportedUids.has(uid),
         }))}
       />
     </PageContainer>

--- a/docs/superpowers/plans/2026-07-16-recurring-confirm-to-post.md
+++ b/docs/superpowers/plans/2026-07-16-recurring-confirm-to-post.md
@@ -1,0 +1,946 @@
+# Recurring Confirm-to-Post Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Due/overdue recurring occurrences appear on the dashboard with Post/Skip buttons; Post writes a real journal transaction, Skip dismisses one occurrence; state lives entirely in the journal as a `:handled:` comment on the `~` rule.
+
+**Architecture:** `~` directives stay the rule store (immutable period expression = schedule anchor). A pure JS `expandSchedule` computes occurrence dates (dates are explicitly allowed in JS per CLAUDE.md; ledger 3.4.1 `--forecast` ignores date anchors — verified 2026-07-16, see spec). All money stays ledger's: amounts are the rule's postings verbatim, every write is verified with `ledger stats` and rolled back on rejection. Spec: `docs/superpowers/specs/2026-07-16-recurring-confirm-to-post-design.md`.
+
+**Tech Stack:** Next.js server actions, zod, vitest (`pnpm vitest run <file>`), existing `JournalService` write pipeline (withUserLock → pull → edit → verifyJournalParseable → push → invalidateCache).
+
+## Global Constraints
+
+- HARD RULE: no accounting math in JS/TS — ledger computes all monetary values. Date arithmetic in JS is explicitly allowed (CLAUDE.md "Allowed in JS/TS").
+- No abbreviations in identifiers (`occurrence`, not `occ`; `schedule`, not `sched`).
+- No Claude/Anthropic references anywhere; no Co-Authored-By trailers.
+- Server actions are one file each; DB/business logic in Repository/Service classes; UI in `features/`, pages in `app/` as thin shells.
+- Every service write: snapshot → mutate → `verifyJournalParseable` → rollback on failure → `push` → rollback on conflict → `invalidateCache`.
+- Commit after every green test cycle.
+
+## File Structure
+
+- Create: `lib/journal/schedule.ts` + `lib/journal/schedule.test.ts` — schedule parse/serialize/expand (pure)
+- Modify: `lib/journal/recurring.ts` + `lib/journal/recurring.test.ts` — `:handled:` line, schedule-bearing draft
+- Modify: `lib/journal/service.ts`; Create: `lib/journal/service.recurring-occurrence.test.ts` — post/skip occurrence
+- Create: `features/recurring/dueList.ts` + `features/recurring/dueList.test.ts` — occurrence rows for UI
+- Modify: `lib/audit/schema.ts`, `lib/audit/describe.ts` — new audit actions
+- Create: `features/recurring/actions/postOccurrence.ts`, `features/recurring/actions/skipOccurrence.ts`
+- Create: `features/dashboard/UpcomingBillsWidget.tsx`; Modify: `features/dashboard/Dashboard.tsx`
+- Modify: `features/recurring/RecurringView.tsx`, `app/recurring/page.tsx`, `features/recurring/actions/createRecurring.ts` (only if types change)
+
+---
+
+### Task 1: Schedule module (parse / serialize / expand)
+
+**Files:**
+- Create: `lib/journal/schedule.ts`
+- Test: `lib/journal/schedule.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure module).
+- Produces:
+  - `type ScheduleUnit = 'day' | 'week' | 'month' | 'year'`
+  - `type Schedule = { unit: ScheduleUnit; count: number; anchor: string }` (anchor is `YYYY-MM-DD`)
+  - `parseSchedule(period: string): Schedule | null` — recognizes `every N days|weeks|months|years from DATE`, `every day|week|month|year from DATE`, and the aliases `Daily|Weekly|Monthly|Yearly from DATE` (case-insensitive; DATE in `YYYY/MM/DD` or `YYYY-MM-DD`). Anything else (including anchor-less periods) → `null` = "unsupported schedule".
+  - `serializeSchedule(schedule: Schedule): string` — always `every N days|weeks|months|years from YYYY/MM/DD` (ledger-parseable; plural even for N=1 — ledger accepts it).
+  - `expandSchedule(schedule: Schedule, afterExclusive: string, throughInclusive: string): string[]` — occurrence dates strictly after `afterExclusive`, up to and including `throughInclusive`, computed by stepping from the anchor (never iterating day-by-day): day/week = anchor + k·count·(1|7) days; month = anchor month + k·count with day-of-month clamped to the target month's length; year = same with Feb 29 → Feb 28 clamping. Returns `[]` when the anchor is after `throughInclusive`.
+  - `lastOccurrenceBefore(schedule: Schedule, date: string): string | null` — most recent occurrence strictly before `date` (used to initialize `:handled:` at creation).
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// lib/journal/schedule.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  parseSchedule,
+  serializeSchedule,
+  expandSchedule,
+  lastOccurrenceBefore,
+} from './schedule';
+
+describe('parseSchedule', () => {
+  it('parses every-N form', () => {
+    expect(parseSchedule('every 2 weeks from 2026/05/08')).toEqual({
+      unit: 'week',
+      count: 2,
+      anchor: '2026-05-08',
+    });
+  });
+  it('parses singular and alias forms', () => {
+    expect(parseSchedule('every month from 2026-01-05')).toEqual({
+      unit: 'month',
+      count: 1,
+      anchor: '2026-01-05',
+    });
+    expect(parseSchedule('Monthly from 2026/01/05')).toEqual({
+      unit: 'month',
+      count: 1,
+      anchor: '2026-01-05',
+    });
+  });
+  it('rejects anchor-less and freeform periods', () => {
+    expect(parseSchedule('Monthly')).toBeNull();
+    expect(parseSchedule('every friday')).toBeNull();
+  });
+});
+
+describe('serializeSchedule', () => {
+  it('round-trips through parseSchedule', () => {
+    const schedule = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
+    expect(serializeSchedule(schedule)).toBe('every 1 months from 2026/01/05');
+    expect(parseSchedule(serializeSchedule(schedule))).toEqual(schedule);
+  });
+});
+
+describe('expandSchedule', () => {
+  const monthly = { unit: 'month' as const, count: 1, anchor: '2026-01-31' };
+  it('anchors monthly to day-of-month with short-month clamping', () => {
+    expect(expandSchedule(monthly, '2026-01-31', '2026-04-30')).toEqual([
+      '2026-02-28',
+      '2026-03-31',
+      '2026-04-30',
+    ]);
+  });
+  it('is exclusive of afterExclusive and inclusive of throughInclusive', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
+    expect(expandSchedule(fifth, '2026-02-05', '2026-04-05')).toEqual([
+      '2026-03-05',
+      '2026-04-05',
+    ]);
+  });
+  it('keeps biweekly anchored to the anchor weekday', () => {
+    const biweekly = { unit: 'week' as const, count: 2, anchor: '2026-05-08' };
+    expect(expandSchedule(biweekly, '2026-05-08', '2026-06-20')).toEqual([
+      '2026-05-22',
+      '2026-06-05',
+      '2026-06-19',
+    ]);
+  });
+  it('includes the anchor itself when after the floor', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2026-08-05' };
+    expect(expandSchedule(fifth, '2026-07-16', '2026-09-30')).toEqual([
+      '2026-08-05',
+      '2026-09-05',
+    ]);
+  });
+  it('returns empty when anchor is beyond the window', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2027-01-05' };
+    expect(expandSchedule(fifth, '2026-07-16', '2026-08-16')).toEqual([]);
+  });
+  it('handles yearly Feb 29 clamping', () => {
+    const leap = { unit: 'year' as const, count: 1, anchor: '2024-02-29' };
+    expect(expandSchedule(leap, '2024-02-29', '2026-03-01')).toEqual([
+      '2025-02-28',
+      '2026-02-28',
+    ]);
+  });
+});
+
+describe('lastOccurrenceBefore', () => {
+  it('returns the most recent occurrence strictly before the date', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
+    expect(lastOccurrenceBefore(fifth, '2026-07-16')).toBe('2026-07-05');
+    expect(lastOccurrenceBefore(fifth, '2026-01-05')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run lib/journal/schedule.test.ts`
+Expected: FAIL — cannot resolve `./schedule`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// lib/journal/schedule.ts
+export type ScheduleUnit = 'day' | 'week' | 'month' | 'year';
+
+export type Schedule = {
+  unit: ScheduleUnit;
+  count: number;
+  anchor: string; // YYYY-MM-DD
+};
+
+const PERIOD_REGEX =
+  /^(?:every\s+(?:(\d+)\s+)?(day|week|month|year)s?|(daily|weekly|monthly|yearly))\s+from\s+(\d{4})[/-](\d{2})[/-](\d{2})$/i;
+
+const ALIAS_UNITS: Record<string, ScheduleUnit> = {
+  daily: 'day',
+  weekly: 'week',
+  monthly: 'month',
+  yearly: 'year',
+};
+
+export const parseSchedule = (period: string): Schedule | null => {
+  const match = period.trim().match(PERIOD_REGEX);
+  if (!match) return null;
+  const [, countRaw, unitRaw, aliasRaw, year, month, day] = match;
+  const unit = unitRaw
+    ? (unitRaw.toLowerCase() as ScheduleUnit)
+    : ALIAS_UNITS[aliasRaw.toLowerCase()];
+  const count = countRaw ? parseInt(countRaw, 10) : 1;
+  if (count < 1 || count > 366) return null;
+  const anchor = `${year}-${month}-${day}`;
+  if (Number.isNaN(Date.parse(anchor))) return null;
+  return { unit, count, anchor };
+};
+
+export const serializeSchedule = (schedule: Schedule): string =>
+  `every ${schedule.count} ${schedule.unit}s from ${schedule.anchor.replaceAll('-', '/')}`;
+
+// All arithmetic below is calendar-date-only (UTC to avoid DST edges). No
+// monetary values pass through this module.
+const toUtc = (iso: string): Date => new Date(`${iso}T00:00:00Z`);
+const toIso = (date: Date): string => date.toISOString().slice(0, 10);
+
+const daysInMonth = (year: number, monthIndex: number): number =>
+  new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+
+/** k-th occurrence (k >= 0) of the schedule, anchored to the anchor date. */
+const occurrenceAt = (schedule: Schedule, k: number): string => {
+  const anchor = toUtc(schedule.anchor);
+  if (schedule.unit === 'day' || schedule.unit === 'week') {
+    const stepDays = schedule.count * (schedule.unit === 'week' ? 7 : 1);
+    const result = new Date(anchor);
+    result.setUTCDate(result.getUTCDate() + k * stepDays);
+    return toIso(result);
+  }
+  const monthsPerStep = schedule.unit === 'month' ? schedule.count : schedule.count * 12;
+  const totalMonths =
+    anchor.getUTCMonth() + k * monthsPerStep;
+  const year = anchor.getUTCFullYear() + Math.floor(totalMonths / 12);
+  const monthIndex = ((totalMonths % 12) + 12) % 12;
+  const day = Math.min(anchor.getUTCDate(), daysInMonth(year, monthIndex));
+  return toIso(new Date(Date.UTC(year, monthIndex, day)));
+};
+
+/** Smallest k whose occurrence is strictly after `afterExclusive`. */
+const firstIndexAfter = (schedule: Schedule, afterExclusive: string): number => {
+  if (schedule.anchor > afterExclusive) return 0;
+  const anchor = toUtc(schedule.anchor);
+  const after = toUtc(afterExclusive);
+  const elapsedDays =
+    (after.getTime() - anchor.getTime()) / (24 * 60 * 60 * 1000);
+  // Estimate then correct: clamping (short months) can only push a date
+  // earlier, so the estimate may be at most a couple of steps off.
+  const approxStepDays =
+    schedule.unit === 'day'
+      ? schedule.count
+      : schedule.unit === 'week'
+        ? schedule.count * 7
+        : schedule.unit === 'month'
+          ? schedule.count * 28
+          : schedule.count * 365;
+  let k = Math.max(0, Math.floor(elapsedDays / approxStepDays) - 2);
+  while (occurrenceAt(schedule, k) <= afterExclusive) k++;
+  return k;
+};
+
+export const expandSchedule = (
+  schedule: Schedule,
+  afterExclusive: string,
+  throughInclusive: string
+): string[] => {
+  const result: string[] = [];
+  let k = firstIndexAfter(schedule, afterExclusive);
+  for (;;) {
+    const occurrence = occurrenceAt(schedule, k);
+    if (occurrence > throughInclusive) return result;
+    result.push(occurrence);
+    k++;
+  }
+};
+
+export const lastOccurrenceBefore = (
+  schedule: Schedule,
+  date: string
+): string | null => {
+  const k = firstIndexAfter(schedule, date) - 1;
+  // firstIndexAfter uses strict >, so back up while the occurrence at k
+  // equals `date` (we need strictly before).
+  for (let i = k; i >= 0; i--) {
+    const occurrence = occurrenceAt(schedule, i);
+    if (occurrence < date) return occurrence;
+  }
+  return null;
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run lib/journal/schedule.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/journal/schedule.ts lib/journal/schedule.test.ts
+git commit -m "feat(recurring): schedule parse/serialize/expand module"
+```
+
+---
+
+### Task 2: `:handled:` line in the recurring parser/formatter
+
+**Files:**
+- Modify: `lib/journal/recurring.ts`
+- Test: `lib/journal/recurring.test.ts` (extend existing file)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `recurringDraftSchema` gains `handled: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional()`; `RecurringDraft` and `ParsedRecurring` therefore carry `handled?: string`.
+  - `formatRecurring` emits `    ; :handled: YYYY-MM-DD` immediately after the uid line when `handled` is set.
+  - `parseRecurringBlock` recognizes `HANDLED_LINE_REGEX = /^\s*;\s*:handled:\s*(\d{4}-\d{2}-\d{2})\s*$/` before the generic comment branch (so it never leaks into `note`).
+  - Because `fingerprintRecurring` hashes `formatRecurring(draft)`, updating `handled` changes the fingerprint — this is what makes Post/Skip replay-safe.
+
+- [ ] **Step 1: Write the failing tests** — append to `lib/journal/recurring.test.ts`:
+
+```typescript
+describe(':handled: state line', () => {
+  it('round-trips through format and parse without polluting note', () => {
+    const draft = {
+      period: 'every 1 months from 2026/01/05',
+      note: 'Netflix',
+      uid: '01HZX5G5KJDS9HQRYK8E5T0DJC',
+      handled: '2026-07-05',
+      postings: [
+        { account: 'Expenses:Netflix', amount: '15', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    };
+    const block = formatRecurring(draft);
+    expect(block).toContain('; :handled: 2026-07-05');
+    const parsed = parseRecurringFile('main.ledger', block + '\n');
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].handled).toBe('2026-07-05');
+    expect(parsed[0].note).toBe('Netflix');
+  });
+
+  it('changes the fingerprint when handled advances', () => {
+    const base = {
+      period: 'every 1 months from 2026/01/05',
+      postings: [
+        { account: 'Expenses:Netflix', amount: '15', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    };
+    expect(fingerprintRecurring({ ...base, handled: '2026-06-05' })).not.toBe(
+      fingerprintRecurring({ ...base, handled: '2026-07-05' })
+    );
+  });
+});
+```
+
+(Add `fingerprintRecurring` to the file's imports from `./recurring` if not already imported.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/journal/recurring.test.ts`
+Expected: FAIL — `handled` is `undefined` after parse and missing from the formatted block.
+
+- [ ] **Step 3: Implement** — in `lib/journal/recurring.ts`:
+
+Add to the schema object (after `uid`):
+
+```typescript
+  handled: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'handled must be YYYY-MM-DD')
+    .optional(),
+```
+
+In `formatRecurring`, after `uidLines`:
+
+```typescript
+  const handledLines = draft.handled
+    ? [`    ; :handled: ${draft.handled}`]
+    : [];
+```
+
+and include `...handledLines` between `...uidLines` and `...noteLines` in the returned array.
+
+In `parseRecurringBlock`, add near the top:
+
+```typescript
+const HANDLED_LINE_REGEX = /^\s*;\s*:handled:\s*(\d{4}-\d{2}-\d{2})\s*$/;
+```
+
+declare `let handled: string | undefined;` beside `uid`, and inside the loop, after the uid match and before the generic comment match:
+
+```typescript
+    const handledMatch = line.match(HANDLED_LINE_REGEX);
+    if (handledMatch) {
+      handled = handledMatch[1];
+      continue;
+    }
+```
+
+and add `handled,` to the returned object.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run lib/journal/recurring.test.ts`
+Expected: PASS (existing tests must stay green too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/journal/recurring.ts lib/journal/recurring.test.ts
+git commit -m "feat(recurring): parse and format :handled: state line"
+```
+
+---
+
+### Task 3: Structured schedule on create + `:handled:` initialization
+
+**Files:**
+- Modify: `lib/journal/recurring.ts` (draft schema), `lib/journal/service.ts` (`addRecurring`)
+- Test: `lib/journal/recurring.test.ts`, `lib/journal/service.recurring-occurrence.test.ts` (create; service tests follow the `setupTestDb` pattern of `lib/journal/service.test.ts`)
+
+**Interfaces:**
+- Consumes: `parseSchedule`, `serializeSchedule`, `lastOccurrenceBefore` from `lib/journal/schedule.ts` (Task 1).
+- Produces:
+  - `recurringDraftSchema` accepts `schedule: { unit, count, anchor }` **instead of** `period` on input. Shape:
+
+```typescript
+export const recurringScheduleInputSchema = z.object({
+  unit: z.enum(['day', 'week', 'month', 'year']),
+  count: z.number().int().min(1).max(366),
+  anchor: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Anchor must be YYYY-MM-DD')
+    .refine((s) => !Number.isNaN(Date.parse(s)), 'Anchor is not a real date'),
+});
+```
+
+  - New `recurringCreateSchema = recurringDraftSchema.omit({ period: true, handled: true, uid: true }).extend({ schedule: recurringScheduleInputSchema })` exported from `lib/journal/recurring.ts`.
+  - `JournalService.addRecurring(userId, rawDraft, today: string)` now validates against `recurringCreateSchema`, then builds the stored draft: `period = serializeSchedule(draft.schedule)`, `handled = lastOccurrenceBefore(draft.schedule, today) ?? undefined`. `today` is passed by the caller (`createRecurringAction`) as `new Date().toISOString().slice(0, 10)` so the service stays clock-free for tests.
+  - Everything downstream (`formatRecurring`, quota, verify, push, rollback) is unchanged.
+
+- [ ] **Step 1: Write the failing test** — create `lib/journal/service.recurring-occurrence.test.ts` with the same harness as `lib/journal/service.test.ts` (`resetObjectStore`, `setupTestDb('journal-recurring-')`, `insertUser`, `new JournalService(new JournalRepository(ctx.db))`, `fs.mkdir(getJournalDir(userId))`):
+
+```typescript
+describe('JournalService.addRecurring (structured schedule)', () => {
+  it('serializes the schedule and initializes :handled: to the last occurrence before today', async () => {
+    const result = await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-01-05' },
+        note: 'Netflix',
+        postings: [
+          { account: 'Expenses:Netflix', amount: '15', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-16'
+    );
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('~ every 1 months from 2026/01/05');
+    expect(text).toContain('; :handled: 2026-07-05');
+  });
+
+  it('omits :handled: for a future anchor (no backlog either way)', async () => {
+    const result = await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-09-05' },
+        postings: [
+          { account: 'Expenses:Rent', amount: '900', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-16'
+    );
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('~ every 1 months from 2026/09/05');
+    expect(text).not.toContain(':handled:');
+  });
+
+  it('rejects a draft without a schedule', async () => {
+    const result = await service.addRecurring(
+      'test-user',
+      { period: 'Monthly', postings: [] },
+      '2026-07-16'
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/journal/service.recurring-occurrence.test.ts`
+Expected: FAIL — `addRecurring` rejects `schedule` as an unknown key / wrong arity.
+
+- [ ] **Step 3: Implement**
+
+In `lib/journal/recurring.ts` export `recurringScheduleInputSchema` (shape above) and:
+
+```typescript
+export const recurringCreateSchema = recurringDraftSchema
+  .omit({ period: true, handled: true, uid: true })
+  .extend({ schedule: recurringScheduleInputSchema });
+export type RecurringCreateDraft = z.infer<typeof recurringCreateSchema>;
+```
+
+In `lib/journal/service.ts` `addRecurring`: change the signature to `(userId: string, rawDraft: unknown, today: string)`, validate with `recurringCreateSchema`, then build the stored draft before the existing `withUserLock` block:
+
+```typescript
+    const { schedule, ...rest } = parsed.data;
+    const storedDraft: RecurringDraft = {
+      ...rest,
+      period: serializeSchedule(schedule),
+      handled: lastOccurrenceBefore(schedule, today) ?? undefined,
+      uid: generateUid(),
+    };
+```
+
+(then use `storedDraft` where the old code built `draft`; import `serializeSchedule`, `lastOccurrenceBefore` from `./schedule`). Update `createRecurringAction` to pass `new Date().toISOString().slice(0, 10)` as the third argument, and update `features/recurring/RecurringView.tsx`'s `draft` JSON to send `schedule: { unit, count, anchor }` instead of `period` (full form change lands in Task 8; here just keep the app compiling — replace the `period` state with the three schedule fields and serialize them into the hidden input).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run lib/journal/service.recurring-occurrence.test.ts lib/journal/recurring.test.ts && pnpm exec tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/journal/recurring.ts lib/journal/service.ts lib/journal/service.recurring-occurrence.test.ts features/recurring/actions/createRecurring.ts features/recurring/RecurringView.tsx
+git commit -m "feat(recurring): structured schedule input with handled initialization"
+```
+
+---
+
+### Task 4: Service — post and skip an occurrence
+
+**Files:**
+- Modify: `lib/journal/service.ts`
+- Test: `lib/journal/service.recurring-occurrence.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `parseSchedule`, `expandSchedule` (Task 1); `handled` on `ParsedRecurring` (Task 2); existing `formatTransaction`, `formatRecurring`, `generateUid`, `verifyJournalParseable`, `pull`/`push`, `withUserLock`, `getJournalDirSize`/quota helpers.
+- Produces (both on `JournalService`):
+  - `postRecurringOccurrence(userId: string, input: { uid: string; expectedFingerprint: string; dueDate: string; today: string }): Promise<WriteResult>`
+  - `skipRecurringOccurrence(userId: string, input: { uid: string; expectedFingerprint: string; dueDate: string; today: string }): Promise<WriteResult>`
+  - Shared behavior (private `handleRecurringOccurrence(userId, input, mode: 'post' | 'skip')`):
+    1. `withUserLock` → `pull` → locate the rule by uid across `resolveIncludes` files (same loop as `deleteRecurring`).
+    2. Fingerprint mismatch → `{ ok: false, reason: 'stale', message: 'This recurring entry was modified somewhere else.' }`.
+    3. `parseSchedule(rule.period)` null → `{ ok: false, reason: 'invalid', message: 'This rule has an unsupported schedule.' }`.
+    4. Oldest unhandled occurrence = `expandSchedule(schedule, floor, input.today)[0]` where `floor = rule.handled ?? dayBefore(input.today)` (helper `dayBefore` = ISO date minus one day, so a no-`:handled:` rule is due only for an occurrence landing today — no backlog, per spec rollout). If it is `undefined` or ≠ `input.dueDate` → `{ ok: false, reason: 'invalid', message: 'This occurrence is not the oldest unhandled one.' }`.
+    5. Snapshot every file to be touched. For `post`: append to `mainPath` (quota-checked, exactly like `addTransaction`) a transaction built as:
+
+```typescript
+      const transactionDraft: TransactionDraft = {
+        date: input.dueDate,
+        payee: (rule.note ?? '').split('\n')[0] || 'Recurring',
+        status: 'none',
+        note: `:recurring: ${rule.uid}`,
+        uid: generateUid(),
+        postings: rule.postings,
+      };
+```
+
+       (the provenance tag rides the existing `note` field — `formatTransaction` renders it as `    ; :recurring: <uid>` with zero formatter changes; nothing ever parses it back, it is provenance only).
+    6. For both modes: rewrite the rule's block in its own file (line-splice `startLine-1..endLine-1`, same as `performEdit`) with `formatRecurring({ ...ruleDraftFields, handled: input.dueDate })`.
+    7. One `verifyJournalParseable(mainPath)`; on failure restore all snapshots → `parse-failed`. Then `push`; on conflict restore all snapshots → `stale`. Then `invalidateCache`, `{ ok: true }`.
+
+- [ ] **Step 1: Write the failing tests** — append to `lib/journal/service.recurring-occurrence.test.ts`. Seed helper for these tests:
+
+```typescript
+const seedRule = async (userId: string, handled?: string) => {
+  const block = [
+    '~ every 1 months from 2026/01/05',
+    '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DJC',
+    ...(handled ? [`    ; :handled: ${handled}`] : []),
+    '    ; Netflix',
+    '    Expenses:Netflix                            USD 15',
+    '    Assets:Checking                             USD -15',
+    '',
+  ].join('\n');
+  await fs.writeFile(path.join(getJournalDir(userId), 'main.ledger'), block);
+  await push(userId);
+  const rules = await service.listRecurring(userId);
+  return rules[0];
+};
+```
+
+Tests:
+
+```typescript
+describe('postRecurringOccurrence', () => {
+  it('writes the transaction, tags provenance, and advances :handled:', async () => {
+    const rule = await seedRule('test-user', '2026-06-05');
+    const result = await service.postRecurringOccurrence('test-user', {
+      uid: rule.uid!,
+      expectedFingerprint: rule.fingerprint,
+      dueDate: '2026-07-05',
+      today: '2026-07-16',
+    });
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('2026-07-05 Netflix');
+    expect(text).toContain('; :recurring: 01HZX5G5KJDS9HQRYK8E5T0DJC');
+    expect(text).toContain('; :handled: 2026-07-05');
+    expect(text).not.toContain('; :handled: 2026-06-05');
+  });
+
+  it('rejects a replay: the first post changed the fingerprint', async () => {
+    const rule = await seedRule('test-user', '2026-06-05');
+    const input = {
+      uid: rule.uid!,
+      expectedFingerprint: rule.fingerprint,
+      dueDate: '2026-07-05',
+      today: '2026-07-16',
+    };
+    expect((await service.postRecurringOccurrence('test-user', input)).ok).toBe(true);
+    const replay = await service.postRecurringOccurrence('test-user', input);
+    expect(replay.ok).toBe(false);
+    if (!replay.ok) expect(replay.reason).toBe('stale');
+  });
+
+  it('rejects posting a non-oldest occurrence', async () => {
+    const rule = await seedRule('test-user', '2026-05-05');
+    const result = await service.postRecurringOccurrence('test-user', {
+      uid: rule.uid!,
+      expectedFingerprint: rule.fingerprint,
+      dueDate: '2026-07-05', // 2026-06-05 is still unhandled
+      today: '2026-07-16',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid');
+  });
+
+  it('rule without :handled: has no backlog: only a today-dated occurrence is due', async () => {
+    const rule = await seedRule('test-user'); // no handled line
+    const result = await service.postRecurringOccurrence('test-user', {
+      uid: rule.uid!,
+      expectedFingerprint: rule.fingerprint,
+      dueDate: '2026-07-05',
+      today: '2026-07-16',
+    });
+    expect(result.ok).toBe(false); // oldest unhandled is 2026-08-05 (> today) — nothing due
+  });
+});
+
+describe('skipRecurringOccurrence', () => {
+  it('advances :handled: without writing a transaction', async () => {
+    const rule = await seedRule('test-user', '2026-06-05');
+    const result = await service.skipRecurringOccurrence('test-user', {
+      uid: rule.uid!,
+      expectedFingerprint: rule.fingerprint,
+      dueDate: '2026-07-05',
+      today: '2026-07-16',
+    });
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('; :handled: 2026-07-05');
+    expect(text).not.toContain('2026-07-05 Netflix');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/journal/service.recurring-occurrence.test.ts`
+Expected: FAIL — methods don't exist.
+
+- [ ] **Step 3: Implement** `handleRecurringOccurrence` in `lib/journal/service.ts` per the interface contract above (mirror `deleteRecurring` for locate/splice/rollback and `addTransaction` for append/quota; both file mutations happen before the single verify+push; keep per-file snapshots in a `Map<string, string>` and restore all on any failure). Public wrappers:
+
+```typescript
+  async postRecurringOccurrence(userId: string, input: RecurringOccurrenceInput) {
+    return this.handleRecurringOccurrence(userId, input, 'post');
+  }
+  async skipRecurringOccurrence(userId: string, input: RecurringOccurrenceInput) {
+    return this.handleRecurringOccurrence(userId, input, 'skip');
+  }
+```
+
+with `export type RecurringOccurrenceInput = { uid: string; expectedFingerprint: string; dueDate: string; today: string }`. The `dayBefore` helper:
+
+```typescript
+const dayBefore = (iso: string): string => {
+  const date = new Date(`${iso}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+};
+```
+
+Rebuilding the rule draft for `formatRecurring`: `{ period: rule.period, note: rule.note, uid: rule.uid, handled: input.dueDate, postings: rule.postings }`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run lib/journal/service.recurring-occurrence.test.ts && pnpm vitest run lib/journal/service.test.ts`
+Expected: PASS, existing service tests untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/journal/service.ts lib/journal/service.recurring-occurrence.test.ts
+git commit -m "feat(recurring): post and skip occurrence service methods"
+```
+
+---
+
+### Task 5: Due-list builder
+
+**Files:**
+- Create: `features/recurring/dueList.ts`
+- Test: `features/recurring/dueList.test.ts`
+
+**Interfaces:**
+- Consumes: `ParsedRecurring` (with `handled`), `parseSchedule`, `expandSchedule`.
+- Produces:
+
+```typescript
+export type RecurringOccurrenceView = {
+  ruleUid: string;
+  fingerprint: string;
+  date: string; // YYYY-MM-DD
+  label: string; // rule note first line, or first posting account
+  postings: { account: string; amount: string; currency: string }[];
+  overdue: boolean;
+};
+
+export type RecurringDueList = {
+  due: RecurringOccurrenceView[]; // date <= today, oldest first
+  upcoming: RecurringOccurrenceView[]; // today < date <= horizon
+  unsupported: { ruleUid: string | undefined; period: string }[];
+};
+
+export const buildDueList = (
+  rules: readonly ParsedRecurring[],
+  today: string,
+  horizon: string // e.g. today + 30 days
+): RecurringDueList
+```
+
+- Pure function: for each rule, `parseSchedule(rule.period)`; null → `unsupported`. Rules without a uid also go to `unsupported` (no stable identity to act on). Floor = `rule.handled ?? dayBefore(today)`. Expand floor→horizon; split by `date <= today`. `overdue = date < today`. Due rows sorted date ascending across rules; only the oldest unhandled occurrence **per rule** is actionable, and later ones are still listed (the UI disables all but the first per rule — buttons carry `dueDate`, and the service enforces oldest-first regardless). Move `dayBefore` into `lib/journal/schedule.ts` and export it so this module and the service share it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// features/recurring/dueList.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildDueList } from './dueList';
+import { parseRecurringFile } from '@/lib/journal/recurring';
+
+const rules = parseRecurringFile(
+  'main.ledger',
+  [
+    '~ every 1 months from 2026/01/05',
+    '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DJC',
+    '    ; :handled: 2026-05-05',
+    '    ; Netflix',
+    '    Expenses:Netflix                            USD 15',
+    '    Assets:Checking                             USD -15',
+    '',
+    '~ Monthly',
+    '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DKZ',
+    '    Expenses:Rent                               USD 900',
+    '    Assets:Checking                             USD -900',
+    '',
+  ].join('\n')
+);
+
+describe('buildDueList', () => {
+  it('splits due (with backlog) from upcoming and flags unsupported', () => {
+    const list = buildDueList(rules, '2026-07-16', '2026-08-15');
+    expect(list.due.map((o) => o.date)).toEqual(['2026-06-05', '2026-07-05']);
+    expect(list.due[0].overdue).toBe(true);
+    expect(list.due[0].label).toBe('Netflix');
+    expect(list.upcoming.map((o) => o.date)).toEqual(['2026-08-05']);
+    expect(list.unsupported).toEqual([
+      { ruleUid: '01HZX5G5KJDS9HQRYK8E5T0DKZ', period: 'Monthly' },
+    ]);
+  });
+
+  it('rule without :handled: contributes no backlog', () => {
+    const fresh = parseRecurringFile(
+      'main.ledger',
+      [
+        '~ every 1 months from 2026/01/16',
+        '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DAA',
+        '    Expenses:Gym                             USD 20',
+        '    Assets:Checking                          USD -20',
+        '',
+      ].join('\n')
+    );
+    const list = buildDueList(fresh, '2026-07-16', '2026-08-15');
+    expect(list.due.map((o) => o.date)).toEqual(['2026-07-16']); // today only
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `pnpm vitest run features/recurring/dueList.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** `buildDueList` per the contract (straightforward map/filter over `expandSchedule` output; label = `(rule.note ?? '').split('\n')[0] || rule.postings[0]?.account ?? ''`; postings mapped to `{ account, amount, currency }`).
+
+- [ ] **Step 4: Run to verify pass** — `pnpm vitest run features/recurring/dueList.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/recurring/dueList.ts features/recurring/dueList.test.ts lib/journal/schedule.ts
+git commit -m "feat(recurring): due-list builder"
+```
+
+---
+
+### Task 6: Audit actions + Post/Skip server actions
+
+**Files:**
+- Modify: `lib/audit/schema.ts` (add `'recurring.post'`, `'recurring.skip'` to `AUDIT_ACTIONS`, after `'recurring.add'`), `lib/audit/describe.ts` (add human labels following the existing entries — check `lib/audit/describe.test.ts` for the expected mapping shape and extend it)
+- Create: `features/recurring/actions/postOccurrence.ts`, `features/recurring/actions/skipOccurrence.ts`
+- Test: `lib/audit/describe.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `journalService.postRecurringOccurrence` / `skipRecurringOccurrence` (Task 4).
+- Produces: `postOccurrenceAction(uid: string, fingerprint: string, dueDate: string): Promise<{ ok: true } | { ok: false; message: string }>` and the identical `skipOccurrenceAction`. Client components import these.
+
+- [ ] **Step 1: Write the action** — `features/recurring/actions/postOccurrence.ts`, cloned from `deleteRecurring.ts`'s structure:
+
+```typescript
+'use server';
+
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { getJournalDirSize } from '@/lib/journal/quota';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export type OccurrenceActionResult = { ok: true } | { ok: false; message: string };
+
+export async function postOccurrenceAction(
+  uid: string,
+  fingerprint: string,
+  dueDate: string
+): Promise<OccurrenceActionResult> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
+  const bytesBefore = await getJournalDirSize(user.id);
+  const result = await journalService.postRecurringOccurrence(user.id, {
+    uid,
+    expectedFingerprint: fingerprint,
+    dueDate,
+    today: new Date().toISOString().slice(0, 10),
+  });
+  const bytesAfter = await getJournalDirSize(user.id);
+  await auditService.record(user.id, {
+    action: 'recurring.post',
+    result: result.ok ? 'success' : 'failure',
+    targetUid: uid,
+    bytesBefore,
+    bytesAfter,
+    detail: result.ok ? { dueDate } : { reason: result.reason, dueDate },
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) return { ok: false, message: result.message };
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+```
+
+`skipOccurrence.ts` is identical with `skipRecurringOccurrence` and `'recurring.skip'` (import `OccurrenceActionResult` from `./postOccurrence`).
+
+- [ ] **Step 2: Extend audit schema, describe map, and its test**; run `pnpm vitest run lib/audit/describe.test.ts` → PASS.
+
+- [ ] **Step 3: Type-check** — `pnpm exec tsc --noEmit` → clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/audit/schema.ts lib/audit/describe.ts lib/audit/describe.test.ts features/recurring/actions/postOccurrence.ts features/recurring/actions/skipOccurrence.ts
+git commit -m "feat(recurring): post/skip occurrence server actions with audit"
+```
+
+---
+
+### Task 7: Dashboard widget — due queue + upcoming preview
+
+**Files:**
+- Create: `features/dashboard/UpcomingBillsWidget.tsx` (client component)
+- Modify: `features/dashboard/Dashboard.tsx` (replace the `getUpcomingBills(...)` entry in the `Promise.all` with `journalService.listRecurring(user.id).then((rules) => buildDueList(rules, todayIso, upcomingEnd))` and render `<UpcomingBillsWidget dueList={dueList} />` where the current upcoming-bills markup sits; delete `getUpcomingBills` and `UpcomingBill` from `Dashboard.utils.ts` once nothing references them)
+
+**Interfaces:**
+- Consumes: `RecurringDueList` (Task 5), `postOccurrenceAction` / `skipOccurrenceAction` (Task 6).
+- Produces: `UpcomingBillsWidget({ dueList }: { dueList: RecurringDueList })`.
+
+- [ ] **Step 1: Build the component.** Client component modeled on `RecurringView`'s delete flow (`useTransition`, per-row pending key `${ruleUid}:${date}`, one inline error slot). Layout:
+  - "Due" section: rows `label — date — amount` with overdue rows styled `text-destructive` on the date; Post (primary, small) and Skip (ghost) buttons. Per rule, only the oldest row's buttons are enabled (`disabled={!isOldestForRule}` — compute a `Set` of `ruleUid` first-seen while rendering; the list is date-ascending).
+  - "Upcoming" section: read-only rows exactly like today's widget.
+  - Unsupported rules: one muted line — "N rules have schedules this view can't expand" linking to `/recurring`.
+  - Empty due + empty upcoming keeps the widget's existing empty state.
+  - Amount display: the first posting with a non-empty amount, rendered as `${currency} ${amount}` — the rule's own text, no arithmetic.
+- [ ] **Step 2: Wire into `Dashboard.tsx`**, remove dead `getUpcomingBills`/`UpcomingBill` code and their import.
+- [ ] **Step 3: Verify** — `pnpm exec tsc --noEmit && pnpm lint`, then `pnpm vitest run` (full suite; `Dashboard.utils.test.ts` may need its `getUpcomingBills` cases deleted with the function). Manually: `pnpm dev`, seed a rule with a past `:handled:`, confirm due rows render, Post writes the transaction and the row disappears, Skip advances without a transaction, double-click shows the stale message.
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/dashboard/UpcomingBillsWidget.tsx features/dashboard/Dashboard.tsx features/dashboard/Dashboard.utils.ts features/dashboard/Dashboard.utils.test.ts
+git commit -m "feat(dashboard): due-occurrence queue with post/skip in upcoming bills widget"
+```
+
+---
+
+### Task 8: /recurring form → structured schedule; rule list gains next-due
+
+**Files:**
+- Modify: `features/recurring/RecurringView.tsx`, `app/recurring/page.tsx`
+
+**Interfaces:**
+- Consumes: `recurringCreateSchema` draft shape (Task 3), `buildDueList` (Task 5).
+- Produces: no new exports; `RecurringRowView` gains `nextDue?: string` and `unsupported: boolean`.
+
+- [ ] **Step 1: Form.** Replace the freeform "Repeats" input (and its datalist) with: `Every [number input, min 1] [select: days/weeks/months/years] starting [input type="date"]` (native date input; default = today). The hidden `draft` JSON becomes `{ schedule: { unit, count, anchor }, note, postings }`. Helper text: "Repeats on the anchor's day — e.g. every 1 months starting 2026-01-05 runs on the 5th."
+- [ ] **Step 2: Rule list.** `app/recurring/page.tsx` computes `buildDueList` alongside `listRecurring` and passes per-rule `nextDue` (first occurrence, due or upcoming, for that uid) and `unsupported` into rows. `RecurringView` renders a "Next due" column; unsupported rules show "unsupported schedule" in that cell (delete still works).
+- [ ] **Step 3: Verify** — `pnpm exec tsc --noEmit && pnpm lint && pnpm vitest run`; manually create a rule via the form, confirm the serialized directive and `:handled:` in the journal (Settings → export or `/transactions` raw view), and the next-due column.
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/recurring/RecurringView.tsx app/recurring/page.tsx
+git commit -m "feat(recurring): structured schedule form and next-due column"
+```
+
+---
+
+### Task 9: End-to-end verification + docs pruning
+
+**Files:**
+- Modify: `LEDGER-AUDIT.md` (append the 2026-07-16 `--forecast` findings: no past emission, `--now` behavior, calendar-boundary snapping — they are exactly the gotcha class that file collects)
+- Modify: `features/dashboard/Dashboard.utils.ts` (the `getSafeToSpend` doc comment already notes the anchor snapping; leave the function — income forecasting still uses ledger `--forecast` and is out of scope)
+
+- [ ] **Step 1:** Full suite: `pnpm vitest run && pnpm exec tsc --noEmit && pnpm lint && pnpm build` — all green.
+- [ ] **Step 2:** Live walk: create rule anchored last month → no backlog; set `:handled:` back two months by editing the journal → two due rows, oldest actionable; Post oldest → transaction visible on /transactions with the `:recurring:` note line; Skip next; refresh → empty due list. Verify plain `ledger stats` still parses the journal.
+- [ ] **Step 3:** Append findings to `LEDGER-AUDIT.md`; commit.
+
+```bash
+git add LEDGER-AUDIT.md
+git commit -m "docs(ledger-audit): record --forecast anchor-snapping findings"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: data model (Tasks 2–4), creation normalization (Task 3), due list (Task 5), actions/audit (Task 6), widget (Task 7), form + next-due (Task 8), rollout/no-migration (floor default covered in Tasks 4–5), out-of-scope list untouched.
+- Deliberate simplifications: provenance tag rides the transaction `note` field (no formatter/schema change; visible when editing that transaction — acceptable, nothing parses it); overdue backlog is uncapped (a daily rule ignored for a year lists 365 rows — add a cap only if it ever happens).
+- `addRecurring` signature change (`today` parameter) touches only `createRecurringAction`.

--- a/docs/superpowers/specs/2026-07-16-recurring-confirm-to-post-design.md
+++ b/docs/superpowers/specs/2026-07-16-recurring-confirm-to-post-design.md
@@ -1,0 +1,128 @@
+# Recurring transactions: confirm-to-post
+
+2026-07-16
+
+## Problem
+
+Recurring entries are ledger `~` periodic directives rendered via `--forecast`.
+They are forecast-only: nothing links them to real transactions, nothing tells
+the user "this is due, confirm it", and a paid occurrence keeps showing in the
+forecast. Users expect the calendar model every mainstream tool converged on
+(GnuCash Since-Last-Run, Actual Budget manual-approval schedules, YNAB
+scheduled transactions): a rule generates due occurrences, the user confirms
+each into a real transaction, missed occurrences queue up until handled.
+
+Research summary (verified against official docs 2026-07-16): three models
+exist — forecast-only overlay (hledger/ledger), silent cron auto-post
+(Firefly III), and confirm-to-post with per-occurrence state (GnuCash, Actual,
+YNAB, HomeBank, MMEX). Confirm-to-post is the dominant model and the best fit
+for a journal-as-source-of-truth constraint. Common UX expectations: explicit
+single-occurrence skip, an overdue review queue that survives the app being
+closed, end conditions, visible next-due status.
+
+## Design
+
+### Data model — the journal is the only state
+
+A rule remains a `~` directive. Its `from` date doubles as "next unhandled
+occurrence"; there is no occurrence table, no database state.
+
+```
+~ Monthly from 2026/08/05
+    ; :uid: 01ABC...
+    ; Netflix
+    Expenses:Subscriptions:Netflix  USD 15.00
+    Assets:Checking
+```
+
+- **Create**: normalize the stored `from` to the first occurrence on or after
+  today, preserving the user's anchor (input "Monthly from 2026/01/05", saved
+  "Monthly from 2026/08/05"). A rule with no `from` is stored as-is and treated
+  as `from = today` at expansion time. New rules therefore never show a
+  backlog.
+- **Post**: write a real transaction dated on the due date through the
+  existing add path, plus a provenance comment `; :recurring: <rule-uid>`
+  (no logic depends on it), then rewrite the rule's `from` to the day after
+  the posted occurrence. Both edits in one write, one `ledger stats` verify,
+  one push; rollback both on failure.
+- **Skip**: the `from` rewrite only, no transaction.
+- Concurrency: rule fingerprint (existing sha256 mechanism) is required by
+  Post/Skip; the first successful action changes it, so double-clicks and
+  replays fail as stale. Oldest-first is enforced server-side: an action whose
+  due date is not the rule's oldest unhandled occurrence is rejected.
+
+### Due-list query — ledger expands, JS buckets
+
+`--forecast` on the real journal cannot emit past-due occurrences (it starts
+after the last real transaction), so expansion runs against a rules-only view:
+
+1. `listRecurring` parses all `~` blocks (exists today).
+2. Per rule, write its block to a temp journal inside the per-user journal
+   working directory (plaintext-safe location for encrypted journals; deleted
+   after the call) and run
+   `ledger reg --forecast 'd<[today+30]' -e <today+30>` with a `%D|quantity|
+   commodity|%A` format. Per-rule expansion avoids attributing rows when rules
+   share accounts; rules are few and calls run concurrently.
+3. Rows with date <= today are due/overdue (actionable); later rows are the
+   read-only upcoming preview. This replaces `getUpcomingBills` as the
+   widget's single source.
+
+All recurrence math is ledger's. JS parses rows, buckets by date, formats.
+
+### UI
+
+Dashboard upcoming-bills widget: "Due" group (date <= today, overdue styling
+for past dates, Post + Skip buttons per row, oldest first, one row per missed
+occurrence) above the existing read-only "Upcoming" group. Button pattern
+follows `RecurringView` delete: `useTransition`, per-row pending, inline
+error, `revalidatePath('/', 'layout')` on success.
+
+/recurring page: create/delete unchanged; the rule list gains a "next due"
+column from the same expansion.
+
+### Server surface
+
+- Actions (one file each): `postOccurrenceAction(ruleUid, fingerprint,
+  dueDate)`, `skipOccurrenceAction(ruleUid, fingerprint, dueDate)` —
+  `requireUser` → WRITE rate-limit → service → audit (`recurring.post` /
+  `recurring.skip`, bytes before/after), same shape as `deleteRecurringAction`.
+- `JournalService.postRecurringOccurrence` / `skipRecurringOccurrence` under
+  the user lock: pull → locate rule by uid → fingerprint check → oldest-first
+  check → mutate → verify → push/rollback. Errors surface as
+  `{ ok: false, message }` with ledger's own message; no silent fallbacks.
+
+### Empirical preconditions (step 1 of implementation, before feature code)
+
+Verify on synthetic journals against ledger 3.4.1 and pin as tests:
+
+1. A rules-only journal plus `--forecast` emits occurrences starting at
+   `from`, including dates in the past.
+2. Rewriting `from` preserves anchor alignment for "every 2 weeks from a
+   Friday" and "monthly from the 5th". If it re-anchors, compute the bumped
+   `from` by asking ledger for the next occurrence rather than JS date math.
+
+If either fails, revisit the design at that point.
+
+### Testing
+
+End-to-end against real ledger, existing test style:
+- The two gotcha-pinning tests above.
+- Service: post writes transaction + tag + bump atomically; skip bumps only;
+  stale fingerprint rejected; non-oldest occurrence rejected; ledger-rejected
+  rewrite rolls back both edits; quota respected.
+- Expansion: multi-currency, multiple rules, overdue vs upcoming bucketing,
+  creation-time `from` normalization.
+- Parser: the `:recurring:` comment line survives
+  `parseJournalFile`/`formatTransaction` round-trips.
+
+### Rollout
+
+No migration. Existing `from`-less rules show no backlog and gain an explicit
+`from` on first Post. Journals stay valid for plain ledger CLI; a user who
+never posts keeps today's forecast-only behavior.
+
+### Out of scope
+
+Auto-post mode, notifications/reminders (later: cron on the same due-list
+function), bank-import matching, a postpone state (inaction is postpone),
+rule editing UI.

--- a/docs/superpowers/specs/2026-07-16-recurring-confirm-to-post-design.md
+++ b/docs/superpowers/specs/2026-07-16-recurring-confirm-to-post-design.md
@@ -24,50 +24,76 @@ closed, end conditions, visible next-due status.
 
 ### Data model — the journal is the only state
 
-A rule remains a `~` directive. Its `from` date doubles as "next unhandled
-occurrence"; there is no occurrence table, no database state.
+A rule remains a `~` directive. The period expression is immutable (it
+carries the schedule anchor); occurrence state is a single `:handled:`
+comment line recording the last handled occurrence date. There is no
+occurrence table, no database state.
 
 ```
-~ Monthly from 2026/08/05
+~ every 1 months from 2026/01/05
     ; :uid: 01ABC...
+    ; :handled: 2026-07-05
     ; Netflix
     Expenses:Subscriptions:Netflix  USD 15.00
     Assets:Checking
 ```
 
-- **Create**: normalize the stored `from` to the first occurrence on or after
-  today, preserving the user's anchor (input "Monthly from 2026/01/05", saved
-  "Monthly from 2026/08/05"). A rule with no `from` is stored as-is and treated
-  as `from = today` at expansion time. New rules therefore never show a
-  backlog.
+- **Expansion floor**: occurrences strictly after `:handled:` are unhandled.
+- **Create**: the anchor is stored as given; `:handled:` is initialized to
+  the last occurrence before today (or omitted when the anchor is in the
+  future), so new rules never show a backlog. The anchor never changes, so
+  "the 31st" survives February instead of being clamped away by a bump.
 - **Post**: write a real transaction dated on the due date through the
   existing add path, plus a provenance comment `; :recurring: <rule-uid>`
-  (no logic depends on it), then rewrite the rule's `from` to the day after
-  the posted occurrence. Both edits in one write, one `ledger stats` verify,
-  one push; rollback both on failure.
-- **Skip**: the `from` rewrite only, no transaction.
+  (no logic depends on it), then set the rule's `:handled:` line to the
+  posted occurrence date. Both edits in one write, one `ledger stats`
+  verify, one push; rollback both on failure.
+- **Skip**: the `:handled:` update only, no transaction.
+- Plain ledger CLI ignores the comment lines, so the journal stays fully
+  portable; its own `--forecast` remains approximate (boundary snapping),
+  which it already is today.
 - Concurrency: rule fingerprint (existing sha256 mechanism) is required by
   Post/Skip; the first successful action changes it, so double-clicks and
   replays fail as stale. Oldest-first is enforced server-side: an action whose
   due date is not the rule's oldest unhandled occurrence is rejected.
 
-### Due-list query — ledger expands, JS buckets
+### Due-list query — JS computes occurrence dates, ledger keeps all money
 
-`--forecast` on the real journal cannot emit past-due occurrences (it starts
-after the last real transaction), so expansion runs against a rules-only view:
+Empirical findings against ledger 3.4.1 (2026-07-16, synthetic journals):
 
-1. `listRecurring` parses all `~` blocks (exists today).
-2. Per rule, write its block to a temp journal inside the per-user journal
-   working directory (plaintext-safe location for encrypted journals; deleted
-   after the call) and run
-   `ledger reg --forecast 'd<[today+30]' -e <today+30>` with a `%D|quantity|
-   commodity|%A` format. Per-rule expansion avoids attributing rows when rules
-   share accounts; rules are few and calls run concurrently.
-3. Rows with date <= today are due/overdue (actionable); later rows are the
-   read-only upcoming preview. This replaces `getUpcomingBills` as the
-   widget's single source.
+- `--forecast` never emits occurrences before "now", even on a rules-only
+  journal; `--now <date>` backdates generation but the anchor period itself
+  is skipped.
+- Date anchors are ignored: `Monthly from 2026/05/05` fires on the 1st;
+  `every 2 weeks from <a Friday>` fires on Sundays (calendar-boundary
+  snapping); `every 30 days` keeps day arithmetic but drifts across months.
 
-All recurrence math is ledger's. JS parses rows, buckets by date, formats.
+Ledger therefore cannot produce "the 5th of every month" — the calendar
+behavior this feature exists to deliver. Occurrence **dates** are computed in
+JS instead. This is within the project's HARD RULE: CLAUDE.md's allowed list
+explicitly includes dates; recurrence scheduling contains no money. Amounts
+are the rule's postings verbatim (never summed or converted in JS), rule
+validity remains `ledger stats`, and every report stays ledger-computed.
+
+Consequences:
+
+1. The /recurring form replaces the freeform period input with a structured
+   schedule: interval unit (day/week/month/year), interval count N, anchor
+   date — serialized to `~ every N <unit>s from <anchor>` so the journal
+   stays valid and portable for plain ledger CLI (which will forecast it
+   with its own boundary quirks). Existing freeform rules that don't parse
+   into that grammar are listed and deletable but show "unsupported
+   schedule" instead of occurrences.
+2. A pure function `expandSchedule(schedule, fromDate, throughDate)` returns
+   occurrence dates: month arithmetic anchored to the anchor's day-of-month
+   (clamping to short months, e.g. the 31st in February → Feb 28/29),
+   week/day arithmetic as plain day steps, year arithmetic anchored to
+   month+day.
+3. Due list = per rule, occurrences from `expandSchedule(schedule, anchor,
+   today + 30 days)` that are strictly after `:handled:` (all of them when
+   no `:handled:` exists); dates <= today are due/overdue (actionable),
+   later dates are the read-only upcoming preview. This replaces
+   `getUpcomingBills` as the widget's single source.
 
 ### UI
 
@@ -91,35 +117,36 @@ column from the same expansion.
   check → mutate → verify → push/rollback. Errors surface as
   `{ ok: false, message }` with ledger's own message; no silent fallbacks.
 
-### Empirical preconditions (step 1 of implementation, before feature code)
+### Resolved empirical preconditions
 
-Verify on synthetic journals against ledger 3.4.1 and pin as tests:
-
-1. A rules-only journal plus `--forecast` emits occurrences starting at
-   `from`, including dates in the past.
-2. Rewriting `from` preserves anchor alignment for "every 2 weeks from a
-   Friday" and "monthly from the 5th". If it re-anchors, compute the bumped
-   `from` by asking ledger for the next occurrence rather than JS date math.
-
-If either fails, revisit the design at that point.
+The original design deferred two ledger 3.4.1 checks; both ran on 2026-07-16
+and both failed (see findings above). Two consequences: occurrence dates
+moved to JS, and the state mechanism changed from bumping the period's
+`from` (which would have destroyed the anchor day the JS expansion needs)
+to the immutable-anchor + `:handled:` comment model described in the data
+model section.
 
 ### Testing
 
 End-to-end against real ledger, existing test style:
 - The two gotcha-pinning tests above.
-- Service: post writes transaction + tag + bump atomically; skip bumps only;
+- Service: post writes transaction + tag + `:handled:` update atomically;
+  skip updates `:handled:` only;
   stale fingerprint rejected; non-oldest occurrence rejected; ledger-rejected
   rewrite rolls back both edits; quota respected.
 - Expansion: multi-currency, multiple rules, overdue vs upcoming bucketing,
-  creation-time `from` normalization.
+  creation-time `:handled:` initialization (no backlog on new rules).
 - Parser: the `:recurring:` comment line survives
   `parseJournalFile`/`formatTransaction` round-trips.
 
 ### Rollout
 
-No migration. Existing `from`-less rules show no backlog and gain an explicit
-`from` on first Post. Journals stay valid for plain ledger CLI; a user who
-never posts keeps today's forecast-only behavior.
+No migration. Existing structured-parseable rules without `:handled:` show
+no backlog (floor defaults to today at expansion time) and gain a
+`:handled:` line on first Post/Skip; freeform rules that don't parse into
+the structured grammar are listed as "unsupported schedule" (still
+deletable, still forecast by plain ledger CLI). A user who never posts
+keeps today's behavior.
 
 ### Out of scope
 

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -6,10 +6,10 @@ import {
   getNetWorthChange,
   getNetWorthSeries,
   getSafeToSpend,
-  getUpcomingBills,
 } from './Dashboard.utils';
 import EmptyJournal from './EmptyJournal';
 import SavedViewsCard from './SavedViewsCard';
+import UpcomingBillsWidget from './UpcomingBillsWidget';
 import Card from '@/components/Card';
 import Chart from '@/components/Chart';
 import Help from '@/components/Help';
@@ -17,6 +17,7 @@ import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import { Card as ShadcnCard } from '@/components/ui/card';
 import { getCashFlow } from '@/features/monthlyComparison/MonthlyComparison.utils';
+import { buildDueList } from '@/features/recurring/dueList';
 import { loadJournalTransactions } from '@/features/transactions/loadJournalTransactions';
 import { pageTransactions } from '@/features/transactions/pageTransactions';
 import TransactionRow from '@/features/transactions/row/TransactionRow';
@@ -24,6 +25,7 @@ import { transactionRowToView } from '@/features/transactions/row/rowView';
 import { requireUser } from '@/lib/auth/require-user';
 import { type WidgetId } from '@/lib/dashboard/widgets';
 import { env } from '@/lib/env';
+import { journalService } from '@/lib/journal';
 import { savedViewService } from '@/lib/savedViews';
 import { getBaseCurrency, getDashboardWidgets } from '@/lib/settings';
 import { endOfMonth, startOfMonth, toISODate } from '@/utils/date';
@@ -75,7 +77,7 @@ const Dashboard = async () => {
     recent,
     stats,
     savedViews,
-    upcomingBills,
+    dueList,
     netWorthSeries,
     netWorthChange,
     cashFlow,
@@ -118,7 +120,9 @@ const Dashboard = async () => {
     ),
     getJournalStats(),
     savedViewService.list(user.id),
-    getUpcomingBills(upcomingStart, upcomingEnd),
+    journalService
+      .listRecurring(user.id)
+      .then((rules) => buildDueList(rules, upcomingStart, upcomingEnd)),
     getNetWorthSeries(currency, sparklineCutoff),
     getNetWorthChange(currency, lastMonthStart, thisMonthStart),
     getCashFlow(currency),
@@ -316,54 +320,7 @@ const Dashboard = async () => {
         </ShadcnCard>
       </div>
     ),
-    upcomingBills: (
-      <section className="flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold tracking-tight">
-              Upcoming bills
-            </h2>
-            <Help label="About upcoming bills">
-              Forecast for the next {UPCOMING_DAYS} days from your recurring
-              transactions, computed by <code>ledger --forecast</code>. Bills
-              already posted this period don&apos;t reappear.
-            </Help>
-          </div>
-          <Link
-            href="/recurring"
-            className={buttonVariants({ variant: 'link', size: 'sm' })}
-          >
-            Manage recurring →
-          </Link>
-        </div>
-        {upcomingBills.length === 0 ? (
-          <ShadcnCard className="p-6 text-center text-sm text-muted-foreground">
-            Nothing due in the next {UPCOMING_DAYS} days.{' '}
-            <Link href="/recurring" className="underline">
-              Add recurring bills
-            </Link>{' '}
-            to see them forecast here.
-          </ShadcnCard>
-        ) : (
-          <ShadcnCard className="divide-y px-6 py-2">
-            {upcomingBills.map((bill, i) => (
-              <div
-                key={`${bill.date}:${bill.account}:${i}`}
-                className="flex items-center justify-between gap-4 py-2 text-sm"
-              >
-                <span className="whitespace-nowrap text-muted-foreground">
-                  {formatDate(bill.date, Format.DATE)}
-                </span>
-                <span className="min-w-0 flex-1 truncate">{bill.account}</span>
-                <span className="whitespace-nowrap font-medium tabular-nums">
-                  {formatAmount(bill.amount, true)}
-                </span>
-              </div>
-            ))}
-          </ShadcnCard>
-        )}
-      </section>
-    ),
+    upcomingBills: <UpcomingBillsWidget dueList={dueList} />,
     savedViews: (
       <SavedViewsCard
         views={savedViews.map(({ id, name, targetPath }) => ({

--- a/features/dashboard/Dashboard.utils.ts
+++ b/features/dashboard/Dashboard.utils.ts
@@ -99,52 +99,6 @@ export const getSafeToSpend = async (
   return { amount, until, basedOnIncome: nextIncome !== null };
 };
 
-export type UpcomingBill = {
-  date: string;
-  account: string;
-  amount: string;
-};
-
-/**
- * Forecasts the next stretch of expenses from the journal's periodic (`~`)
- * directives via `ledger --forecast`. Ledger generates the future postings;
- * JS only parses rows. Ledger only forecasts dates after the journal's last
- * real transaction, so already-posted bills don't reappear.
- */
-export const getUpcomingBills = async (
-  start: string,
-  end: string
-): Promise<UpcomingBill[]> => {
-  const stdout = await runLedger(
-    [
-      'reg',
-      '^Expenses',
-      '--forecast',
-      `d<[${end}]`,
-      '-b',
-      start,
-      '-e',
-      end,
-      '--sort',
-      'date',
-      '--date-format',
-      '%Y-%m-%d',
-      '--format',
-      '%D|%A|%t\n',
-    ],
-    { sortByDate: false }
-  );
-  return stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const [date, account, amount] = line.split('|');
-      return { date, account, amount };
-    })
-    .filter((bill) => bill.date && bill.account && bill.amount);
-};
-
 /**
  * Monthly net-worth running total for the sparkline — same query as the
  * /net-worth page: window with `--display`, never `-b`, because `%T` must

--- a/features/dashboard/UpcomingBillsWidget.tsx
+++ b/features/dashboard/UpcomingBillsWidget.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { postOccurrenceAction } from '../recurring/actions/postOccurrence';
+import { skipOccurrenceAction } from '../recurring/actions/skipOccurrence';
+import type {
+  RecurringDueList,
+  RecurringOccurrenceView,
+} from '../recurring/dueList';
+import { Button } from '@/components/ui/button';
+import { Card as ShadcnCard } from '@/components/ui/card';
+import formatDate, { Format } from '@/utils/formatDate';
+import Link from 'next/link';
+
+type Props = { dueList: RecurringDueList };
+
+const occurrenceAmount = (occurrence: RecurringOccurrenceView): string => {
+  const posting = occurrence.postings.find((p) => p.amount.trim() !== '');
+  return posting ? `${posting.currency} ${posting.amount}` : '';
+};
+
+const UpcomingBillsWidget = ({ dueList }: Props) => {
+  const { due, upcoming, unsupported } = dueList;
+  const [isPending, startTransition] = useTransition();
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const seenRuleUids = new Set<string>();
+
+  const runAction = (
+    action: typeof postOccurrenceAction,
+    occurrence: RecurringOccurrenceView
+  ) => {
+    setError(null);
+    const key = `${occurrence.ruleUid}:${occurrence.date}`;
+    setPendingKey(key);
+    startTransition(async () => {
+      const result = await action(
+        occurrence.ruleUid,
+        occurrence.fingerprint,
+        occurrence.date
+      );
+      setPendingKey(null);
+      if (!result.ok) setError(result.message);
+    });
+  };
+
+  const isEmpty = due.length === 0 && upcoming.length === 0;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold tracking-tight">Upcoming bills</h2>
+        <Link
+          href="/recurring"
+          className="text-sm font-medium text-primary hover:underline"
+        >
+          Manage recurring →
+        </Link>
+      </div>
+
+      {error && <p className="text-destructive text-sm">{error}</p>}
+
+      {isEmpty ? (
+        <ShadcnCard className="p-6 text-center text-sm text-muted-foreground">
+          Nothing due or upcoming.{' '}
+          <Link href="/recurring" className="underline">
+            Add recurring bills
+          </Link>{' '}
+          to see them here.
+        </ShadcnCard>
+      ) : (
+        <>
+          {due.length > 0 && (
+            <ShadcnCard className="divide-y px-6 py-2">
+              {due.map((occurrence) => {
+                const isOldestForRule = !seenRuleUids.has(occurrence.ruleUid);
+                seenRuleUids.add(occurrence.ruleUid);
+                const key = `${occurrence.ruleUid}:${occurrence.date}`;
+                const rowPending = isPending && pendingKey === key;
+                return (
+                  <div
+                    key={key}
+                    className="flex items-center justify-between gap-4 py-2 text-sm"
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {occurrence.label}
+                    </span>
+                    <span
+                      className={`whitespace-nowrap ${occurrence.overdue ? 'text-destructive' : 'text-muted-foreground'}`}
+                    >
+                      {formatDate(occurrence.date, Format.DATE)}
+                    </span>
+                    <span className="whitespace-nowrap font-medium tabular-nums">
+                      {occurrenceAmount(occurrence)}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={!isOldestForRule || rowPending}
+                        onClick={() =>
+                          runAction(postOccurrenceAction, occurrence)
+                        }
+                      >
+                        Post
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={!isOldestForRule || rowPending}
+                        onClick={() =>
+                          runAction(skipOccurrenceAction, occurrence)
+                        }
+                      >
+                        Skip
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </ShadcnCard>
+          )}
+
+          {upcoming.length > 0 && (
+            <ShadcnCard className="divide-y px-6 py-2">
+              {upcoming.map((occurrence, i) => (
+                <div
+                  key={`${occurrence.ruleUid}:${occurrence.date}:${i}`}
+                  className="flex items-center justify-between gap-4 py-2 text-sm"
+                >
+                  <span className="min-w-0 flex-1 truncate">
+                    {occurrence.label}
+                  </span>
+                  <span className="whitespace-nowrap text-muted-foreground">
+                    {formatDate(occurrence.date, Format.DATE)}
+                  </span>
+                  <span className="whitespace-nowrap font-medium tabular-nums">
+                    {occurrenceAmount(occurrence)}
+                  </span>
+                </div>
+              ))}
+            </ShadcnCard>
+          )}
+
+          {unsupported.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              <Link href="/recurring" className="underline">
+                {unsupported.length} rules have schedules this view can&apos;t
+                expand.
+              </Link>
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default UpcomingBillsWidget;

--- a/features/dashboard/UpcomingBillsWidget.tsx
+++ b/features/dashboard/UpcomingBillsWidget.tsx
@@ -9,7 +9,7 @@ import type {
 } from '../recurring/dueList';
 import { Button } from '@/components/ui/button';
 import { Card as ShadcnCard } from '@/components/ui/card';
-import formatDate, { Format } from '@/utils/formatDate';
+import { Format, formatDateWithLocale } from '@/utils/formatDateCore';
 import Link from 'next/link';
 
 type Props = { dueList: RecurringDueList };
@@ -89,7 +89,7 @@ const UpcomingBillsWidget = ({ dueList }: Props) => {
                     <span
                       className={`whitespace-nowrap ${occurrence.overdue ? 'text-destructive' : 'text-muted-foreground'}`}
                     >
-                      {formatDate(occurrence.date, Format.DATE)}
+                      {formatDateWithLocale(occurrence.date, Format.DATE)}
                     </span>
                     <span className="whitespace-nowrap font-medium tabular-nums">
                       {occurrenceAmount(occurrence)}
@@ -134,7 +134,7 @@ const UpcomingBillsWidget = ({ dueList }: Props) => {
                     {occurrence.label}
                   </span>
                   <span className="whitespace-nowrap text-muted-foreground">
-                    {formatDate(occurrence.date, Format.DATE)}
+                    {formatDateWithLocale(occurrence.date, Format.DATE)}
                   </span>
                   <span className="whitespace-nowrap font-medium tabular-nums">
                     {occurrenceAmount(occurrence)}

--- a/features/recurring/RecurringView.tsx
+++ b/features/recurring/RecurringView.tsx
@@ -23,6 +23,8 @@ export type RecurringRowView = {
   note?: string;
   fingerprint: string;
   postings: PostingRow[];
+  nextDue?: string;
+  unsupported: boolean;
 };
 
 type Props = { rows: RecurringRowView[]; baseCurrency: string };
@@ -125,7 +127,8 @@ const RecurringView = ({ rows, baseCurrency }: Props) => {
               />
             </div>
             <p className="text-muted-foreground text-xs">
-              E.g. every 1 month(s) from the anchor date.
+              Repeats on the anchor&apos;s day — e.g. every 1 months starting
+              2026-01-05 runs on the 5th.
             </p>
           </div>
           <div className="space-y-1">
@@ -255,6 +258,7 @@ const RecurringView = ({ rows, baseCurrency }: Props) => {
                   <th className="py-1 whitespace-nowrap">Repeats</th>
                   <th>Note</th>
                   <th>Postings</th>
+                  <th className="whitespace-nowrap">Next due</th>
                   <th />
                 </tr>
               </thead>
@@ -271,6 +275,15 @@ const RecurringView = ({ rows, baseCurrency }: Props) => {
                             : p.account
                         )
                         .join(' → ')}
+                    </td>
+                    <td className="whitespace-nowrap">
+                      {row.unsupported ? (
+                        <span className="text-muted-foreground text-xs">
+                          unsupported schedule
+                        </span>
+                      ) : (
+                        (row.nextDue ?? '')
+                      )}
                     </td>
                     <td className="text-right">
                       {row.uid ? (

--- a/features/recurring/RecurringView.tsx
+++ b/features/recurring/RecurringView.tsx
@@ -27,13 +27,6 @@ export type RecurringRowView = {
 
 type Props = { rows: RecurringRowView[]; baseCurrency: string };
 
-const PERIOD_SUGGESTIONS = [
-  'Monthly',
-  'Weekly',
-  'Yearly',
-  'Monthly from 2026/01/01',
-];
-
 const emptyPosting = (currency: string): PostingRow => ({
   id: crypto.randomUUID(),
   account: '',
@@ -47,7 +40,11 @@ const RecurringView = ({ rows, baseCurrency }: Props) => {
     FormData
   >(createRecurringAction, null);
 
-  const [period, setPeriod] = useState('Monthly');
+  const [unit, setUnit] = useState<'day' | 'week' | 'month' | 'year'>('month');
+  const [count, setCount] = useState('1');
+  const [anchor, setAnchor] = useState(() =>
+    new Date().toISOString().slice(0, 10)
+  );
   const [note, setNote] = useState('');
   const [postings, setPostings] = useState<PostingRow[]>([
     emptyPosting(baseCurrency),
@@ -76,7 +73,7 @@ const RecurringView = ({ rows, baseCurrency }: Props) => {
     setPostings((ps) => (ps.length > 2 ? ps.filter((_, j) => j !== i) : ps));
 
   const draft = JSON.stringify({
-    period: period.trim(),
+    schedule: { unit, count: Number(count), anchor },
     note: note.trim() || undefined,
     postings: postings
       .filter((p) => p.account.trim())
@@ -94,23 +91,41 @@ const RecurringView = ({ rows, baseCurrency }: Props) => {
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="space-y-1">
-            <Label htmlFor="recurring-period">Repeats</Label>
-            <Input
-              id="recurring-period"
-              list="recurring-period-suggestions"
-              value={period}
-              onChange={(e) => setPeriod(e.target.value)}
-              placeholder="Monthly from 2026/01/01"
-              required
-            />
-            <datalist id="recurring-period-suggestions">
-              {PERIOD_SUGGESTIONS.map((s) => (
-                <option key={s} value={s} />
-              ))}
-            </datalist>
+            <Label htmlFor="recurring-count">Repeats</Label>
+            <div className="flex gap-2">
+              <Input
+                id="recurring-count"
+                type="number"
+                min={1}
+                max={366}
+                value={count}
+                onChange={(e) => setCount(e.target.value)}
+                className="w-20"
+                required
+              />
+              <select
+                id="recurring-unit"
+                value={unit}
+                onChange={(e) =>
+                  setUnit(e.target.value as 'day' | 'week' | 'month' | 'year')
+                }
+                className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+              >
+                <option value="day">Day(s)</option>
+                <option value="week">Week(s)</option>
+                <option value="month">Month(s)</option>
+                <option value="year">Year(s)</option>
+              </select>
+              <Input
+                id="recurring-anchor"
+                type="date"
+                value={anchor}
+                onChange={(e) => setAnchor(e.target.value)}
+                required
+              />
+            </div>
             <p className="text-muted-foreground text-xs">
-              Any ledger period expression works, e.g. “Monthly from
-              2026/01/05”, “Every 2 weeks”, “Yearly”.
+              E.g. every 1 month(s) from the anchor date.
             </p>
           </div>
           <div className="space-y-1">

--- a/features/recurring/actions/createRecurring.ts
+++ b/features/recurring/actions/createRecurring.ts
@@ -29,7 +29,8 @@ export async function createRecurringAction(
   }
 
   const bytesBefore = await getJournalDirSize(user.id);
-  const result = await journalService.addRecurring(user.id, parsed);
+  const today = new Date().toISOString().slice(0, 10);
+  const result = await journalService.addRecurring(user.id, parsed, today);
   const bytesAfter = await getJournalDirSize(user.id);
   await auditService.record(user.id, {
     action: 'recurring.add',

--- a/features/recurring/actions/postOccurrence.ts
+++ b/features/recurring/actions/postOccurrence.ts
@@ -1,0 +1,42 @@
+'use server';
+
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { getJournalDirSize } from '@/lib/journal/quota';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export type OccurrenceActionResult =
+  { ok: true } | { ok: false; message: string };
+
+export async function postOccurrenceAction(
+  uid: string,
+  fingerprint: string,
+  dueDate: string
+): Promise<OccurrenceActionResult> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
+  const bytesBefore = await getJournalDirSize(user.id);
+  const result = await journalService.postRecurringOccurrence(user.id, {
+    uid,
+    expectedFingerprint: fingerprint,
+    dueDate,
+    today: new Date().toISOString().slice(0, 10),
+  });
+  const bytesAfter = await getJournalDirSize(user.id);
+  await auditService.record(user.id, {
+    action: 'recurring.post',
+    result: result.ok ? 'success' : 'failure',
+    targetUid: uid,
+    bytesBefore,
+    bytesAfter,
+    detail: result.ok ? { dueDate } : { reason: result.reason, dueDate },
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) return { ok: false, message: result.message };
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/features/recurring/actions/skipOccurrence.ts
+++ b/features/recurring/actions/skipOccurrence.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import type { OccurrenceActionResult } from './postOccurrence';
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { getJournalDirSize } from '@/lib/journal/quota';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export async function skipOccurrenceAction(
+  uid: string,
+  fingerprint: string,
+  dueDate: string
+): Promise<OccurrenceActionResult> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
+  const bytesBefore = await getJournalDirSize(user.id);
+  const result = await journalService.skipRecurringOccurrence(user.id, {
+    uid,
+    expectedFingerprint: fingerprint,
+    dueDate,
+    today: new Date().toISOString().slice(0, 10),
+  });
+  const bytesAfter = await getJournalDirSize(user.id);
+  await auditService.record(user.id, {
+    action: 'recurring.skip',
+    result: result.ok ? 'success' : 'failure',
+    targetUid: uid,
+    bytesBefore,
+    bytesAfter,
+    detail: result.ok ? { dueDate } : { reason: result.reason, dueDate },
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) return { ok: false, message: result.message };
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/features/recurring/dueList.test.ts
+++ b/features/recurring/dueList.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildDueList } from './dueList';
+import { parseRecurringFile } from '@/lib/journal/recurring';
+
+const rules = parseRecurringFile(
+  'main.ledger',
+  [
+    '~ every 1 months from 2026/01/05',
+    '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DJC',
+    '    ; :handled: 2026-05-05',
+    '    ; Netflix',
+    '    Expenses:Netflix                            USD 15',
+    '    Assets:Checking                             USD -15',
+    '',
+    '~ Monthly',
+    '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DKZ',
+    '    Expenses:Rent                               USD 900',
+    '    Assets:Checking                             USD -900',
+    '',
+  ].join('\n')
+);
+
+describe('buildDueList', () => {
+  it('splits due (with backlog) from upcoming and flags unsupported', () => {
+    const list = buildDueList(rules, '2026-07-16', '2026-08-15');
+    expect(list.due.map((o) => o.date)).toEqual(['2026-06-05', '2026-07-05']);
+    expect(list.due[0].overdue).toBe(true);
+    expect(list.due[0].label).toBe('Netflix');
+    expect(list.upcoming.map((o) => o.date)).toEqual(['2026-08-05']);
+    expect(list.unsupported).toEqual([
+      { ruleUid: '01HZX5G5KJDS9HQRYK8E5T0DKZ', period: 'Monthly' },
+    ]);
+  });
+
+  it('rule without :handled: contributes no backlog', () => {
+    const fresh = parseRecurringFile(
+      'main.ledger',
+      [
+        '~ every 1 months from 2026/01/16',
+        '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DAA',
+        '    Expenses:Gym                             USD 20',
+        '    Assets:Checking                          USD -20',
+        '',
+      ].join('\n')
+    );
+    const list = buildDueList(fresh, '2026-07-16', '2026-08-15');
+    expect(list.due.map((o) => o.date)).toEqual(['2026-07-16']); // today only
+  });
+});

--- a/features/recurring/dueList.ts
+++ b/features/recurring/dueList.ts
@@ -1,0 +1,66 @@
+import type { ParsedRecurring } from '@/lib/journal/recurring';
+import {
+  parseSchedule,
+  expandSchedule,
+  dayBefore,
+} from '@/lib/journal/schedule';
+
+export type RecurringOccurrenceView = {
+  ruleUid: string;
+  fingerprint: string;
+  date: string; // YYYY-MM-DD
+  label: string; // rule note first line, or first posting account
+  postings: { account: string; amount: string; currency: string }[];
+  overdue: boolean;
+};
+
+export type RecurringDueList = {
+  due: RecurringOccurrenceView[]; // date <= today, oldest first
+  upcoming: RecurringOccurrenceView[]; // today < date <= horizon
+  unsupported: { ruleUid: string | undefined; period: string }[];
+};
+
+export const buildDueList = (
+  rules: readonly ParsedRecurring[],
+  today: string,
+  horizon: string
+): RecurringDueList => {
+  const due: RecurringOccurrenceView[] = [];
+  const upcoming: RecurringOccurrenceView[] = [];
+  const unsupported: { ruleUid: string | undefined; period: string }[] = [];
+
+  for (const rule of rules) {
+    const schedule = rule.uid ? parseSchedule(rule.period) : null;
+    if (!rule.uid || !schedule) {
+      unsupported.push({ ruleUid: rule.uid, period: rule.period });
+      continue;
+    }
+
+    const floor = rule.handled ?? dayBefore(today);
+    const label =
+      (rule.note ?? '').split('\n')[0] || rule.postings[0]?.account || '';
+    const postings = rule.postings.map((posting) => ({
+      account: posting.account,
+      amount: posting.amount,
+      currency: posting.currency,
+    }));
+
+    for (const date of expandSchedule(schedule, floor, horizon)) {
+      const occurrence: RecurringOccurrenceView = {
+        ruleUid: rule.uid,
+        fingerprint: rule.fingerprint,
+        date,
+        label,
+        postings,
+        overdue: date < today,
+      };
+      if (date <= today) due.push(occurrence);
+      else upcoming.push(occurrence);
+    }
+  }
+
+  due.sort((a, b) => a.date.localeCompare(b.date));
+  upcoming.sort((a, b) => a.date.localeCompare(b.date));
+
+  return { due, upcoming, unsupported };
+};

--- a/lib/audit/describe.ts
+++ b/lib/audit/describe.ts
@@ -7,6 +7,22 @@ const COPY: Record<string, [string, string]> = {
   'tx.add': ['Added a transaction', 'Failed to add a transaction'],
   'tx.edit': ['Edited a transaction', 'Failed to edit a transaction'],
   'tx.delete': ['Deleted a transaction', 'Failed to delete a transaction'],
+  'recurring.add': [
+    'Added a recurring transaction',
+    'Failed to add a recurring transaction',
+  ],
+  'recurring.delete': [
+    'Deleted a recurring transaction',
+    'Failed to delete a recurring transaction',
+  ],
+  'recurring.post': [
+    'Posted a recurring occurrence',
+    'Failed to post a recurring occurrence',
+  ],
+  'recurring.skip': [
+    'Skipped a recurring occurrence',
+    'Failed to skip a recurring occurrence',
+  ],
   'journal.import': ['Imported journal', 'Import failed'],
   'price.add': ['Recorded a price', 'Failed to record a price'],
   'price.delete': ['Deleted a price', 'Failed to delete a price'],
@@ -22,6 +38,10 @@ const COPY: Record<string, [string, string]> = {
     'Failed to rotate recovery code',
   ],
   'crypto.reset': ['Reset encryption', 'Failed to reset encryption'],
+  'price.map': ['Mapped a commodity', 'Failed to map a commodity'],
+  'commodity.create': ['Created a commodity', 'Failed to create a commodity'],
+  'commodity.update': ['Updated a commodity', 'Failed to update a commodity'],
+  'commodity.delete': ['Deleted a commodity', 'Failed to delete a commodity'],
 };
 
 // More specific copy for a failed import, keyed by the recorded reason code.

--- a/lib/audit/schema.ts
+++ b/lib/audit/schema.ts
@@ -6,6 +6,8 @@ export const AUDIT_ACTIONS = [
   'tx.delete',
   'recurring.add',
   'recurring.delete',
+  'recurring.post',
+  'recurring.skip',
   'journal.import',
   'price.add',
   'price.delete',

--- a/lib/journal/recurring.test.ts
+++ b/lib/journal/recurring.test.ts
@@ -80,3 +80,37 @@ describe('recurringDraftSchema', () => {
     ).toBe(false);
   });
 });
+
+describe(':handled: state line', () => {
+  it('round-trips through format and parse without polluting note', () => {
+    const testDraft = {
+      period: 'every 1 months from 2026/01/05',
+      note: 'Netflix',
+      uid: '01HZX5G5KJDS9HQRYK8E5T0DJC',
+      handled: '2026-07-05',
+      postings: [
+        { account: 'Expenses:Netflix', amount: '15', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    };
+    const block = formatRecurring(testDraft);
+    expect(block).toContain('; :handled: 2026-07-05');
+    const parsed = parseRecurringFile('main.ledger', block + '\n');
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].handled).toBe('2026-07-05');
+    expect(parsed[0].note).toBe('Netflix');
+  });
+
+  it('changes the fingerprint when handled advances', () => {
+    const base = {
+      period: 'every 1 months from 2026/01/05',
+      postings: [
+        { account: 'Expenses:Netflix', amount: '15', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    };
+    expect(fingerprintRecurring({ ...base, handled: '2026-06-05' })).not.toBe(
+      fingerprintRecurring({ ...base, handled: '2026-07-05' })
+    );
+  });
+});

--- a/lib/journal/recurring.ts
+++ b/lib/journal/recurring.ts
@@ -36,10 +36,16 @@ const uidSchema = z
   )
   .optional();
 
+const handledSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'handled must be YYYY-MM-DD')
+  .optional();
+
 export const recurringDraftSchema = z.object({
   period: periodSchema,
   note: noteSchema,
   uid: uidSchema,
+  handled: handledSchema,
   postings: z
     .array(postingSchema)
     .min(2, 'At least 2 postings are required')
@@ -59,19 +65,25 @@ export type ParsedRecurring = RecurringDraft & {
 export const formatRecurring = (draft: RecurringDraft): string => {
   const header = `~ ${draft.period}`;
   const uidLines = draft.uid ? [`    ; :uid: ${draft.uid}`] : [];
+  const handledLines = draft.handled
+    ? [`    ; :handled: ${draft.handled}`]
+    : [];
   const noteLines = (draft.note ?? '')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => `    ; ${line}`);
   const postings = draft.postings.map(formatPosting);
-  return [header, ...uidLines, ...noteLines, ...postings].join('\n');
+  return [header, ...uidLines, ...handledLines, ...noteLines, ...postings].join(
+    '\n'
+  );
 };
 
 export const fingerprintRecurring = (draft: RecurringDraft): string =>
   createHash('sha256').update(formatRecurring(draft)).digest('hex');
 
 const RECURRING_HEADER_REGEX = /^~\s+(\S.*)$/;
+const HANDLED_LINE_REGEX = /^\s*;\s*:handled:\s*(\d{4}-\d{2}-\d{2})\s*$/;
 const COMMENT_LINE_REGEX = /^\s*;\s?(.*)$/;
 
 const parseRecurringBlock = (
@@ -85,6 +97,7 @@ const parseRecurringBlock = (
   if (!header) return null;
 
   let uid: string | undefined;
+  let handled: string | undefined;
   const noteLines: string[] = [];
   const postings: ParsedPosting[] = [];
 
@@ -94,6 +107,11 @@ const parseRecurringBlock = (
     const uidMatch = line.match(UID_LINE_REGEX);
     if (uidMatch) {
       uid = uidMatch[1];
+      continue;
+    }
+    const handledMatch = line.match(HANDLED_LINE_REGEX);
+    if (handledMatch) {
+      handled = handledMatch[1];
       continue;
     }
     const commentMatch = line.match(COMMENT_LINE_REGEX);
@@ -109,6 +127,7 @@ const parseRecurringBlock = (
   return {
     period: header[1].trim(),
     uid,
+    handled,
     note: noteLines.length > 0 ? noteLines.join('\n') : undefined,
     postings,
   };

--- a/lib/journal/recurring.ts
+++ b/lib/journal/recurring.ts
@@ -54,6 +54,21 @@ export const recurringDraftSchema = z.object({
 
 export type RecurringDraft = z.infer<typeof recurringDraftSchema>;
 
+export const recurringScheduleInputSchema = z.object({
+  unit: z.enum(['day', 'week', 'month', 'year']),
+  count: z.number().int().min(1).max(366),
+  anchor: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Anchor must be YYYY-MM-DD')
+    .refine((s) => !Number.isNaN(Date.parse(s)), 'Anchor is not a real date'),
+});
+
+export const recurringCreateSchema = recurringDraftSchema
+  .omit({ period: true, handled: true, uid: true })
+  .extend({ schedule: recurringScheduleInputSchema });
+
+export type RecurringCreateDraft = z.infer<typeof recurringCreateSchema>;
+
 export type ParsedRecurring = RecurringDraft & {
   file: string;
   startLine: number;

--- a/lib/journal/schedule.test.ts
+++ b/lib/journal/schedule.test.ts
@@ -82,6 +82,36 @@ describe('expandSchedule', () => {
       '2026-02-28',
     ]);
   });
+  it('does not drop monthly occurrences for a far-past anchor (regression)', () => {
+    const monthlySince2000 = {
+      unit: 'month' as const,
+      count: 1,
+      anchor: '2000-01-01',
+    };
+    expect(
+      expandSchedule(monthlySince2000, '2026-07-16', '2026-09-30')
+    ).toEqual(['2026-08-01', '2026-09-01']);
+  });
+  it('does not drop clamped monthly occurrences for a far-past anchor (regression)', () => {
+    const monthly31Since2000 = {
+      unit: 'month' as const,
+      count: 1,
+      anchor: '2000-01-31',
+    };
+    expect(
+      expandSchedule(monthly31Since2000, '2026-07-16', '2026-09-30')
+    ).toEqual(['2026-07-31', '2026-08-31', '2026-09-30']);
+  });
+  it('does not drop yearly occurrences for a far-past anchor (regression)', () => {
+    const yearlySince1990 = {
+      unit: 'year' as const,
+      count: 1,
+      anchor: '1990-06-15',
+    };
+    expect(expandSchedule(yearlySince1990, '2026-01-01', '2027-12-31')).toEqual(
+      ['2026-06-15', '2027-06-15']
+    );
+  });
 });
 
 describe('lastOccurrenceBefore', () => {
@@ -89,5 +119,15 @@ describe('lastOccurrenceBefore', () => {
     const fifth = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
     expect(lastOccurrenceBefore(fifth, '2026-07-16')).toBe('2026-07-05');
     expect(lastOccurrenceBefore(fifth, '2026-01-05')).toBeNull();
+  });
+  it('does not drop occurrences for a far-past anchor (regression)', () => {
+    const monthlySince2000 = {
+      unit: 'month' as const,
+      count: 1,
+      anchor: '2000-01-05',
+    };
+    expect(lastOccurrenceBefore(monthlySince2000, '2026-07-16')).toBe(
+      '2026-07-05'
+    );
   });
 });

--- a/lib/journal/schedule.test.ts
+++ b/lib/journal/schedule.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSchedule,
+  serializeSchedule,
+  expandSchedule,
+  lastOccurrenceBefore,
+} from './schedule';
+
+describe('parseSchedule', () => {
+  it('parses every-N form', () => {
+    expect(parseSchedule('every 2 weeks from 2026/05/08')).toEqual({
+      unit: 'week',
+      count: 2,
+      anchor: '2026-05-08',
+    });
+  });
+  it('parses singular and alias forms', () => {
+    expect(parseSchedule('every month from 2026-01-05')).toEqual({
+      unit: 'month',
+      count: 1,
+      anchor: '2026-01-05',
+    });
+    expect(parseSchedule('Monthly from 2026/01/05')).toEqual({
+      unit: 'month',
+      count: 1,
+      anchor: '2026-01-05',
+    });
+  });
+  it('rejects anchor-less and freeform periods', () => {
+    expect(parseSchedule('Monthly')).toBeNull();
+    expect(parseSchedule('every friday')).toBeNull();
+  });
+});
+
+describe('serializeSchedule', () => {
+  it('round-trips through parseSchedule', () => {
+    const schedule = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
+    expect(serializeSchedule(schedule)).toBe('every 1 months from 2026/01/05');
+    expect(parseSchedule(serializeSchedule(schedule))).toEqual(schedule);
+  });
+});
+
+describe('expandSchedule', () => {
+  const monthly = { unit: 'month' as const, count: 1, anchor: '2026-01-31' };
+  it('anchors monthly to day-of-month with short-month clamping', () => {
+    expect(expandSchedule(monthly, '2026-01-31', '2026-04-30')).toEqual([
+      '2026-02-28',
+      '2026-03-31',
+      '2026-04-30',
+    ]);
+  });
+  it('is exclusive of afterExclusive and inclusive of throughInclusive', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
+    expect(expandSchedule(fifth, '2026-02-05', '2026-04-05')).toEqual([
+      '2026-03-05',
+      '2026-04-05',
+    ]);
+  });
+  it('keeps biweekly anchored to the anchor weekday', () => {
+    const biweekly = { unit: 'week' as const, count: 2, anchor: '2026-05-08' };
+    expect(expandSchedule(biweekly, '2026-05-08', '2026-06-20')).toEqual([
+      '2026-05-22',
+      '2026-06-05',
+      '2026-06-19',
+    ]);
+  });
+  it('includes the anchor itself when after the floor', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2026-08-05' };
+    expect(expandSchedule(fifth, '2026-07-16', '2026-09-30')).toEqual([
+      '2026-08-05',
+      '2026-09-05',
+    ]);
+  });
+  it('returns empty when anchor is beyond the window', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2027-01-05' };
+    expect(expandSchedule(fifth, '2026-07-16', '2026-08-16')).toEqual([]);
+  });
+  it('handles yearly Feb 29 clamping', () => {
+    const leap = { unit: 'year' as const, count: 1, anchor: '2024-02-29' };
+    expect(expandSchedule(leap, '2024-02-29', '2026-03-01')).toEqual([
+      '2025-02-28',
+      '2026-02-28',
+    ]);
+  });
+});
+
+describe('lastOccurrenceBefore', () => {
+  it('returns the most recent occurrence strictly before the date', () => {
+    const fifth = { unit: 'month' as const, count: 1, anchor: '2026-01-05' };
+    expect(lastOccurrenceBefore(fifth, '2026-07-16')).toBe('2026-07-05');
+    expect(lastOccurrenceBefore(fifth, '2026-01-05')).toBeNull();
+  });
+});

--- a/lib/journal/schedule.ts
+++ b/lib/journal/schedule.ts
@@ -1,0 +1,114 @@
+export type ScheduleUnit = 'day' | 'week' | 'month' | 'year';
+
+export type Schedule = {
+  unit: ScheduleUnit;
+  count: number;
+  anchor: string; // YYYY-MM-DD
+};
+
+const PERIOD_REGEX =
+  /^(?:every\s+(?:(\d+)\s+)?(day|week|month|year)s?|(daily|weekly|monthly|yearly))\s+from\s+(\d{4})[/-](\d{2})[/-](\d{2})$/i;
+
+const ALIAS_UNITS: Record<string, ScheduleUnit> = {
+  daily: 'day',
+  weekly: 'week',
+  monthly: 'month',
+  yearly: 'year',
+};
+
+export const parseSchedule = (period: string): Schedule | null => {
+  const match = period.trim().match(PERIOD_REGEX);
+  if (!match) return null;
+  const [, countRaw, unitRaw, aliasRaw, year, month, day] = match;
+  const unit = unitRaw
+    ? (unitRaw.toLowerCase() as ScheduleUnit)
+    : ALIAS_UNITS[aliasRaw.toLowerCase()];
+  const count = countRaw ? parseInt(countRaw, 10) : 1;
+  if (count < 1 || count > 366) return null;
+  const anchor = `${year}-${month}-${day}`;
+  if (Number.isNaN(Date.parse(anchor))) return null;
+  return { unit, count, anchor };
+};
+
+export const serializeSchedule = (schedule: Schedule): string =>
+  `every ${schedule.count} ${schedule.unit}s from ${schedule.anchor.replaceAll('-', '/')}`;
+
+// All arithmetic below is calendar-date-only (UTC to avoid DST edges). No
+// monetary values pass through this module.
+const toUtc = (iso: string): Date => new Date(`${iso}T00:00:00Z`);
+const toIso = (date: Date): string => date.toISOString().slice(0, 10);
+
+const daysInMonth = (year: number, monthIndex: number): number =>
+  new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+
+/** k-th occurrence (k >= 0) of the schedule, anchored to the anchor date. */
+const occurrenceAt = (schedule: Schedule, k: number): string => {
+  const anchor = toUtc(schedule.anchor);
+  if (schedule.unit === 'day' || schedule.unit === 'week') {
+    const stepDays = schedule.count * (schedule.unit === 'week' ? 7 : 1);
+    const result = new Date(anchor);
+    result.setUTCDate(result.getUTCDate() + k * stepDays);
+    return toIso(result);
+  }
+  const monthsPerStep =
+    schedule.unit === 'month' ? schedule.count : schedule.count * 12;
+  const totalMonths = anchor.getUTCMonth() + k * monthsPerStep;
+  const year = anchor.getUTCFullYear() + Math.floor(totalMonths / 12);
+  const monthIndex = ((totalMonths % 12) + 12) % 12;
+  const day = Math.min(anchor.getUTCDate(), daysInMonth(year, monthIndex));
+  return toIso(new Date(Date.UTC(year, monthIndex, day)));
+};
+
+/** Smallest k whose occurrence is strictly after `afterExclusive`. */
+const firstIndexAfter = (
+  schedule: Schedule,
+  afterExclusive: string
+): number => {
+  if (schedule.anchor > afterExclusive) return 0;
+  const anchor = toUtc(schedule.anchor);
+  const after = toUtc(afterExclusive);
+  const elapsedDays =
+    (after.getTime() - anchor.getTime()) / (24 * 60 * 60 * 1000);
+  // Estimate then correct: clamping (short months) can only push a date
+  // earlier, so the estimate may be at most a couple of steps off.
+  const approxStepDays =
+    schedule.unit === 'day'
+      ? schedule.count
+      : schedule.unit === 'week'
+        ? schedule.count * 7
+        : schedule.unit === 'month'
+          ? schedule.count * 28
+          : schedule.count * 365;
+  let k = Math.max(0, Math.floor(elapsedDays / approxStepDays) - 2);
+  while (occurrenceAt(schedule, k) <= afterExclusive) k++;
+  return k;
+};
+
+export const expandSchedule = (
+  schedule: Schedule,
+  afterExclusive: string,
+  throughInclusive: string
+): string[] => {
+  const result: string[] = [];
+  let k = firstIndexAfter(schedule, afterExclusive);
+  for (;;) {
+    const occurrence = occurrenceAt(schedule, k);
+    if (occurrence > throughInclusive) return result;
+    result.push(occurrence);
+    k++;
+  }
+};
+
+export const lastOccurrenceBefore = (
+  schedule: Schedule,
+  date: string
+): string | null => {
+  const k = firstIndexAfter(schedule, date) - 1;
+  // firstIndexAfter uses strict >, so back up while the occurrence at k
+  // equals `date` (we need strictly before).
+  for (let i = k; i >= 0; i--) {
+    const occurrence = occurrenceAt(schedule, i);
+    if (occurrence < date) return occurrence;
+  }
+  return null;
+};

--- a/lib/journal/schedule.ts
+++ b/lib/journal/schedule.ts
@@ -69,16 +69,19 @@ const firstIndexAfter = (
   const after = toUtc(afterExclusive);
   const elapsedDays =
     (after.getTime() - anchor.getTime()) / (24 * 60 * 60 * 1000);
-  // Estimate then correct: clamping (short months) can only push a date
-  // earlier, so the estimate may be at most a couple of steps off.
+  // Estimate then correct: divide by the MAXIMUM possible step length (31
+  // days/month, 366 days/year) so elapsedDays / approxStepDays can only
+  // UNDER-estimate k, never over. The forward-only correction loop below
+  // then walks up to the exact index; an over-estimate would never be
+  // corrected back down.
   const approxStepDays =
     schedule.unit === 'day'
       ? schedule.count
       : schedule.unit === 'week'
         ? schedule.count * 7
         : schedule.unit === 'month'
-          ? schedule.count * 28
-          : schedule.count * 365;
+          ? schedule.count * 31
+          : schedule.count * 366;
   let k = Math.max(0, Math.floor(elapsedDays / approxStepDays) - 2);
   while (occurrenceAt(schedule, k) <= afterExclusive) k++;
   return k;

--- a/lib/journal/schedule.ts
+++ b/lib/journal/schedule.ts
@@ -102,6 +102,13 @@ export const expandSchedule = (
   }
 };
 
+/** ISO date minus one calendar day, computed in UTC. */
+export const dayBefore = (iso: string): string => {
+  const date = toUtc(iso);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return toIso(date);
+};
+
 export const lastOccurrenceBefore = (
   schedule: Schedule,
   date: string

--- a/lib/journal/service.recurring-occurrence.test.ts
+++ b/lib/journal/service.recurring-occurrence.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getJournalDir } from './layout';
 import { JournalRepository } from './repository';
 import { JournalService } from './service';
-import { resetObjectStore } from '@/lib/storage';
+import { push, resetObjectStore } from '@/lib/storage';
 import {
   setupTestDb,
   teardownTestDb,
@@ -78,5 +78,118 @@ describe('JournalService.addRecurring (structured schedule)', () => {
       '2026-07-16'
     );
     expect(result.ok).toBe(false);
+  });
+});
+
+describe('JournalService.postRecurringOccurrence / skipRecurringOccurrence', () => {
+  let ctx: TestDbContext;
+  let service: JournalService;
+
+  beforeEach(async () => {
+    resetObjectStore();
+    ctx = await setupTestDb('journal-recurring-occurrence-');
+    await ctx.insertUser('test-user', 'Test', 'test@example.com');
+    service = new JournalService(new JournalRepository(ctx.db));
+    await fs.mkdir(getJournalDir('test-user'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    resetObjectStore();
+  });
+
+  const seedRule = async (userId: string, handled?: string) => {
+    const block = [
+      '~ every 1 months from 2026/01/05',
+      '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DJC',
+      ...(handled ? [`    ; :handled: ${handled}`] : []),
+      '    ; Netflix',
+      '    Expenses:Netflix                            USD 15',
+      '    Assets:Checking                             USD -15',
+      '',
+    ].join('\n');
+    await fs.writeFile(path.join(getJournalDir(userId), 'main.ledger'), block);
+    await push(userId);
+    const rules = await service.listRecurring(userId);
+    return rules[0];
+  };
+
+  describe('postRecurringOccurrence', () => {
+    it('writes the transaction, tags provenance, and advances :handled:', async () => {
+      const rule = await seedRule('test-user', '2026-06-05');
+      const result = await service.postRecurringOccurrence('test-user', {
+        uid: rule.uid!,
+        expectedFingerprint: rule.fingerprint,
+        dueDate: '2026-07-05',
+        today: '2026-07-16',
+      });
+      expect(result.ok).toBe(true);
+      const text = await fs.readFile(
+        path.join(getJournalDir('test-user'), 'main.ledger'),
+        'utf-8'
+      );
+      expect(text).toContain('2026-07-05 Netflix');
+      expect(text).toContain('; :recurring: 01HZX5G5KJDS9HQRYK8E5T0DJC');
+      expect(text).toContain('; :handled: 2026-07-05');
+      expect(text).not.toContain('; :handled: 2026-06-05');
+    });
+
+    it('rejects a replay: the first post changed the fingerprint', async () => {
+      const rule = await seedRule('test-user', '2026-06-05');
+      const input = {
+        uid: rule.uid!,
+        expectedFingerprint: rule.fingerprint,
+        dueDate: '2026-07-05',
+        today: '2026-07-16',
+      };
+      expect(
+        (await service.postRecurringOccurrence('test-user', input)).ok
+      ).toBe(true);
+      const replay = await service.postRecurringOccurrence('test-user', input);
+      expect(replay.ok).toBe(false);
+      if (!replay.ok) expect(replay.reason).toBe('stale');
+    });
+
+    it('rejects posting a non-oldest occurrence', async () => {
+      const rule = await seedRule('test-user', '2026-05-05');
+      const result = await service.postRecurringOccurrence('test-user', {
+        uid: rule.uid!,
+        expectedFingerprint: rule.fingerprint,
+        dueDate: '2026-07-05', // 2026-06-05 is still unhandled
+        today: '2026-07-16',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('invalid');
+    });
+
+    it('rule without :handled: has no backlog: only a today-dated occurrence is due', async () => {
+      const rule = await seedRule('test-user'); // no handled line
+      const result = await service.postRecurringOccurrence('test-user', {
+        uid: rule.uid!,
+        expectedFingerprint: rule.fingerprint,
+        dueDate: '2026-07-05',
+        today: '2026-07-16',
+      });
+      expect(result.ok).toBe(false); // oldest unhandled is 2026-08-05 (> today) — nothing due
+    });
+  });
+
+  describe('skipRecurringOccurrence', () => {
+    it('advances :handled: without writing a transaction', async () => {
+      const rule = await seedRule('test-user', '2026-06-05');
+      const result = await service.skipRecurringOccurrence('test-user', {
+        uid: rule.uid!,
+        expectedFingerprint: rule.fingerprint,
+        dueDate: '2026-07-05',
+        today: '2026-07-16',
+      });
+      expect(result.ok).toBe(true);
+      const text = await fs.readFile(
+        path.join(getJournalDir('test-user'), 'main.ledger'),
+        'utf-8'
+      );
+      expect(text).toContain('; :handled: 2026-07-05');
+      expect(text).not.toContain('2026-07-05 Netflix');
+    });
   });
 });

--- a/lib/journal/service.recurring-occurrence.test.ts
+++ b/lib/journal/service.recurring-occurrence.test.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+import { JournalService } from './service';
+import { resetObjectStore } from '@/lib/storage';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('JournalService.addRecurring (structured schedule)', () => {
+  let ctx: TestDbContext;
+  let service: JournalService;
+
+  beforeEach(async () => {
+    resetObjectStore();
+    ctx = await setupTestDb('journal-recurring-');
+    await ctx.insertUser('test-user', 'Test', 'test@example.com');
+    service = new JournalService(new JournalRepository(ctx.db));
+    await fs.mkdir(getJournalDir('test-user'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    resetObjectStore();
+  });
+
+  it('serializes the schedule and initializes :handled: to the last occurrence before today', async () => {
+    const result = await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-01-05' },
+        note: 'Netflix',
+        postings: [
+          { account: 'Expenses:Netflix', amount: '15', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-16'
+    );
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('~ every 1 months from 2026/01/05');
+    expect(text).toContain('; :handled: 2026-07-05');
+  });
+
+  it('omits :handled: for a future anchor (no backlog either way)', async () => {
+    const result = await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-09-05' },
+        postings: [
+          { account: 'Expenses:Rent', amount: '900', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-16'
+    );
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('~ every 1 months from 2026/09/05');
+    expect(text).not.toContain(':handled:');
+  });
+
+  it('rejects a draft without a schedule', async () => {
+    const result = await service.addRecurring(
+      'test-user',
+      { period: 'Monthly', postings: [] },
+      '2026-07-16'
+    );
+    expect(result.ok).toBe(false);
+  });
+});

--- a/lib/journal/service.recurring-occurrence.test.ts
+++ b/lib/journal/service.recurring-occurrence.test.ts
@@ -191,5 +191,58 @@ describe('JournalService.postRecurringOccurrence / skipRecurringOccurrence', () 
       expect(text).toContain('; :handled: 2026-07-05');
       expect(text).not.toContain('2026-07-05 Netflix');
     });
+
+    it('posting a rule defined in an included file leaves the include untouched', async () => {
+      const journalDir = getJournalDir('test-user');
+      const includeLine = 'include recurring.ledger';
+      await fs.writeFile(
+        path.join(journalDir, 'main.ledger'),
+        [
+          includeLine,
+          '',
+          '2026/07/01 Opening Balance',
+          '    Assets:Checking                             USD 100',
+          '    Equity:Opening Balances                    USD -100',
+          '',
+        ].join('\n')
+      );
+      await fs.writeFile(
+        path.join(journalDir, 'recurring.ledger'),
+        [
+          '~ every 1 months from 2026/01/05',
+          '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DJD',
+          '    ; :handled: 2026-06-05',
+          '    ; Netflix',
+          '    Expenses:Netflix                            USD 15',
+          '    Assets:Checking                             USD -15',
+          '',
+        ].join('\n')
+      );
+      await push('test-user');
+      const rules = await service.listRecurring('test-user');
+      const rule = rules.find((r) => r.uid === '01HZX5G5KJDS9HQRYK8E5T0DJD')!;
+
+      const result = await service.postRecurringOccurrence('test-user', {
+        uid: rule.uid!,
+        expectedFingerprint: rule.fingerprint,
+        dueDate: '2026-07-05',
+        today: '2026-07-16',
+      });
+      expect(result.ok).toBe(true);
+
+      const mainText = await fs.readFile(
+        path.join(journalDir, 'main.ledger'),
+        'utf-8'
+      );
+      const recurringText = await fs.readFile(
+        path.join(journalDir, 'recurring.ledger'),
+        'utf-8'
+      );
+      expect(mainText).toContain('2026-07-05 Netflix');
+      expect(mainText.trim().startsWith(includeLine)).toBe(true);
+      expect(mainText).not.toContain(':handled:');
+      expect(recurringText).toContain('; :handled: 2026-07-05');
+      expect(recurringText).not.toContain('; :handled: 2026-06-05');
+    });
   });
 });

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -21,7 +21,13 @@ import {
   type RecurringDraft,
 } from './recurring';
 import { JournalRepository } from './repository';
-import { lastOccurrenceBefore, serializeSchedule } from './schedule';
+import {
+  dayBefore,
+  expandSchedule,
+  lastOccurrenceBefore,
+  parseSchedule,
+  serializeSchedule,
+} from './schedule';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
 import { encryptFile, isCiphertext } from '@/lib/crypto/fileCrypto';
@@ -71,6 +77,13 @@ export type WriteResult =
       message: string;
       fieldErrors?: Record<string, string>;
     };
+
+export type RecurringOccurrenceInput = {
+  uid: string;
+  expectedFingerprint: string;
+  dueDate: string;
+  today: string;
+};
 
 export type BackfillFileResult = {
   uidsAdded: number;
@@ -382,6 +395,171 @@ export class JournalService {
         await push(userId);
       } catch (e) {
         await this.repo.writeFileAtomic(current.file, text);
+        return {
+          ok: false,
+          reason: 'stale',
+          message:
+            e instanceof StorageConflictError
+              ? e.message
+              : 'Failed to save journal to storage.',
+        };
+      }
+      invalidateCache(userId);
+      return { ok: true };
+    });
+  }
+
+  async postRecurringOccurrence(
+    userId: string,
+    input: RecurringOccurrenceInput
+  ): Promise<WriteResult> {
+    return this.handleRecurringOccurrence(userId, input, 'post');
+  }
+
+  async skipRecurringOccurrence(
+    userId: string,
+    input: RecurringOccurrenceInput
+  ): Promise<WriteResult> {
+    return this.handleRecurringOccurrence(userId, input, 'skip');
+  }
+
+  private async handleRecurringOccurrence(
+    userId: string,
+    input: RecurringOccurrenceInput,
+    mode: 'post' | 'skip'
+  ): Promise<WriteResult> {
+    return withUserLock(userId, async () => {
+      await pull(userId);
+      const { mainPath } = await this.repo.getLayout(userId);
+      const files = await resolveIncludes(mainPath);
+
+      let rule: ParsedRecurring | null = null;
+      let ruleFileText = '';
+      for (const file of files) {
+        const fileText = await this.repo.readFile(file);
+        const match = parseRecurringFile(file, fileText).find(
+          (r) => r.uid === input.uid
+        );
+        if (match) {
+          rule = match;
+          ruleFileText = fileText;
+          break;
+        }
+      }
+      if (!rule) {
+        return {
+          ok: false,
+          reason: 'not-found',
+          message: 'Recurring entry not found.',
+        };
+      }
+      if (rule.fingerprint !== input.expectedFingerprint) {
+        return {
+          ok: false,
+          reason: 'stale',
+          message: 'This recurring entry was modified somewhere else.',
+        };
+      }
+
+      const schedule = parseSchedule(rule.period);
+      if (!schedule) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'This rule has an unsupported schedule.',
+        };
+      }
+
+      const floor = rule.handled ?? dayBefore(input.today);
+      const oldestDue = expandSchedule(schedule, floor, input.today)[0];
+      if (oldestDue === undefined || oldestDue !== input.dueDate) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'This occurrence is not the oldest unhandled one.',
+        };
+      }
+
+      const snapshots = new Map<string, string>();
+      snapshots.set(rule.file, ruleFileText);
+
+      if (mode === 'post') {
+        const transactionDraft: TransactionDraft = {
+          date: input.dueDate,
+          payee: (rule.note ?? '').split('\n')[0] || 'Recurring',
+          status: 'none',
+          note: `:recurring: ${rule.uid}`,
+          uid: generateUid(),
+          postings: rule.postings,
+        };
+        if (!snapshots.has(mainPath)) {
+          snapshots.set(mainPath, await this.repo.readFile(mainPath));
+        }
+        const block = `\n\n${formatTransaction(transactionDraft)}\n`;
+        const projected =
+          (await getJournalDirSize(userId)) + Buffer.byteLength(block);
+        if (projected > journalQuotaBytes()) {
+          return {
+            ok: false,
+            reason: 'invalid',
+            message: `This entry would exceed your ${journalQuotaMb()} MB journal limit.`,
+          };
+        }
+        await this.repo.appendFile(mainPath, block);
+      }
+
+      // Re-read the rule's file: if it's the same file the transaction was
+      // just appended to, its content (and therefore the rule's line
+      // numbers) has changed since `rule` was parsed.
+      const currentRuleFileText = await this.repo.readFile(rule.file);
+      const currentRule = parseRecurringFile(
+        rule.file,
+        currentRuleFileText
+      ).find((r) => r.uid === input.uid);
+      if (!currentRule) {
+        for (const [file, snapshot] of snapshots) {
+          await this.repo.writeFileAtomic(file, snapshot);
+        }
+        return {
+          ok: false,
+          reason: 'not-found',
+          message: 'Recurring entry not found.',
+        };
+      }
+
+      const ruleDraft: RecurringDraft = {
+        period: rule.period,
+        note: rule.note,
+        uid: rule.uid,
+        handled: input.dueDate,
+        postings: rule.postings,
+      };
+      const lines = currentRuleFileText.split('\n');
+      const before = lines.slice(0, currentRule.startLine - 1).join('\n');
+      const after = lines.slice(currentRule.endLine).join('\n');
+      const next =
+        (before ? before + '\n' : '') +
+        formatRecurring(ruleDraft) +
+        (after ? '\n' + after : '');
+      await this.repo.writeFileAtomic(rule.file, next);
+
+      const verify = await verifyJournalParseable(mainPath);
+      if (!verify.ok) {
+        for (const [file, snapshot] of snapshots) {
+          await this.repo.writeFileAtomic(file, snapshot);
+        }
+        return {
+          ok: false,
+          reason: 'parse-failed',
+          message: `Ledger rejected the change: ${verify.message}`,
+        };
+      }
+      try {
+        await push(userId);
+      } catch (e) {
+        for (const [file, snapshot] of snapshots) {
+          await this.repo.writeFileAtomic(file, snapshot);
+        }
         return {
           ok: false,
           reason: 'stale',

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -16,11 +16,12 @@ import { getJournalDirSize, journalQuotaBytes, journalQuotaMb } from './quota';
 import {
   formatRecurring,
   parseRecurringFile,
-  recurringDraftSchema,
+  recurringCreateSchema,
   type ParsedRecurring,
   type RecurringDraft,
 } from './recurring';
 import { JournalRepository } from './repository';
+import { lastOccurrenceBefore, serializeSchedule } from './schedule';
 import { detectFirstPostingIndent, findUidInBlock, generateUid } from './uid';
 import { verifyJournalParseable } from './verify';
 import { encryptFile, isCiphertext } from '@/lib/crypto/fileCrypto';
@@ -244,9 +245,10 @@ export class JournalService {
 
   async addRecurring(
     userId: string,
-    rawDraft: unknown
+    rawDraft: unknown,
+    today: string
   ): Promise<AddTransactionResult> {
-    const parsed = recurringDraftSchema.safeParse(rawDraft);
+    const parsed = recurringCreateSchema.safeParse(rawDraft);
     if (!parsed.success) {
       const fieldErrors: Record<string, string> = {};
       for (const issue of parsed.error.issues) {
@@ -258,7 +260,13 @@ export class JournalService {
 
     return withUserLock(userId, async () => {
       const uid = generateUid();
-      const draft: RecurringDraft = { ...parsed.data, uid };
+      const { schedule, ...rest } = parsed.data;
+      const draft: RecurringDraft = {
+        ...rest,
+        period: serializeSchedule(schedule),
+        handled: lastOccurrenceBefore(schedule, today) ?? undefined,
+        uid,
+      };
       await pull(userId);
       const { mainPath } = await this.repo.ensureLayout(userId);
       const snapshot = await this.repo.readFile(mainPath);

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -73,7 +73,8 @@ export type WriteResult =
   | { ok: true }
   | {
       ok: false;
-      reason: 'not-found' | 'stale' | 'invalid' | 'parse-failed';
+      reason:
+        'not-found' | 'stale' | 'invalid' | 'parse-failed' | 'write-failed';
       message: string;
       fieldErrors?: Record<string, string>;
     };
@@ -505,27 +506,26 @@ export class JournalService {
             message: `This entry would exceed your ${journalQuotaMb()} MB journal limit.`,
           };
         }
-        await this.repo.appendFile(mainPath, block);
+        try {
+          await this.repo.appendFile(mainPath, block);
+        } catch (e) {
+          for (const [file, snapshot] of snapshots) {
+            await this.repo.writeFileAtomic(file, snapshot);
+          }
+          return {
+            ok: false,
+            reason: 'write-failed',
+            message: e instanceof Error ? e.message : 'Failed to write journal',
+          };
+        }
       }
 
-      // Re-read the rule's file: if it's the same file the transaction was
-      // just appended to, its content (and therefore the rule's line
-      // numbers) has changed since `rule` was parsed.
+      // Re-read the rule's file: appendFile only adds bytes at the very end
+      // of mainPath, so it can't shift any earlier line's position. When
+      // rule.file === mainPath the already-parsed startLine/endLine are still
+      // correct offsets into this text -- we only need the fresh content
+      // (which now includes the appended transaction), not a re-parse.
       const currentRuleFileText = await this.repo.readFile(rule.file);
-      const currentRule = parseRecurringFile(
-        rule.file,
-        currentRuleFileText
-      ).find((r) => r.uid === input.uid);
-      if (!currentRule) {
-        for (const [file, snapshot] of snapshots) {
-          await this.repo.writeFileAtomic(file, snapshot);
-        }
-        return {
-          ok: false,
-          reason: 'not-found',
-          message: 'Recurring entry not found.',
-        };
-      }
 
       const ruleDraft: RecurringDraft = {
         period: rule.period,
@@ -535,13 +535,24 @@ export class JournalService {
         postings: rule.postings,
       };
       const lines = currentRuleFileText.split('\n');
-      const before = lines.slice(0, currentRule.startLine - 1).join('\n');
-      const after = lines.slice(currentRule.endLine).join('\n');
+      const before = lines.slice(0, rule.startLine - 1).join('\n');
+      const after = lines.slice(rule.endLine).join('\n');
       const next =
         (before ? before + '\n' : '') +
         formatRecurring(ruleDraft) +
         (after ? '\n' + after : '');
-      await this.repo.writeFileAtomic(rule.file, next);
+      try {
+        await this.repo.writeFileAtomic(rule.file, next);
+      } catch (e) {
+        for (const [file, snapshot] of snapshots) {
+          await this.repo.writeFileAtomic(file, snapshot);
+        }
+        return {
+          ok: false,
+          reason: 'write-failed',
+          message: e instanceof Error ? e.message : 'Failed to write journal',
+        };
+      }
 
       const verify = await verifyJournalParseable(mainPath);
       if (!verify.ok) {


### PR DESCRIPTION
## Summary

Recurring transactions move from forecast-only display to a confirm-to-post model (the pattern GnuCash / Actual Budget / YNAB converge on):

- **Rules** stay ledger `~` periodic directives. The period expression is now a structured, immutable schedule anchor (`every N days|weeks|months|years from DATE`), created via a structured form on /recurring (count / unit / anchor date) instead of freeform text.
- **Occurrence state lives in the journal**: a `; :handled: YYYY-MM-DD` comment on the rule records the last handled occurrence. No database state; journals stay fully parseable by plain ledger (verified against 3.4.1).
- **Dashboard due queue**: the upcoming-bills widget now lists due/overdue occurrences with **Post** (writes a real transaction dated on the due date, tagged `; :recurring: <rule-uid>`, and advances `:handled:`) and **Skip** (advances only). Missed occurrences accumulate until handled — nothing auto-posts. Future occurrences remain a read-only preview; /recurring gains a next-due column.
- **Why occurrence dates are computed in JS** (`lib/journal/schedule.ts`, dates only — amounts pass through verbatim per the repo HARD RULE): ledger 3.4.1 `--forecast` ignores date anchors entirely (monthly fires the 1st, biweekly-from-Friday fires Sundays) and never emits pre-now occurrences. Findings documented in LEDGER-AUDIT.md by this branch.

## Safety

- Post/Skip run under the user lock with snapshot → mutate → `ledger stats` verify → push, rolling back **all** touched files on any failure (including mid-sequence write errors).
- Replay-safe twice over: the rule fingerprint covers `:handled:` (a successful action invalidates stale buttons), and the server independently rejects any occurrence that isn't the rule's oldest unhandled one.
- New rules initialize `:handled:` to the last occurrence before today — no phantom backlog; existing `:handled:`-less rules likewise show no backlog. Freeform legacy periods render as "unsupported schedule" (still deletable, still forecast by plain ledger).

## Test plan

- 1151 tests / 198 files green; tsc, lint, `pnpm build` clean.
- New coverage: schedule parse/serialize/expand (incl. far-anchor and short-month/Feb-29 clamping regressions), `:handled:` round-trip + fingerprint participation, post/skip service paths (stale fingerprint, non-oldest rejection, rollback on parse/push/write failure, rule-in-included-file), due-list bucketing, audit labels.
- Plain-ledger portability check: `ledger stats`/`bal` parse a journal containing the new rule + tag shapes cleanly.
- [ ] Manual walk (needs authenticated session): create rule → due row on dashboard → Post lands in /transactions with `:recurring:` tag → Skip advances → queue clears on refresh.