### PR TITLE
feat(budgets): allowance-style budgets computed by ledger

### DIFF
--- a/LEDGER-AUDIT.md
+++ b/LEDGER-AUDIT.md
@@ -203,3 +203,52 @@ ledger 3.4.1-20251025 on synthetic `~` periodic-transaction journals.
    confirm-to-post state are plain ledger comments — `ledger` ignores them
    entirely (confirmed via `stats`/`bal` on a journal containing both), so
    journals stay portable to any other ledger-reading tool.
+
+---
+
+## Budget report `--format` and running-total gotchas — 2026-07-17
+
+Verified while finishing the budgets feature (Task 8) against a synthetic
+journal with a `:budget:`-tagged periodic transaction (`~ every 1 months from
+2026/07/01`), a recurring bill rule also tagged `:budget:` and carrying a
+`; :handled:` marker, and three real July transactions on
+`Expenses:Groceries` / `Expenses:Rent`.
+
+1. **`budget`'s `--format` needs `get_at(display_total, 0|1)`, and element 1
+   is the *negated* allowance.** `ledger budget ^Expenses --flat --format
+   '%A|%(get_at(display_total, 0))|%(get_at(display_total, 1))\n'` returns
+   the actual in slot 0 and the allowance as a negative amount in slot 1 (a
+   `$ 400.00` budget line renders as `$ -400.00` in slot 1) — `report.ts`'s
+   `BUDGET_ROW_FORMAT` negates it back with `0 - get_at(display_total, 1)`
+   before treating it as a positive allowance.
+2. **`neg()` is not a valid identifier in this format context.** Swapping the
+   working `0 - get_at(display_total, 1)` for `neg(get_at(display_total, 1))`
+   fails outright:
+   ```
+   Error: Unknown identifier 'neg'
+   ```
+   confirmed on the synthetic journal above — `0 - …` is the only form that
+   works inside a `--format` value expression here.
+3. **`reg --budget`'s `%T` running total is global across the whole register,
+   not per account.** On the synthetic journal, `ledger reg ^Expenses
+   --budget -p 'jul 2026' --format '%A|%T\n'` interleaves `Expenses:Groceries`
+   and `Expenses:Rent` postings and accumulates one running total across both
+   accounts (`-$400 → -$1,600 → -$1,450 → -$250 → -$130`), never resetting
+   per account. This is why the year-to-date column in `getBudgetReport`
+   re-runs the `budget` command over the Jan-1-to-month-end span instead of
+   trying to read a cumulative total off `reg --budget` — `budget` totals
+   each account independently over the requested period.
+4. **Recurring bill rules count as budget allowances by design.** The
+   synthetic journal's `Expenses:Rent` bill (`~ ... ; :budget: ... ;
+   :handled: 2026-07-01`) showed up in the `budget` report's allowance column
+   exactly like the plain `:budget:`-tagged Groceries line — both rows
+   appeared in the same `budget ^Expenses -p 'jul 2026' --flat --format
+   BUDGET_ROW_FORMAT` output:
+   ```
+   Expenses:Groceries|$ 270.00|$ 400.00|$ -130.00|270|400
+   Expenses:Rent|$ 1,200.00|$ 1,200.00|0|1200|1200
+   ```
+   This is the "bills are budget lines" decision (spec 2026-07-17): any `~`
+   rule tagged `:budget:` — whether an explicit budget line or a recurring
+   bill — is an allowance ledger's `budget` command will honor, with no
+   special-casing needed in `report.ts` to distinguish the two.

--- a/app/budgets/page.tsx
+++ b/app/budgets/page.tsx
@@ -34,9 +34,11 @@ const BudgetsPage = async () => {
       <BudgetsView
         baseCurrency={baseCurrency}
         report={report}
-        lines={lines.map(({ uid, fingerprint, postings }) => ({
+        lines={lines.map(({ uid, fingerprint, period, note, postings }) => ({
           uid,
           fingerprint,
+          period,
+          note,
           postings: postings.map(({ account, amount, currency }) => ({
             account,
             amount,

--- a/app/budgets/page.tsx
+++ b/app/budgets/page.tsx
@@ -1,0 +1,51 @@
+import Help from '@/components/Help';
+import PageContainer from '@/components/PageContainer';
+import BudgetsView from '@/features/budgets/BudgetsView';
+import { getBudgetReport } from '@/features/budgets/report';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { getBaseCurrency } from '@/lib/settings';
+
+const BudgetsPage = async () => {
+  const user = await requireUser();
+  const baseCurrency = await getBaseCurrency();
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const [lines, report] = await Promise.all([
+    journalService.listBudgets(user.id),
+    getBudgetReport(baseCurrency, todayIso),
+  ]);
+
+  return (
+    <PageContainer>
+      <div>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Budgets</h1>
+          <Help label="About budgets">
+            Allowances compared against actual spending by ledger; your
+            recurring bills count toward their account&apos;s allowance
+            automatically.
+          </Help>
+        </div>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Set an allowance per account and see how this month and year to date
+          stack up.
+        </p>
+      </div>
+      <BudgetsView
+        baseCurrency={baseCurrency}
+        report={report}
+        lines={lines.map(({ uid, fingerprint, postings }) => ({
+          uid,
+          fingerprint,
+          postings: postings.map(({ account, amount, currency }) => ({
+            account,
+            amount,
+            currency,
+          })),
+        }))}
+      />
+    </PageContainer>
+  );
+};
+
+export default BudgetsPage;

--- a/app/recurring/page.tsx
+++ b/app/recurring/page.tsx
@@ -53,19 +53,21 @@ const RecurringPage = async () => {
       </div>
       <RecurringView
         baseCurrency={baseCurrency}
-        rows={recurring.map(({ uid, period, note, fingerprint, postings }) => ({
-          uid,
-          period,
-          note,
-          fingerprint,
-          postings: postings.map(({ account, amount, currency }) => ({
-            account,
-            amount,
-            currency,
-          })),
-          nextDue: uid ? nextDueByUid.get(uid) : undefined,
-          unsupported: !uid || unsupportedUids.has(uid),
-        }))}
+        rows={recurring
+          .filter((rule) => !rule.budget)
+          .map(({ uid, period, note, fingerprint, postings }) => ({
+            uid,
+            period,
+            note,
+            fingerprint,
+            postings: postings.map(({ account, amount, currency }) => ({
+              account,
+              amount,
+              currency,
+            })),
+            nextDue: uid ? nextDueByUid.get(uid) : undefined,
+            unsupported: !uid || unsupportedUids.has(uid),
+          }))}
       />
     </PageContainer>
   );

--- a/components/nav/config.ts
+++ b/components/nav/config.ts
@@ -12,6 +12,7 @@ import {
   GitCompareArrows,
   ListChecks,
   PiggyBank,
+  Wallet,
   PlusCircle,
   Repeat,
   Settings,
@@ -172,6 +173,15 @@ export const getNavSections = (): NavSection[] => {
           description: 'Bills and subscriptions that repeat on a schedule.',
           icon: Repeat,
           keywords: ['bills', 'subscriptions', 'periodic', 'schedule'],
+        },
+        {
+          id: 'budgets',
+          title: 'Budgets',
+          href: '/budgets',
+          match: 'exact',
+          description: 'Allowances compared against actual spending.',
+          icon: Wallet,
+          keywords: ['allowance', 'spending', 'limit'],
         },
         {
           id: 'templates',

--- a/docs/superpowers/plans/2026-07-17-budgets.md
+++ b/docs/superpowers/plans/2026-07-17-budgets.md
@@ -1,0 +1,488 @@
+# Budgets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allowance-style budgets: `:budget:`-tagged `~` directives in the journal, a /budgets page with a ledger-computed budget-vs-actual table (this month + YTD cumulative + unbudgeted), and a compact dashboard widget.
+
+**Architecture:** Budget lines reuse the recurring machinery (structured schedule, uid, fingerprint, verify/rollback write path) plus a `budget` flag parsed from a `; :budget:` comment. All money math is ledger's: the `budget` report with a `get_at(display_total, …)` format string emits account|actual|budget|diff (diff computed by ledger via `0 - x` / `+` value expressions — `neg()` fails in this context, verified 3.4.1), `bal --unbudgeted` catches unbudgeted spend, and the YTD cumulative column is the same `budget` report over a Jan-1-to-next-month span. JS parses pipe rows and renders. Spec: `docs/superpowers/specs/2026-07-17-budgets-design.md`.
+
+**Tech Stack:** Next.js server actions/components, zod, vitest (`pnpm vitest run <file>`), `runLedger` (request-scoped) for reports, `JournalService` for writes.
+
+## Global Constraints
+
+- HARD RULE: no accounting math in JS/TS. Every displayed amount is a string ledger rendered; the only JS number use is progress-bar width ratio from ledger-emitted `quantity()` fields (display geometry only). Never regex-decompose a rendered amount — use `quantity()`/`commodity()` value expressions.
+- No identifier abbreviations. No Claude/Anthropic references anywhere; no Co-Authored-By trailers.
+- Server actions one file each; Repository/Service classes; UI in features/, thin app/ pages.
+- Journal writes: snapshot → mutate → `verifyJournalParseable` → rollback → push → rollback → `invalidateCache`, under `withUserLock`.
+- Verified ledger 3.4.1 facts this plan relies on (pin them as tests, do not re-derive):
+  - `budget --flat --format '%A|%(get_at(display_total, 0))|%(0 - get_at(display_total, 1))|%(get_at(display_total, 0) + get_at(display_total, 1))\n'` emits `Expenses:Rent|$ 1,850.00|$ 2,000.00|$ -150.00`; a trailing grand-total row has empty `%A` (filter it). `display_total` element 0 = actual, element 1 = negated budget. `neg()` throws here; use `0 - …`.
+  - Recurring bill `~` rules count as budget allowances automatically (wanted; spec decision).
+  - `bal --unbudgeted` isolates spending on accounts with no allowance.
+  - Budget periods bucket on calendar boundaries; anchors are not honored for non-monthly schedules (accepted; document).
+- Commit after every green test cycle.
+
+## File Structure
+
+- Modify: `lib/journal/recurring.ts` (+test) — `budget` flag round-trip
+- Modify: `features/recurring/dueList.ts` (+test), `lib/journal/service.ts` (+test) — budget rules excluded from due queue and post/skip
+- Modify: `lib/journal/service.ts` (+test in `lib/journal/service.recurring-occurrence.test.ts` sibling file `lib/journal/service.budget.test.ts`) — `addBudget`, `listBudgets`
+- Create: `features/budgets/report.ts` + `features/budgets/report.test.ts` — query builders + row parsers
+- Modify: `lib/audit/schema.ts`, `lib/audit/describe.ts` (+test); Create: `features/budgets/actions/createBudget.ts`, `features/budgets/actions/deleteBudget.ts`
+- Create: `features/budgets/BudgetsView.tsx`, `app/budgets/page.tsx`
+- Modify: `lib/dashboard/widgets.ts`, `features/dashboard/Dashboard.tsx`; Create: `features/budgets/BudgetsWidget.tsx`
+- Modify: `LEDGER-AUDIT.md`
+
+---
+
+### Task 1: `budget` flag on the recurring parser/formatter
+
+**Files:**
+- Modify: `lib/journal/recurring.ts`
+- Test: `lib/journal/recurring.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing `recurringDraftSchema`, `formatRecurring`, `parseRecurringBlock` (which already handle `:uid:` and `:handled:` special comment lines).
+- Produces: `recurringDraftSchema` gains `budget: z.boolean().optional()`; `RecurringDraft`/`ParsedRecurring` carry `budget?: boolean`. `formatRecurring` emits `    ; :budget:` between the uid line and the `:handled:` line when set. `parseRecurringBlock` recognizes `BUDGET_LINE_REGEX = /^\s*;\s*:budget:\s*$/` before the generic comment branch. The flag participates in the fingerprint automatically (fingerprint hashes `formatRecurring` output).
+
+- [ ] **Step 1: Write the failing tests** — append to `lib/journal/recurring.test.ts`:
+
+```typescript
+describe(':budget: tag', () => {
+  const draft = {
+    period: 'every 1 months from 2026/07/01',
+    note: 'Groceries budget',
+    uid: '01HZX5G5KJDS9HQRYK8E5T0DJC',
+    budget: true,
+    postings: [
+      { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '', currency: '' },
+    ],
+  };
+
+  it('round-trips through format and parse without polluting note', () => {
+    const block = formatRecurring(draft);
+    expect(block).toContain('; :budget:');
+    const parsed = parseRecurringFile('main.ledger', block + '\n');
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].budget).toBe(true);
+    expect(parsed[0].note).toBe('Groceries budget');
+  });
+
+  it('is absent by default and changes the fingerprint when set', () => {
+    const { budget: _budget, ...plain } = draft;
+    const block = formatRecurring(plain);
+    expect(block).not.toContain(':budget:');
+    expect(parseRecurringFile('main.ledger', block + '\n')[0].budget).toBeUndefined();
+    expect(fingerprintRecurring(plain)).not.toBe(fingerprintRecurring(draft));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/journal/recurring.test.ts`
+Expected: FAIL — `budget` missing from formatted block and parse result.
+
+- [ ] **Step 3: Implement** in `lib/journal/recurring.ts`:
+
+Schema (after `handled`):
+
+```typescript
+  budget: z.boolean().optional(),
+```
+
+`formatRecurring` (after `uidLines`, before the `:handled:` lines):
+
+```typescript
+  const budgetLines = draft.budget ? ['    ; :budget:'] : [];
+```
+
+include `...budgetLines` in the joined array between `uidLines` and the handled lines. `parseRecurringBlock`: add
+
+```typescript
+const BUDGET_LINE_REGEX = /^\s*;\s*:budget:\s*$/;
+```
+
+declare `let budget: boolean | undefined;`, and in the loop before the generic comment branch:
+
+```typescript
+    if (BUDGET_LINE_REGEX.test(line)) {
+      budget = true;
+      continue;
+    }
+```
+
+return `budget,` in the object.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run lib/journal/recurring.test.ts`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/journal/recurring.ts lib/journal/recurring.test.ts
+git commit -m "feat(budgets): parse and format :budget: tag on periodic directives"
+```
+
+---
+
+### Task 2: Exclude budget rules from the due queue and post/skip
+
+**Files:**
+- Modify: `features/recurring/dueList.ts`, `lib/journal/service.ts`
+- Test: `features/recurring/dueList.test.ts`, `lib/journal/service.recurring-occurrence.test.ts` (extend both)
+
+**Interfaces:**
+- Consumes: `budget?: boolean` on `ParsedRecurring` (Task 1); existing `buildDueList` and `handleRecurringOccurrence`.
+- Produces: `buildDueList` silently skips budget-tagged rules (not due, not upcoming, NOT listed in `unsupported` — they are supported, just not bills). `postRecurringOccurrence`/`skipRecurringOccurrence` return `{ ok: false, reason: 'invalid', message: 'Budget lines cannot be posted.' }` for a budget-tagged uid.
+
+- [ ] **Step 1: Failing test in `features/recurring/dueList.test.ts`:**
+
+```typescript
+  it('skips budget-tagged rules entirely', () => {
+    const withBudget = parseRecurringFile(
+      'main.ledger',
+      [
+        '~ every 1 months from 2026/01/01',
+        '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DBB',
+        '    ; :budget:',
+        '    Expenses:Food                            USD 400',
+        '    Assets:Checking                          USD -400',
+        '',
+      ].join('\n')
+    );
+    const list = buildDueList(withBudget, '2026-07-17', '2026-08-16');
+    expect(list.due).toEqual([]);
+    expect(list.upcoming).toEqual([]);
+    expect(list.unsupported).toEqual([]);
+  });
+```
+
+**Failing test in `lib/journal/service.recurring-occurrence.test.ts`** (uses that file's existing harness and a `seedRule`-style helper — write the budget block inline):
+
+```typescript
+  it('rejects posting a budget-tagged rule', async () => {
+    const block = [
+      '~ every 1 months from 2026/01/01',
+      '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DBB',
+      '    ; :budget:',
+      '    Expenses:Food                            USD 400',
+      '    Assets:Checking                          USD -400',
+      '',
+    ].join('\n');
+    await fs.writeFile(path.join(getJournalDir('test-user'), 'main.ledger'), block);
+    await push('test-user');
+    const rules = await service.listRecurring('test-user');
+    const result = await service.postRecurringOccurrence('test-user', {
+      uid: rules[0].uid!,
+      expectedFingerprint: rules[0].fingerprint,
+      dueDate: '2026-07-01',
+      today: '2026-07-17',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain('Budget');
+  });
+```
+
+- [ ] **Step 2: Run both files, verify the new tests fail** (budget rule shows up in due list / post succeeds or fails for the wrong reason).
+- [ ] **Step 3: Implement.** `dueList.ts`: first line of the per-rule loop: `if (rule.budget) continue;` (before the unsupported checks). `service.ts` `handleRecurringOccurrence`: after locating the rule and BEFORE the fingerprint check:
+
+```typescript
+    if (rule.budget) {
+      return {
+        ok: false,
+        reason: 'invalid',
+        message: 'Budget lines cannot be posted.',
+      };
+    }
+```
+
+- [ ] **Step 4: Run to verify pass:** `pnpm vitest run features/recurring/dueList.test.ts lib/journal/service.recurring-occurrence.test.ts` — all green.
+- [ ] **Step 5: Commit**
+
+```bash
+git add features/recurring/dueList.ts lib/journal/service.ts features/recurring/dueList.test.ts lib/journal/service.recurring-occurrence.test.ts
+git commit -m "feat(budgets): exclude budget lines from due queue and post/skip"
+```
+
+---
+
+### Task 3: Service — addBudget / listBudgets
+
+**Files:**
+- Modify: `lib/journal/service.ts`
+- Test: Create `lib/journal/service.budget.test.ts`
+
+**Interfaces:**
+- Consumes: `recurringCreateSchema` (structured schedule create shape from the recurring feature), `serializeSchedule`, existing `addRecurring` internals.
+- Produces:
+  - `JournalService.addBudget(userId: string, rawDraft: unknown): Promise<AddTransactionResult>` — validates with `recurringCreateSchema`, then stores a draft with `period = serializeSchedule(schedule)`, `budget: true`, fresh uid, **no `handled`** (budget lines never track occurrences). Reuse `addRecurring`'s write body by extracting a private `appendPeriodicDirective(userId, storedDraft)` helper both call — do NOT duplicate the 50-line quota/verify/push/rollback block.
+  - `JournalService.listBudgets(userId: string): Promise<ParsedRecurring[]>` = `(await this.listRecurring(userId)).filter((rule) => rule.budget)`.
+  - Deletion needs no new method: budget lines are deleted through the existing `deleteRecurring` (uid + fingerprint), which finds any `~` rule regardless of tag.
+
+- [ ] **Step 1: Failing tests** — `lib/journal/service.budget.test.ts`, same harness as `lib/journal/service.test.ts` (`resetObjectStore`, `setupTestDb('journal-budget-')`, insert user `test-user`, `fs.mkdir(getJournalDir(...), { recursive: true })`):
+
+```typescript
+describe('JournalService.addBudget / listBudgets', () => {
+  it('writes a :budget: tagged directive with no :handled: line', async () => {
+    const result = await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      note: 'Groceries budget',
+      postings: [
+        { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('~ every 1 months from 2026/07/01');
+    expect(text).toContain('; :budget:');
+    expect(text).not.toContain(':handled:');
+  });
+
+  it('listBudgets returns only budget rules; listRecurring still returns both', async () => {
+    await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      postings: [
+        { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-01-05' },
+        note: 'Netflix',
+        postings: [
+          { account: 'Expenses:Subscriptions', amount: '15', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-17'
+    );
+    expect(await service.listBudgets('test-user')).toHaveLength(1);
+    expect(await service.listRecurring('test-user')).toHaveLength(2);
+  });
+
+  it('rejects an invalid draft with fieldErrors', async () => {
+    const result = await service.addBudget('test-user', { postings: [] });
+    expect(result.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `pnpm vitest run lib/journal/service.budget.test.ts` → methods missing.
+- [ ] **Step 3: Implement** per the Produces contract (extract the shared private helper from `addRecurring`; `addBudget` differs only in `budget: true` and no `handled`/`today`).
+- [ ] **Step 4: Verify** — `pnpm vitest run lib/journal/service.budget.test.ts lib/journal/service.recurring-occurrence.test.ts lib/journal/service.test.ts && pnpm exec tsc --noEmit` — all green (the extraction must not change addRecurring behavior).
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/journal/service.ts lib/journal/service.budget.test.ts
+git commit -m "feat(budgets): addBudget and listBudgets service methods"
+```
+
+---
+
+### Task 4: Budget report module
+
+**Files:**
+- Create: `features/budgets/report.ts`
+- Test: `features/budgets/report.test.ts`
+
+**Interfaces:**
+- Consumes: `runLedger(args, options?)` from `@/utils/runLedger` (request-scoped, already prepends --file/--price-db; pass `{ sortByDate: false }`).
+- Produces:
+
+```typescript
+export const BUDGET_ROW_FORMAT =
+  '%A|%(get_at(display_total, 0))|%(0 - get_at(display_total, 1))|%(get_at(display_total, 0) + get_at(display_total, 1))|%(quantity(get_at(display_total, 0)))|%(quantity(0 - get_at(display_total, 1)))\n';
+
+export type BudgetRow = {
+  account: string;
+  actual: string;   // ledger-rendered, e.g. "$ 1,850.00"
+  budgeted: string; // ledger-rendered
+  difference: string; // ledger-rendered, negative = under budget
+  usedRatio: number | null; // actualQuantity / budgetedQuantity, ONLY for bar width; null when budgeted quantity is 0
+};
+
+export type UnbudgetedRow = { account: string; amount: string };
+
+export type BudgetReport = {
+  month: BudgetRow[];      // current month
+  yearToDate: BudgetRow[]; // Jan 1 through end of current month (cumulative)
+  unbudgeted: UnbudgetedRow[];
+};
+
+export const parseBudgetRows = (stdout: string): BudgetRow[]
+export const parseUnbudgetedRows = (stdout: string): UnbudgetedRow[]
+export const getBudgetReport = (currency: string, today: string): Promise<BudgetReport>
+```
+
+- `parseBudgetRows`: split lines on `|` (6 fields), drop rows with empty account (the grand-total row) and separator lines (start with `-`). `usedRatio = budgetedQuantity === 0 ? null : actualQuantity / budgetedQuantity` — the ONLY numeric computation, used exclusively for bar width/percent label; the three displayed amounts are ledger's strings verbatim.
+- `getBudgetReport(currency, today)`: three `runLedger` calls with `{ sortByDate: false }`:
+  1. month: `['budget', '^Expenses', '-p', 'this month', '-X', currency, '--flat', '--format', BUDGET_ROW_FORMAT]`
+  2. yearToDate: `['budget', '^Expenses', '-b', <Jan 1 of today's year, YYYY/01/01>, '-e', <first day of next month, YYYY/MM/DD>, '-X', currency, '--flat', '--format', BUDGET_ROW_FORMAT]` (dates derived from the `today` parameter with the same UTC string arithmetic style as `lib/journal/schedule.ts`)
+  3. unbudgeted: `['bal', '^Expenses', '--unbudgeted', '-p', 'this month', '-X', currency, '--flat', '--format', '%A|%T\n']`
+
+- [ ] **Step 1: Failing parser tests** — `features/budgets/report.test.ts` (pure parsers, captured-output fixtures; do not shell out in unit tests):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { parseBudgetRows, parseUnbudgetedRows } from './report';
+
+describe('parseBudgetRows', () => {
+  it('parses rows and drops the grand-total row', () => {
+    const stdout = [
+      'Expenses:Food|$ 90.00|$ 400.00|$ -310.00|90|400',
+      'Expenses:Rent|$ 1,850.00|$ 2,000.00|$ -150.00|1850|2000',
+      '|$ 1,940.00|$ 2,400.00|$ -460.00|1940|2400',
+      '',
+    ].join('\n');
+    const rows = parseBudgetRows(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      account: 'Expenses:Food',
+      actual: '$ 90.00',
+      budgeted: '$ 400.00',
+      difference: '$ -310.00',
+      usedRatio: 90 / 400,
+    });
+    expect(rows[1].actual).toBe('$ 1,850.00'); // thousands separator survives
+  });
+
+  it('yields null ratio for zero budget quantity', () => {
+    const rows = parseBudgetRows('Expenses:Misc|$ 5.00|0|$ 5.00|5|0\n');
+    expect(rows[0].usedRatio).toBeNull();
+  });
+});
+
+describe('parseUnbudgetedRows', () => {
+  it('parses account|amount lines and skips blanks', () => {
+    const rows = parseUnbudgetedRows('Expenses:Fun|$ 40.00\n\n');
+    expect(rows).toEqual([{ account: 'Expenses:Fun', amount: '$ 40.00' }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — module missing.
+- [ ] **Step 3: Implement** parsers + `getBudgetReport` per the contract.
+- [ ] **Step 4: Pin the real ledger behavior** — add an integration test in the same file, guarded like other repo tests that shell out (it may write a temp journal in the test's own tmp dir and call `execFile('ledger', ...)` directly rather than through `runLedger`, mirroring how `lib/journal/verify.test.ts` exercises real ledger):
+
+```typescript
+describe('ledger 3.4.1 budget report contract', () => {
+  it('emits the 6-field format this module parses', async () => {
+    // journal: one Rent transaction USD 1850 in 2026-07 + ~ Monthly Rent budget USD 2000
+    // run: ledger --init-file /dev/null -f <tmp> budget ^Expenses -p 'jul 2026' --flat --format BUDGET_ROW_FORMAT
+    // assert parseBudgetRows returns [{ account: 'Expenses:Rent', actual: '$ 1,850.00', budgeted: '$ 2,000.00', difference: '$ -150.00', usedRatio: 1850/2000 }]
+  });
+});
+```
+
+Write the test fully (the comment above states the required content — the implementer writes real code for it).
+
+- [ ] **Step 5: Verify** — `pnpm vitest run features/budgets/report.test.ts && pnpm exec tsc --noEmit` → PASS.
+- [ ] **Step 6: Commit**
+
+```bash
+git add features/budgets/report.ts features/budgets/report.test.ts
+git commit -m "feat(budgets): ledger budget report queries and parsers"
+```
+
+---
+
+### Task 5: Audit actions + create/delete budget server actions
+
+**Files:**
+- Modify: `lib/audit/schema.ts` (add `'budget.add'`, `'budget.delete'` after the `recurring.*` entries), `lib/audit/describe.ts` + `lib/audit/describe.test.ts` (labels in the existing style)
+- Create: `features/budgets/actions/createBudget.ts`, `features/budgets/actions/deleteBudget.ts`
+
+**Interfaces:**
+- Consumes: `journalService.addBudget` (Task 3), existing `journalService.deleteRecurring`.
+- Produces: `createBudgetAction(_prev: BudgetActionState | null, formData: FormData): Promise<BudgetActionState>` (useActionState shape, hidden `draft` JSON field — clone `features/recurring/actions/createRecurring.ts` exactly, swapping service method and audit action `'budget.add'`; define `BudgetActionState` locally mirroring `RecurringActionState`). `deleteBudgetAction(uid: string, fingerprint: string): Promise<{ ok: true } | { ok: false; message: string }>` — clone `features/recurring/actions/deleteRecurring.ts`, calling `journalService.deleteRecurring` and auditing `'budget.delete'`.
+
+- [ ] **Step 1:** Extend AUDIT_ACTIONS + describe map + describe.test.ts; run `pnpm vitest run lib/audit/describe.test.ts` → PASS.
+- [ ] **Step 2:** Create the two action files per the Produces contract.
+- [ ] **Step 3:** `pnpm exec tsc --noEmit` → clean.
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/audit/schema.ts lib/audit/describe.ts lib/audit/describe.test.ts features/budgets/actions/createBudget.ts features/budgets/actions/deleteBudget.ts
+git commit -m "feat(budgets): create/delete budget server actions with audit"
+```
+
+---
+
+### Task 6: /budgets page
+
+**Files:**
+- Create: `features/budgets/BudgetsView.tsx` (client), `app/budgets/page.tsx` (server)
+
+**Interfaces:**
+- Consumes: `getBudgetReport(currency, today)` + `BudgetReport` (Task 4), `journalService.listBudgets` (Task 3), `createBudgetAction`/`deleteBudgetAction` (Task 5), `getBaseCurrency` from `@/lib/settings`, `requireUser`.
+- Produces: `app/budgets/page.tsx` — server component: `requireUser`, `Promise.all([listBudgets, getBudgetReport(baseCurrency, todayIso), getBaseCurrency()])`, renders `<BudgetsView report={...} lines={...} baseCurrency={...} />` inside `PageContainer` with an `<h1>` + `<Help>` blurb ("Allowances compared against actual spending by ledger; your recurring bills count toward their account's allowance automatically."). Also add a "Budgets" nav entry wherever /recurring is registered in the app's navigation (grep for the recurring nav link and mirror it).
+- `BudgetsView`:
+  - Create form cloned from `RecurringView`'s (account/amount/currency + count/unit/anchor + note), hidden `draft` JSON `{ schedule, note, postings }`, submitted to `createBudgetAction` via `useActionState`. Exactly 2 postings, second one auto: account `Assets:Checking` prefilled but editable, blank amount.
+  - Table: one row per `report.month` entry — account, progress bar (width `min(100, usedRatio*100)%`, bar red when `usedRatio > 1`, amber > 0.85), actual / budgeted / difference strings, YTD difference (matched from `report.yearToDate` by account, empty if absent). Rows whose account matches a budget LINE the user created (by account name in `lines`) get a delete button (uid+fingerprint → `deleteBudgetAction`, useTransition + inline error, same as RecurringView delete); other rows (bill-derived allowances) show a muted "from your bills" label instead.
+  - Unbudgeted section: `report.unbudgeted` rows listed under a "Not budgeted" heading.
+  - Empty state when no budget rows at all: CTA text + the form.
+  - Helper text: non-monthly schedules bucket on calendar boundaries (ledger semantics).
+
+- [ ] **Step 1:** Build both files per contract.
+- [ ] **Step 2:** `pnpm exec tsc --noEmit && pnpm lint && pnpm vitest run` — green.
+- [ ] **Step 3: Commit**
+
+```bash
+git add features/budgets/BudgetsView.tsx app/budgets/page.tsx <nav file>
+git commit -m "feat(budgets): budgets page with ledger-computed table"
+```
+
+---
+
+### Task 7: Dashboard widget
+
+**Files:**
+- Modify: `lib/dashboard/widgets.ts` (WIDGET_IDS + WIDGET_LABELS: `budgets` / 'Budgets'), `features/dashboard/Dashboard.tsx`
+- Create: `features/budgets/BudgetsWidget.tsx` (server component — read-only, no interactivity)
+
+**Interfaces:**
+- Consumes: `getBudgetReport` (Task 4).
+- Produces: `BudgetsWidget({ month }: { month: BudgetRow[] })` — top 5 rows by `usedRatio ?? 0` descending, compact progress bars (same color rules as Task 6), account name + `actual / budgeted`, footer link to /budgets; renders nothing (returns null) when `month` is empty. Dashboard.tsx: add `getBudgetReport(currency, todayIsoAlreadyInScope)` to the Promise.all, render the widget in the `budgets` slot of the widget-order rendering (mirror how existing widgets map ids to sections).
+
+- [ ] **Step 1:** Implement; `normalizeWidgets` auto-appends the new id for existing users — verify by running `pnpm vitest run lib/dashboard` (or the widgets test file if present) plus full `pnpm vitest run`.
+- [ ] **Step 2:** `pnpm exec tsc --noEmit && pnpm lint` — clean.
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/dashboard/widgets.ts features/dashboard/Dashboard.tsx features/budgets/BudgetsWidget.tsx
+git commit -m "feat(dashboard): budgets widget"
+```
+
+---
+
+### Task 8: End-to-end verification + documentation
+
+**Files:**
+- Modify: `LEDGER-AUDIT.md`
+
+- [ ] **Step 1:** `pnpm vitest run && pnpm exec tsc --noEmit && pnpm lint && pnpm build` — all green.
+- [ ] **Step 2:** Real-ledger sanity: temp journal with a budget line + a recurring bill + transactions; run `ledger stats`, `ledger budget ^Expenses --flat --format <BUDGET_ROW_FORMAT>`, `bal --unbudgeted` — outputs parse with the module's parsers; include commands + output in the report.
+- [ ] **Step 3:** Append a LEDGER-AUDIT.md entry: budget report `--format` requires `get_at(display_total, 0|1)` (element 1 is the negated allowance); `neg()` fails in that format context — use `0 - …`; `reg --budget` running total (`%T`) is global across accounts, NOT per-account (why the YTD column uses the `budget` command over a span instead); recurring bill rules count as allowances by design.
+- [ ] **Step 4: Commit**
+
+```bash
+git add LEDGER-AUDIT.md
+git commit -m "docs(ledger-audit): budget report format and running-total gotchas"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: data model (Tasks 1–3), due-queue exclusion + post/skip rejection (Task 2), report queries/parsers incl. empirical pins (Task 4), audit + actions (Task 5), /budgets page incl. bill-derived labeling + unbudgeted + empty state (Task 6), widget (Task 7), portability + LEDGER-AUDIT (Task 8). Out-of-scope list respected (no rollover state, no editing, no income budgets).
+- Deliberate simplifications: `usedRatio` is the single JS numeric computation (bar geometry only — flagged in Global Constraints); bill-derived vs explicit-line matching is by account name (a user with two explicit lines on one account sees one merged ledger row — ledger sums allowances per account; the delete buttons still list each line separately if accounts collide, keyed by uid).
+- Type consistency: `BudgetRow`/`BudgetReport` defined once in Task 4 and consumed by Tasks 6–7; action names and audit actions consistent across Tasks 5–6.

--- a/docs/superpowers/specs/2026-07-17-budgets-design.md
+++ b/docs/superpowers/specs/2026-07-17-budgets-design.md
@@ -1,0 +1,148 @@
+# Budgets: allowance-style, ledger-computed
+
+2026-07-17
+
+## Problem
+
+The app has no budgets. Research across YNAB, Actual, Monarch, Lunch Money,
+Copilot (verified against vendor docs 2026-07-17) shows two models: envelope
+(categories are stateful funds of received income; covering/Ready-to-Assign
+mechanics) and per-period category allowances (planned vs actual, optional
+rollover netting). Envelope math requires stateful allocation that the
+journal + `ledger` cannot compute and JS must not (no-JS-money-math HARD
+RULE). The allowance model is ledger-native: `ledger budget`,
+`bal --unbudgeted`, and `reg --budget --monthly` compute actual, allowance,
+diff, %, and a cumulative running total directly from periodic (`~`)
+directives — all verified empirically against ledger 3.4.1.
+
+Decisions (user-confirmed):
+- Rollover: no stored state, no per-category toggle. Show this-month
+  progress AND a cumulative year-to-date over/under column (ledger's running
+  total) side by side.
+- Bills overlap: recurring bill rules count automatically as allowances
+  (Actual's schedule-template pattern). Explicit budget lines stack on top
+  for the same account; the UI labels bill-derived allowances distinctly.
+- Periods: full structured schedule (same every-N-units-from-anchor grammar
+  as recurring). Caveat accepted: ledger buckets by calendar periods, so
+  non-monthly anchored lines (e.g. every 2 weeks from a Friday) have exact
+  allowance amounts but calendar-snapped bucket edges. Monthly/yearly are
+  exact. Documented in UI helper text and LEDGER-AUDIT.md.
+- Placement: new /budgets page + a compact dashboard widget.
+- Currency: report converts with `-X <display base>` per the existing
+  base-currency selector convention.
+
+## Design
+
+### Data model — budget lines are `:budget:`-tagged periodic directives
+
+```
+~ every 1 months from 2026/07/01
+    ; :uid: 01XYZ...
+    ; :budget:
+    ; Groceries budget
+    Expenses:Food  USD 400.00
+    Assets:Checking
+```
+
+- Reuses the recurring machinery wholesale: `parseSchedule`/
+  `serializeSchedule`, structured create schema, uid + fingerprint,
+  snapshot → mutate → `ledger stats` verify → rollback → push write path,
+  delete-by-uid+fingerprint.
+- `lib/journal/recurring.ts` gains a `budget: boolean` flag: parsed from a
+  `; :budget:` comment line (recognized before the generic note branch,
+  like `:handled:`), emitted by `formatRecurring` when set.
+- **Due-queue exclusion (load-bearing)**: `buildDueList` must skip
+  budget-tagged rules; otherwise every budget line surfaces as a phantom
+  due bill on its period boundary. A regression test asserts a
+  budget-tagged rule never appears in due/upcoming/unsupported.
+- Budget lines take no `:handled:` line and are never posted/skipped; the
+  post/skip service methods reject a budget-tagged uid with reason
+  'invalid'.
+- Ledger ignores the comment tags and counts BOTH budget lines and
+  recurring bills as `--budget` allowances — which implements the
+  bills-count-automatically decision with zero filtering machinery.
+- The balancing posting is required by ledger's periodic-entry grammar; the
+  form auto-fills it (same as recurring).
+
+### Report — three ledger queries, JS only parses and renders
+
+Against the real journal, all with `-X <display base>`:
+
+1. This-month table: `ledger budget ^Expenses -p 'this month' -X <base>` →
+   per budgeted account: actual | budgeted | diff | %. Full-month allowance
+   during a partial month (ledger's behavior; also the surveyed apps'
+   convention — none prorate).
+2. Cumulative over/under: `ledger reg ^Expenses --budget --monthly
+   -b <Jan 1 of current year> -X <base> --format '%D|%A|%t|%T\n'` → per
+   month delta + running total per account; the latest running total is the
+   year-to-date rollover position shown in the cumulative column. Verified
+   working on 3.4.1.
+3. Unbudgeted: `ledger bal ^Expenses --unbudgeted -p 'this month'
+   -X <base>` → catch-all "unbudgeted spending" row.
+
+JS never adds, subtracts, or converts an amount; every displayed number is
+a string ledger printed. Expenses only at launch (`^Expenses` filter).
+
+Empirical preconditions (step 1 of the plan, pinned as tests before feature
+code, per LEDGER-AUDIT discipline):
+- The `budget` report's column structure and whether `--format` applies to
+  it (it is a distinct report type from bal/reg); pin the parse against
+  captured output.
+- `-X` interplay inside `budget` and `reg --budget` (the `-P -X` segfault
+  class lives nearby; my probes verified plain `-X` works on both).
+- Mixed-commodity actuals under a single-commodity allowance.
+
+### UI
+
+/budgets page (feature dir features/budgets/, thin app/budgets/page.tsx):
+- Create form: account input, amount + currency, structured schedule
+  (defaults: every 1 month from the 1st of the current month), optional
+  note. Serializes to the tagged directive via a budget variant of the
+  recurring create path.
+- Budget table: one row per budgeted account — progress bar, actual /
+  budgeted / diff (red when over), cumulative YTD column, delete button on
+  rows backed by an explicit budget line. Bill-derived allowance rows
+  render read-only, labeled "from your bills". Unbudgeted row at the
+  bottom.
+- Helper text notes the calendar-bucket caveat for non-monthly schedules.
+
+Dashboard: new `budgets` id in WIDGET_IDS/WIDGET_LABELS (auto-appears for
+existing users via normalizeWidgets): top categories by % used, compact
+progress bars, links to /budgets.
+
+### Server surface
+
+- Actions (one file each): `createBudgetAction`, `deleteBudgetAction` —
+  requireUser → WRITE rate-limit → journalService → audit (`budget.add`,
+  `budget.delete` added to AUDIT_ACTIONS + describe map) → revalidatePath.
+- JournalService: `addBudget` (thin variant of addRecurring setting the
+  budget flag, no `:handled:` initialization) and `deleteBudget` (reuses
+  the deleteRecurring path; both may share one private helper). listBudgets
+  = listRecurring filtered by the flag.
+- Report assembly in features/budgets/report.ts: runLedger three times,
+  parse, join by account; pure parse functions unit-tested against
+  captured ledger output.
+
+### Testing
+
+- Gotcha-pinning tests: budget report parse shape, -X conversion,
+  mixed-commodity case, weekly calendar-snapping documented.
+- Service: `:budget:` tag round-trip; due-queue exclusion regression;
+  post/skip reject budget uids; add/delete rollback on ledger rejection.
+- Report: parser tests on captured output (budgeted, over-budget,
+  unbudgeted, multi-currency).
+- End-to-end: create budget line → `ledger budget` shows the allowance;
+  `ledger stats` parses the journal (portability).
+
+### Rollout
+
+No migration. Journals without budget lines render an empty-state CTA.
+Pre-existing hand-written `~` rules keep their current recurring-page
+semantics (no `:budget:` tag = bill/unsupported as today).
+
+### Out of scope
+
+Envelope semantics (covering, Ready-to-Assign), per-category rollover
+toggles, alerts/notifications, income budgeting, budget line editing
+(create/delete only, like recurring), proration or pace projection of the
+partial month.

--- a/features/budgets/BudgetsView.test.tsx
+++ b/features/budgets/BudgetsView.test.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect, vi } from 'vitest';
+import BudgetsView from './BudgetsView';
+
+vi.mock('./actions/createBudget', () => ({
+  createBudgetAction: async () => ({ ok: true }) as never,
+}));
+vi.mock('./actions/deleteBudget', () => ({
+  deleteBudgetAction: async () => ({ ok: true }) as never,
+}));
+
+const html = (node: React.ReactNode) => renderToStaticMarkup(node);
+
+describe('BudgetsView', () => {
+  it('renders one delete button per uid even when two lines share an account', () => {
+    const report = {
+      month: [
+        {
+          account: 'Expenses:Groceries',
+          actual: '100 USD',
+          budgeted: '500 USD',
+          difference: '400 USD',
+          usedRatio: 0.2,
+        },
+      ],
+      yearToDate: [],
+      unbudgeted: [],
+    };
+
+    const lines = [
+      {
+        uid: 'uid-1',
+        fingerprint: 'fp-1',
+        period: 'every 1 month',
+        postings: [
+          { account: 'Expenses:Groceries', amount: '300', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      {
+        uid: 'uid-2',
+        fingerprint: 'fp-2',
+        period: 'every 1 month',
+        postings: [
+          { account: 'Expenses:Groceries', amount: '200', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+    ];
+
+    const out = html(
+      <BudgetsView report={report as any} lines={lines} baseCurrency="USD" />
+    );
+
+    const deleteButtonCount = (
+      out.match(/aria-label="Delete budget line uid-/g) ?? []
+    ).length;
+    expect(deleteButtonCount).toBe(2);
+    expect(out).toContain('Delete budget line uid-1');
+    expect(out).toContain('Delete budget line uid-2');
+  });
+});

--- a/features/budgets/BudgetsView.tsx
+++ b/features/budgets/BudgetsView.tsx
@@ -21,6 +21,8 @@ type PostingRow = {
 export type BudgetLineView = {
   uid?: string;
   fingerprint: string;
+  period: string;
+  note?: string;
   postings: PostingRow[];
 };
 
@@ -95,8 +97,8 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
       })),
   });
 
-  const linesByAccount = new Map(
-    lines.map((line) => [line.postings[0]?.account, line])
+  const accountsWithBudgetLines = new Set(
+    lines.map((line) => line.postings[0]?.account)
   );
   const yearToDateByAccount = new Map(
     report.yearToDate.map((row) => [row.account, row])
@@ -229,6 +231,68 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
     </form>
   );
 
+  const linesSection = (
+    <section className="space-y-2">
+      <h2 className="text-lg font-medium">Your budget lines</h2>
+      {deleteError && <p className="text-destructive text-sm">{deleteError}</p>}
+      {lines.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No budget lines yet. Add one above.
+        </p>
+      ) : (
+        <TableScroll>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-muted-foreground text-left">
+                <th className="py-1 whitespace-nowrap">Repeats</th>
+                <th>Note</th>
+                <th>Postings</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {lines.map((line, i) => (
+                <tr key={line.uid ?? `nouid:${i}`} className="border-t">
+                  <td className="py-1 whitespace-nowrap">{line.period}</td>
+                  <td>{line.note ?? ''}</td>
+                  <td>
+                    {line.postings
+                      .map((p) =>
+                        p.amount
+                          ? `${p.account} ${p.currency} ${p.amount}`
+                          : p.account
+                      )
+                      .join(' → ')}
+                  </td>
+                  <td className="text-right">
+                    {line.uid ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete budget line ${line.uid}`}
+                        disabled={isDeleting && deletingUid === line.uid}
+                        onClick={() =>
+                          handleDelete(line.uid!, line.fingerprint)
+                        }
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">
+                        no uid
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TableScroll>
+      )}
+    </section>
+  );
+
   if (report.month.length === 0) {
     return (
       <div className="space-y-8">
@@ -237,6 +301,7 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
           compare it against actual spending from ledger.
         </p>
         {form}
+        {linesSection}
       </div>
     );
   }
@@ -247,9 +312,6 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
 
       <section className="space-y-2">
         <h2 className="text-lg font-medium">This month</h2>
-        {deleteError && (
-          <p className="text-destructive text-sm">{deleteError}</p>
-        )}
         <TableScroll>
           <table className="w-full text-sm">
             <thead>
@@ -265,7 +327,6 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
             </thead>
             <tbody>
               {report.month.map((row) => {
-                const line = linesByAccount.get(row.account);
                 const ytd = yearToDateByAccount.get(row.account);
                 const widthPercent =
                   row.usedRatio === null
@@ -287,20 +348,7 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
                     <td>{row.difference}</td>
                     <td>{ytd?.difference ?? ''}</td>
                     <td className="text-right">
-                      {line?.uid ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          aria-label={`Delete budget ${row.account}`}
-                          disabled={isDeleting && deletingUid === line.uid}
-                          onClick={() =>
-                            handleDelete(line.uid!, line.fingerprint)
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      ) : (
+                      {!accountsWithBudgetLines.has(row.account) && (
                         <span className="text-muted-foreground text-xs">
                           from your bills
                         </span>
@@ -313,6 +361,8 @@ const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
           </table>
         </TableScroll>
       </section>
+
+      {linesSection}
 
       {report.unbudgeted.length > 0 && (
         <section className="space-y-2">

--- a/features/budgets/BudgetsView.tsx
+++ b/features/budgets/BudgetsView.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useActionState, useState, useTransition } from 'react';
+import { createBudgetAction } from './actions/createBudget';
+import { deleteBudgetAction } from './actions/deleteBudget';
+import type { BudgetActionState } from './actions/types';
+import type { BudgetReport } from './report';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { TableScroll } from '@/components/ui/table';
+
+type PostingRow = {
+  id?: string;
+  account: string;
+  amount: string;
+  currency: string;
+};
+
+export type BudgetLineView = {
+  uid?: string;
+  fingerprint: string;
+  postings: PostingRow[];
+};
+
+type Props = {
+  report: BudgetReport;
+  lines: BudgetLineView[];
+  baseCurrency: string;
+};
+
+const emptyPosting = (currency: string): PostingRow => ({
+  id: crypto.randomUUID(),
+  account: '',
+  amount: '',
+  currency,
+});
+
+const barColor = (usedRatio: number | null): string => {
+  if (usedRatio === null) return 'bg-muted-foreground/40';
+  if (usedRatio > 1) return 'bg-destructive';
+  if (usedRatio > 0.85) return 'bg-amber-500';
+  return 'bg-primary';
+};
+
+const BudgetsView = ({ report, lines, baseCurrency }: Props) => {
+  const [state, formAction, isPending] = useActionState<
+    BudgetActionState | null,
+    FormData
+  >(createBudgetAction, null);
+
+  const [unit, setUnit] = useState<'day' | 'week' | 'month' | 'year'>('month');
+  const [count, setCount] = useState('1');
+  const [anchor, setAnchor] = useState(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [note, setNote] = useState('');
+  const [postings, setPostings] = useState<PostingRow[]>([
+    emptyPosting(baseCurrency),
+    {
+      id: crypto.randomUUID(),
+      account: 'Assets:Checking',
+      amount: '',
+      currency: '',
+    },
+  ]);
+
+  const [isDeleting, startDelete] = useTransition();
+  const [deletingUid, setDeletingUid] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleDelete = (uid: string, fingerprint: string) => {
+    setDeleteError(null);
+    setDeletingUid(uid);
+    startDelete(async () => {
+      const result = await deleteBudgetAction(uid, fingerprint);
+      setDeletingUid(null);
+      if (!result.ok) setDeleteError(result.message);
+    });
+  };
+
+  const updatePosting = (i: number, patch: Partial<PostingRow>) =>
+    setPostings((ps) => ps.map((p, j) => (j === i ? { ...p, ...patch } : p)));
+
+  const draft = JSON.stringify({
+    schedule: { unit, count: Number(count), anchor },
+    note: note.trim() || undefined,
+    postings: postings
+      .filter((p) => p.account.trim())
+      .map((p) => ({
+        account: p.account.trim(),
+        amount: p.amount.trim(),
+        currency: p.amount.trim() ? p.currency.trim() : '',
+      })),
+  });
+
+  const linesByAccount = new Map(
+    lines.map((line) => [line.postings[0]?.account, line])
+  );
+  const yearToDateByAccount = new Map(
+    report.yearToDate.map((row) => [row.account, row])
+  );
+
+  const form = (
+    <form action={formAction} className="space-y-4 rounded-lg border p-4">
+      <input type="hidden" name="draft" value={draft} />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor="budget-count">Repeats</Label>
+          <div className="flex gap-2">
+            <Input
+              id="budget-count"
+              type="number"
+              min={1}
+              max={366}
+              value={count}
+              onChange={(e) => setCount(e.target.value)}
+              className="w-20"
+              required
+            />
+            <select
+              id="budget-unit"
+              value={unit}
+              onChange={(e) =>
+                setUnit(e.target.value as 'day' | 'week' | 'month' | 'year')
+              }
+              className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+            >
+              <option value="day">Day(s)</option>
+              <option value="week">Week(s)</option>
+              <option value="month">Month(s)</option>
+              <option value="year">Year(s)</option>
+            </select>
+            <Input
+              id="budget-anchor"
+              type="date"
+              value={anchor}
+              onChange={(e) => setAnchor(e.target.value)}
+              required
+            />
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Non-monthly schedules bucket on calendar boundaries — e.g. a
+            biweekly budget still measures against &quot;this month&quot; and
+            &quot;year to date&quot;, not a rolling window.
+          </p>
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="budget-note">Note (optional)</Label>
+          <Input
+            id="budget-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Groceries allowance"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {postings.map((p, i) => (
+          <div
+            key={p.id ?? i}
+            className="flex flex-col gap-2 rounded-lg border p-2 sm:flex-row sm:items-end sm:rounded-none sm:border-0 sm:p-0"
+          >
+            <div className="flex-2 space-y-1 sm:flex-1">
+              {i === 0 && (
+                <Label htmlFor={`budget-account-${i}`}>Account</Label>
+              )}
+              <Input
+                id={`budget-account-${i}`}
+                value={p.account}
+                onChange={(e) => updatePosting(i, { account: e.target.value })}
+                placeholder={i === 0 ? 'Expenses:Groceries' : 'Assets:Checking'}
+              />
+            </div>
+            <div className="flex items-end gap-2 sm:contents">
+              <div className="w-32 space-y-1">
+                {i === 0 && (
+                  <Label htmlFor={`budget-amount-${i}`}>Amount</Label>
+                )}
+                <Input
+                  id={`budget-amount-${i}`}
+                  type="number"
+                  step="any"
+                  inputMode="decimal"
+                  value={p.amount}
+                  onChange={(e) => updatePosting(i, { amount: e.target.value })}
+                  placeholder="500.00"
+                />
+              </div>
+              <div className="w-24 space-y-1">
+                {i === 0 && (
+                  <Label htmlFor={`budget-currency-${i}`}>Currency</Label>
+                )}
+                <Input
+                  id={`budget-currency-${i}`}
+                  value={p.currency}
+                  onChange={(e) =>
+                    updatePosting(i, { currency: e.target.value })
+                  }
+                  placeholder={baseCurrency}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+        <p className="text-muted-foreground text-xs">
+          Leave the second amount blank to auto-balance, just like a normal
+          transaction.
+        </p>
+      </div>
+
+      {state?.formError && (
+        <p className="text-destructive text-sm">{state.formError}</p>
+      )}
+      {state?.fieldErrors &&
+        Object.entries(state.fieldErrors).map(([field, message]) => (
+          <p key={field} className="text-destructive text-sm">
+            {field}: {message}
+          </p>
+        ))}
+      {state?.ok && <p className="text-sm text-green-600">Budget saved.</p>}
+
+      <Button type="submit" disabled={isPending}>
+        {isPending ? 'Saving…' : 'Save budget'}
+      </Button>
+    </form>
+  );
+
+  if (report.month.length === 0) {
+    return (
+      <div className="space-y-8">
+        <p className="text-muted-foreground text-sm">
+          No budgets yet. Set an allowance per account and this page will
+          compare it against actual spending from ledger.
+        </p>
+        {form}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {form}
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">This month</h2>
+        {deleteError && (
+          <p className="text-destructive text-sm">{deleteError}</p>
+        )}
+        <TableScroll>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-muted-foreground text-left">
+                <th className="py-1">Account</th>
+                <th>Progress</th>
+                <th>Actual</th>
+                <th>Budgeted</th>
+                <th>Difference</th>
+                <th className="whitespace-nowrap">YTD difference</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {report.month.map((row) => {
+                const line = linesByAccount.get(row.account);
+                const ytd = yearToDateByAccount.get(row.account);
+                const widthPercent =
+                  row.usedRatio === null
+                    ? 0
+                    : Math.min(100, row.usedRatio * 100);
+                return (
+                  <tr key={row.account} className="border-t">
+                    <td className="py-1">{row.account}</td>
+                    <td className="w-32">
+                      <div className="bg-muted h-2 w-32 overflow-hidden rounded-full">
+                        <div
+                          className={`h-2 rounded-full ${barColor(row.usedRatio)}`}
+                          style={{ width: `${widthPercent}%` }}
+                        />
+                      </div>
+                    </td>
+                    <td>{row.actual}</td>
+                    <td>{row.budgeted}</td>
+                    <td>{row.difference}</td>
+                    <td>{ytd?.difference ?? ''}</td>
+                    <td className="text-right">
+                      {line?.uid ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Delete budget ${row.account}`}
+                          disabled={isDeleting && deletingUid === line.uid}
+                          onClick={() =>
+                            handleDelete(line.uid!, line.fingerprint)
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">
+                          from your bills
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </TableScroll>
+      </section>
+
+      {report.unbudgeted.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">Not budgeted</h2>
+          <TableScroll>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground text-left">
+                  <th className="py-1">Account</th>
+                  <th>Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.unbudgeted.map((row) => (
+                  <tr key={row.account} className="border-t">
+                    <td className="py-1">{row.account}</td>
+                    <td>{row.amount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableScroll>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default BudgetsView;

--- a/features/budgets/BudgetsWidget.tsx
+++ b/features/budgets/BudgetsWidget.tsx
@@ -1,0 +1,62 @@
+import type { BudgetRow } from './report';
+import { buttonVariants } from '@/components/ui/button';
+import { Card as ShadcnCard } from '@/components/ui/card';
+import Link from 'next/link';
+
+// Same color rules as BudgetsView's barColor.
+const barColor = (usedRatio: number | null): string => {
+  if (usedRatio === null) return 'bg-muted-foreground/40';
+  if (usedRatio > 1) return 'bg-destructive';
+  if (usedRatio > 0.85) return 'bg-amber-500';
+  return 'bg-primary';
+};
+
+type Props = { month: BudgetRow[] };
+
+const BudgetsWidget = ({ month }: Props) => {
+  if (month.length === 0) return null;
+
+  const topRows = [...month]
+    .sort((a, b) => (b.usedRatio ?? 0) - (a.usedRatio ?? 0))
+    .slice(0, 5);
+
+  return (
+    <ShadcnCard className="flex flex-col gap-3 p-6">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Budgets
+        </h2>
+        <Link
+          href="/budgets"
+          className={buttonVariants({ variant: 'link', size: 'sm' })}
+        >
+          All budgets →
+        </Link>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {topRows.map((row) => {
+          const widthPercent =
+            row.usedRatio === null ? 0 : Math.min(100, row.usedRatio * 100);
+          return (
+            <li key={row.account} className="flex flex-col gap-1">
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="truncate">{row.account}</span>
+                <span className="whitespace-nowrap text-muted-foreground">
+                  {row.actual} / {row.budgeted}
+                </span>
+              </div>
+              <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
+                <div
+                  className={`h-2 rounded-full ${barColor(row.usedRatio)}`}
+                  style={{ width: `${widthPercent}%` }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </ShadcnCard>
+  );
+};
+
+export default BudgetsWidget;

--- a/features/budgets/actions/createBudget.ts
+++ b/features/budgets/actions/createBudget.ts
@@ -1,0 +1,51 @@
+'use server';
+
+import type { BudgetActionState } from './types';
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { getJournalDirSize } from '@/lib/journal/quota';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export async function createBudgetAction(
+  _prev: BudgetActionState | null,
+  formData: FormData
+): Promise<BudgetActionState> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, formError: RATE_LIMIT_MESSAGE };
+  }
+  const draftJson = formData.get('draft');
+  if (typeof draftJson !== 'string') {
+    return { ok: false, formError: 'Missing budget payload' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(draftJson);
+  } catch {
+    return { ok: false, formError: 'Budget payload is not valid JSON' };
+  }
+
+  const bytesBefore = await getJournalDirSize(user.id);
+  const result = await journalService.addBudget(user.id, parsed);
+  const bytesAfter = await getJournalDirSize(user.id);
+  await auditService.record(user.id, {
+    action: 'budget.add',
+    result: result.ok ? 'success' : 'failure',
+    bytesBefore,
+    bytesAfter,
+    detail: result.ok ? undefined : { reason: result.reason },
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      fieldErrors: result.fieldErrors,
+      formError: result.formError,
+    };
+  }
+  revalidatePath('/', 'layout');
+  return { ok: true, uid: result.uid };
+}

--- a/features/budgets/actions/deleteBudget.ts
+++ b/features/budgets/actions/deleteBudget.ts
@@ -22,6 +22,7 @@ export async function deleteBudgetAction(
     kind: 'delete',
     uid,
     expectedFingerprint,
+    ruleKind: 'budget',
   });
   const bytesAfter = await getJournalDirSize(user.id);
   await auditService.record(user.id, {

--- a/features/budgets/actions/deleteBudget.ts
+++ b/features/budgets/actions/deleteBudget.ts
@@ -1,0 +1,39 @@
+'use server';
+
+import { auditService, auditRequestMeta } from '@/lib/audit';
+import { requireUser } from '@/lib/auth/require-user';
+import { journalService } from '@/lib/journal';
+import { getJournalDirSize } from '@/lib/journal/quota';
+import { rateLimit, WRITE, RATE_LIMIT_MESSAGE } from '@/lib/rate-limit';
+import { revalidatePath } from 'next/cache';
+
+export type DeleteBudgetResult = { ok: true } | { ok: false; message: string };
+
+export async function deleteBudgetAction(
+  uid: string,
+  expectedFingerprint: string
+): Promise<DeleteBudgetResult> {
+  const user = await requireUser();
+  if (!rateLimit(WRITE, user.id).allowed) {
+    return { ok: false, message: RATE_LIMIT_MESSAGE };
+  }
+  const bytesBefore = await getJournalDirSize(user.id);
+  const result = await journalService.deleteRecurring(user.id, {
+    kind: 'delete',
+    uid,
+    expectedFingerprint,
+  });
+  const bytesAfter = await getJournalDirSize(user.id);
+  await auditService.record(user.id, {
+    action: 'budget.delete',
+    result: result.ok ? 'success' : 'failure',
+    targetUid: uid,
+    bytesBefore,
+    bytesAfter,
+    detail: result.ok ? undefined : { reason: result.reason },
+    ...(await auditRequestMeta()),
+  });
+  if (!result.ok) return { ok: false, message: result.message };
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}

--- a/features/budgets/actions/types.ts
+++ b/features/budgets/actions/types.ts
@@ -1,0 +1,6 @@
+export type BudgetActionState = {
+  ok: boolean;
+  uid?: string;
+  formError?: string;
+  fieldErrors?: Record<string, string>;
+};

--- a/features/budgets/report.test.ts
+++ b/features/budgets/report.test.ts
@@ -1,0 +1,100 @@
+import { execFile } from 'child_process';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  parseBudgetRows,
+  parseUnbudgetedRows,
+  BUDGET_ROW_FORMAT,
+} from './report';
+
+const execFilePromise = promisify(execFile);
+
+describe('parseBudgetRows', () => {
+  it('parses rows and drops the grand-total row', () => {
+    const stdout = [
+      'Expenses:Food|$ 90.00|$ 400.00|$ -310.00|90|400',
+      'Expenses:Rent|$ 1,850.00|$ 2,000.00|$ -150.00|1850|2000',
+      '|$ 1,940.00|$ 2,400.00|$ -460.00|1940|2400',
+      '',
+    ].join('\n');
+    const rows = parseBudgetRows(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      account: 'Expenses:Food',
+      actual: '$ 90.00',
+      budgeted: '$ 400.00',
+      difference: '$ -310.00',
+      usedRatio: 90 / 400,
+    });
+    expect(rows[1].actual).toBe('$ 1,850.00'); // thousands separator survives
+  });
+
+  it('yields null ratio for zero budget quantity', () => {
+    const rows = parseBudgetRows('Expenses:Misc|$ 5.00|0|$ 5.00|5|0\n');
+    expect(rows[0].usedRatio).toBeNull();
+  });
+});
+
+describe('parseUnbudgetedRows', () => {
+  it('parses account|amount lines and skips blanks', () => {
+    const rows = parseUnbudgetedRows('Expenses:Fun|$ 40.00\n\n');
+    expect(rows).toEqual([{ account: 'Expenses:Fun', amount: '$ 40.00' }]);
+  });
+});
+
+describe('ledger 3.4.1 budget report contract', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'budget-report-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('emits the 6-field format this module parses', async () => {
+    const file = path.join(tmp, 'main.ledger');
+    await fs.writeFile(
+      file,
+      [
+        '2026/07/01 Rent',
+        '    Expenses:Rent  USD 1850.00',
+        '    Assets:Checking',
+        '',
+        '~ Monthly',
+        '    Expenses:Rent  USD 2000.00',
+        '    Assets:Checking',
+        '',
+      ].join('\n')
+    );
+
+    const { stdout } = await execFilePromise('ledger', [
+      '--init-file',
+      '/dev/null',
+      '--file',
+      file,
+      'budget',
+      '^Expenses',
+      '-p',
+      'jul 2026',
+      '--flat',
+      '--format',
+      BUDGET_ROW_FORMAT,
+    ]);
+
+    const rows = parseBudgetRows(stdout);
+    expect(rows).toEqual([
+      {
+        account: 'Expenses:Rent',
+        actual: '$ 1,850.00',
+        budgeted: '$ 2,000.00',
+        difference: '$ -150.00',
+        usedRatio: 1850 / 2000,
+      },
+    ]);
+  });
+});

--- a/features/budgets/report.test.ts
+++ b/features/budgets/report.test.ts
@@ -73,11 +73,11 @@ describe('ledger 3.4.1 budget report contract', () => {
       file,
       [
         '2026/07/01 Rent',
-        '    Expenses:Rent  USD 1850.00',
+        '    Expenses:Rent  $1850.00',
         '    Assets:Checking',
         '',
         '~ Monthly',
-        '    Expenses:Rent  USD 2000.00',
+        '    Expenses:Rent  $2000.00',
         '    Assets:Checking',
         '',
       ].join('\n')
@@ -115,15 +115,15 @@ describe('ledger 3.4.1 budget report contract', () => {
       file,
       [
         '2026/07/01 Fun spending',
-        '    Expenses:Fun  USD 40.00',
+        '    Expenses:Fun  $40.00',
         '    Assets:Checking',
         '',
         '2026/07/05 Misc spending',
-        '    Expenses:Misc  USD 15.00',
+        '    Expenses:Misc  $15.00',
         '    Assets:Checking',
         '',
         '~ Monthly',
-        '    Expenses:Rent  USD 2000.00',
+        '    Expenses:Rent  $2000.00',
         '    Assets:Checking',
         '',
       ].join('\n')

--- a/features/budgets/report.test.ts
+++ b/features/budgets/report.test.ts
@@ -43,6 +43,17 @@ describe('parseUnbudgetedRows', () => {
     const rows = parseUnbudgetedRows('Expenses:Fun|$ 40.00\n\n');
     expect(rows).toEqual([{ account: 'Expenses:Fun', amount: '$ 40.00' }]);
   });
+
+  it('drops grand-total rows and malformed lines', () => {
+    const stdout =
+      'Expenses:Fun|$ 40.00\nExpenses:Misc|$ 15.00\n|$ 55.00\nno-pipe-line\n\n';
+    const rows = parseUnbudgetedRows(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual([
+      { account: 'Expenses:Fun', amount: '$ 40.00' },
+      { account: 'Expenses:Misc', amount: '$ 15.00' },
+    ]);
+  });
 });
 
 describe('ledger 3.4.1 budget report contract', () => {
@@ -96,5 +107,50 @@ describe('ledger 3.4.1 budget report contract', () => {
         usedRatio: 1850 / 2000,
       },
     ]);
+  });
+
+  it('parseUnbudgetedRows filters grand-total from real ledger output', async () => {
+    const file = path.join(tmp, 'main.ledger');
+    await fs.writeFile(
+      file,
+      [
+        '2026/07/01 Fun spending',
+        '    Expenses:Fun  USD 40.00',
+        '    Assets:Checking',
+        '',
+        '2026/07/05 Misc spending',
+        '    Expenses:Misc  USD 15.00',
+        '    Assets:Checking',
+        '',
+        '~ Monthly',
+        '    Expenses:Rent  USD 2000.00',
+        '    Assets:Checking',
+        '',
+      ].join('\n')
+    );
+
+    const { stdout } = await execFilePromise('ledger', [
+      '--init-file',
+      '/dev/null',
+      '--file',
+      file,
+      'bal',
+      '^Expenses',
+      '--unbudgeted',
+      '-p',
+      'jul 2026',
+      '--flat',
+      '--format',
+      '%A|%T\n',
+    ]);
+
+    const rows = parseUnbudgetedRows(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.account)).toEqual([
+      'Expenses:Fun',
+      'Expenses:Misc',
+    ]);
+    expect(rows[0].amount).toBe('$ 40.00');
+    expect(rows[1].amount).toBe('$ 15.00');
   });
 });

--- a/features/budgets/report.test.ts
+++ b/features/budgets/report.test.ts
@@ -98,23 +98,18 @@ describe('ledger 3.4.1 budget report contract', () => {
     ]);
 
     const rows = parseBudgetRows(stdout);
-    // Symbol-amount spacing is inferred per ledger build and varies (some
-    // render "$ 1,850.00", others "$1,850.00"); normalize it out and pin the
-    // structural contract this parser actually relies on.
-    const normalize = (amount: string) => amount.replace(/\s+/g, '');
+    // Amount display (symbol spacing, thousands separators) is inferred per
+    // ledger build and varies ("$ 1,850.00" vs "$1850.00"); assert only the
+    // structural contract this parser relies on. A correct usedRatio proves
+    // the quantity fields (5 and 6) parsed in the right positions, and
+    // matching digits prove fields 2-4 carry the rendered amounts.
+    const digits = (amount: string) => amount.replace(/[^\d-]/g, '');
     expect(rows).toHaveLength(1);
-    expect({
-      ...rows[0],
-      actual: normalize(rows[0].actual),
-      budgeted: normalize(rows[0].budgeted),
-      difference: normalize(rows[0].difference),
-    }).toEqual({
-      account: 'Expenses:Rent',
-      actual: '$1,850.00',
-      budgeted: '$2,000.00',
-      difference: '$-150.00',
-      usedRatio: 1850 / 2000,
-    });
+    expect(rows[0].account).toBe('Expenses:Rent');
+    expect(rows[0].usedRatio).toBe(1850 / 2000);
+    expect(digits(rows[0].actual)).toBe('185000');
+    expect(digits(rows[0].budgeted)).toBe('200000');
+    expect(digits(rows[0].difference)).toBe('-15000');
   });
 
   it('parseUnbudgetedRows filters grand-total from real ledger output', async () => {

--- a/features/budgets/report.test.ts
+++ b/features/budgets/report.test.ts
@@ -98,15 +98,23 @@ describe('ledger 3.4.1 budget report contract', () => {
     ]);
 
     const rows = parseBudgetRows(stdout);
-    expect(rows).toEqual([
-      {
-        account: 'Expenses:Rent',
-        actual: '$ 1,850.00',
-        budgeted: '$ 2,000.00',
-        difference: '$ -150.00',
-        usedRatio: 1850 / 2000,
-      },
-    ]);
+    // Symbol-amount spacing is inferred per ledger build and varies (some
+    // render "$ 1,850.00", others "$1,850.00"); normalize it out and pin the
+    // structural contract this parser actually relies on.
+    const normalize = (amount: string) => amount.replace(/\s+/g, '');
+    expect(rows).toHaveLength(1);
+    expect({
+      ...rows[0],
+      actual: normalize(rows[0].actual),
+      budgeted: normalize(rows[0].budgeted),
+      difference: normalize(rows[0].difference),
+    }).toEqual({
+      account: 'Expenses:Rent',
+      actual: '$1,850.00',
+      budgeted: '$2,000.00',
+      difference: '$-150.00',
+      usedRatio: 1850 / 2000,
+    });
   });
 
   it('parseUnbudgetedRows filters grand-total from real ledger output', async () => {
@@ -150,7 +158,8 @@ describe('ledger 3.4.1 budget report contract', () => {
       'Expenses:Fun',
       'Expenses:Misc',
     ]);
-    expect(rows[0].amount).toBe('$ 40.00');
-    expect(rows[1].amount).toBe('$ 15.00');
+    // Symbol-amount spacing varies per ledger build; normalize it out.
+    expect(rows[0].amount.replace(/\s+/g, '')).toBe('$40.00');
+    expect(rows[1].amount.replace(/\s+/g, '')).toBe('$15.00');
   });
 });

--- a/features/budgets/report.ts
+++ b/features/budgets/report.ts
@@ -1,0 +1,129 @@
+import runLedger from '@/utils/runLedger';
+
+export const BUDGET_ROW_FORMAT =
+  '%A|%(get_at(display_total, 0))|%(0 - get_at(display_total, 1))|%(get_at(display_total, 0) + get_at(display_total, 1))|%(quantity(get_at(display_total, 0)))|%(quantity(0 - get_at(display_total, 1)))\n';
+
+export type BudgetRow = {
+  account: string;
+  actual: string; // ledger-rendered, e.g. "$ 1,850.00"
+  budgeted: string; // ledger-rendered
+  difference: string; // ledger-rendered, negative = under budget
+  usedRatio: number | null; // actualQuantity / budgetedQuantity, ONLY for bar width; null when budgeted quantity is 0
+};
+
+export type UnbudgetedRow = { account: string; amount: string };
+
+export type BudgetReport = {
+  month: BudgetRow[]; // current month
+  yearToDate: BudgetRow[]; // Jan 1 through end of current month (cumulative)
+  unbudgeted: UnbudgetedRow[];
+};
+
+export const parseBudgetRows = (stdout: string): BudgetRow[] =>
+  stdout
+    .split('\n')
+    .filter((line) => line.trim() !== '' && !line.startsWith('-'))
+    .map((line) => line.split('|'))
+    .filter((fields) => fields.length === 6 && fields[0] !== '')
+    .map(
+      ([
+        account,
+        actual,
+        budgeted,
+        difference,
+        actualQuantity,
+        budgetedQuantity,
+      ]) => {
+        const budgetedNumber = Number(budgetedQuantity);
+        return {
+          account,
+          actual,
+          budgeted,
+          difference,
+          usedRatio:
+            budgetedNumber === 0
+              ? null
+              : Number(actualQuantity) / budgetedNumber,
+        };
+      }
+    );
+
+export const parseUnbudgetedRows = (stdout: string): UnbudgetedRow[] =>
+  stdout
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => {
+      const [account, amount] = line.split('|');
+      return { account, amount };
+    });
+
+// UTC string arithmetic (same style as lib/journal/schedule.ts) — no local
+// timezone Date parsing.
+const startOfYear = (today: string): string => `${today.slice(0, 4)}/01/01`;
+
+const startOfNextMonth = (today: string): string => {
+  const year = Number(today.slice(0, 4));
+  const month = Number(today.slice(5, 7));
+  const nextYear = month === 12 ? year + 1 : year;
+  const nextMonth = month === 12 ? 1 : month + 1;
+  return `${nextYear}/${String(nextMonth).padStart(2, '0')}/01`;
+};
+
+export const getBudgetReport = async (
+  currency: string,
+  today: string
+): Promise<BudgetReport> => {
+  const [monthStdout, yearToDateStdout, unbudgetedStdout] = await Promise.all([
+    runLedger(
+      [
+        'budget',
+        '^Expenses',
+        '-p',
+        'this month',
+        '-X',
+        currency,
+        '--flat',
+        '--format',
+        BUDGET_ROW_FORMAT,
+      ],
+      { sortByDate: false }
+    ),
+    runLedger(
+      [
+        'budget',
+        '^Expenses',
+        '-b',
+        startOfYear(today),
+        '-e',
+        startOfNextMonth(today),
+        '-X',
+        currency,
+        '--flat',
+        '--format',
+        BUDGET_ROW_FORMAT,
+      ],
+      { sortByDate: false }
+    ),
+    runLedger(
+      [
+        'bal',
+        '^Expenses',
+        '--unbudgeted',
+        '-p',
+        'this month',
+        '-X',
+        currency,
+        '--flat',
+        '--format',
+        '%A|%T\n',
+      ],
+      { sortByDate: false }
+    ),
+  ]);
+
+  return {
+    month: parseBudgetRows(monthStdout),
+    yearToDate: parseBudgetRows(yearToDateStdout),
+    unbudgeted: parseUnbudgetedRows(unbudgetedStdout),
+  };
+};

--- a/features/budgets/report.ts
+++ b/features/budgets/report.ts
@@ -52,10 +52,9 @@ export const parseUnbudgetedRows = (stdout: string): UnbudgetedRow[] =>
   stdout
     .split('\n')
     .filter((line) => line.trim() !== '')
-    .map((line) => {
-      const [account, amount] = line.split('|');
-      return { account, amount };
-    });
+    .map((line) => line.split('|'))
+    .filter((fields) => fields.length === 2 && fields[0] !== '')
+    .map(([account, amount]) => ({ account, amount }));
 
 // UTC string arithmetic (same style as lib/journal/schedule.ts) — no local
 // timezone Date parsing.

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -16,6 +16,8 @@ import Help from '@/components/Help';
 import PageContainer from '@/components/PageContainer';
 import { buttonVariants } from '@/components/ui/button';
 import { Card as ShadcnCard } from '@/components/ui/card';
+import BudgetsWidget from '@/features/budgets/BudgetsWidget';
+import { getBudgetReport } from '@/features/budgets/report';
 import { getCashFlow } from '@/features/monthlyComparison/MonthlyComparison.utils';
 import { buildDueList } from '@/features/recurring/dueList';
 import { loadJournalTransactions } from '@/features/transactions/loadJournalTransactions';
@@ -82,6 +84,7 @@ const Dashboard = async () => {
     netWorthChange,
     cashFlow,
     widgets,
+    budgetReport,
   ] = await Promise.all([
     // `bal --collapse` folds the whole period into one rollup row, so the
     // total comes straight from ledger's `%T` instead of guessing which line
@@ -129,6 +132,7 @@ const Dashboard = async () => {
     // ponytail: data for hidden widgets is still fetched; skip the fetches if
     // the ledger calls ever get slow enough to matter.
     getDashboardWidgets(),
+    getBudgetReport(currency, upcomingStart),
   ]);
 
   const lastMonthReview =
@@ -393,6 +397,7 @@ const Dashboard = async () => {
         </ShadcnCard>
       </section>
     ),
+    budgets: <BudgetsWidget month={budgetReport.month} />,
   };
 
   return (

--- a/features/recurring/actions/deleteRecurring.ts
+++ b/features/recurring/actions/deleteRecurring.ts
@@ -23,6 +23,7 @@ export async function deleteRecurringAction(
     kind: 'delete',
     uid,
     expectedFingerprint,
+    ruleKind: 'recurring',
   });
   const bytesAfter = await getJournalDirSize(user.id);
   await auditService.record(user.id, {

--- a/features/recurring/dueList.test.ts
+++ b/features/recurring/dueList.test.ts
@@ -46,4 +46,22 @@ describe('buildDueList', () => {
     const list = buildDueList(fresh, '2026-07-16', '2026-08-15');
     expect(list.due.map((o) => o.date)).toEqual(['2026-07-16']); // today only
   });
+
+  it('skips budget-tagged rules entirely', () => {
+    const withBudget = parseRecurringFile(
+      'main.ledger',
+      [
+        '~ every 1 months from 2026/01/01',
+        '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DBB',
+        '    ; :budget:',
+        '    Expenses:Food                            USD 400',
+        '    Assets:Checking                          USD -400',
+        '',
+      ].join('\n')
+    );
+    const list = buildDueList(withBudget, '2026-07-17', '2026-08-16');
+    expect(list.due).toEqual([]);
+    expect(list.upcoming).toEqual([]);
+    expect(list.unsupported).toEqual([]);
+  });
 });

--- a/features/recurring/dueList.ts
+++ b/features/recurring/dueList.ts
@@ -30,6 +30,8 @@ export const buildDueList = (
   const unsupported: { ruleUid: string | undefined; period: string }[] = [];
 
   for (const rule of rules) {
+    if (rule.budget) continue;
+
     const schedule = rule.uid ? parseSchedule(rule.period) : null;
     if (!rule.uid || !schedule) {
       unsupported.push({ ruleUid: rule.uid, period: rule.period });

--- a/lib/audit/describe.ts
+++ b/lib/audit/describe.ts
@@ -23,6 +23,8 @@ const COPY: Record<string, [string, string]> = {
     'Skipped a recurring occurrence',
     'Failed to skip a recurring occurrence',
   ],
+  'budget.add': ['Created a budget', 'Failed to create a budget'],
+  'budget.delete': ['Deleted a budget', 'Failed to delete a budget'],
   'journal.import': ['Imported journal', 'Import failed'],
   'price.add': ['Recorded a price', 'Failed to record a price'],
   'price.delete': ['Deleted a price', 'Failed to delete a price'],

--- a/lib/audit/schema.ts
+++ b/lib/audit/schema.ts
@@ -8,6 +8,8 @@ export const AUDIT_ACTIONS = [
   'recurring.delete',
   'recurring.post',
   'recurring.skip',
+  'budget.add',
+  'budget.delete',
   'journal.import',
   'price.add',
   'price.delete',

--- a/lib/dashboard/widgets.test.ts
+++ b/lib/dashboard/widgets.test.ts
@@ -18,7 +18,7 @@ describe('parseDashboardWidgets', () => {
     expect(parsed[1]).toEqual({ id: 'journalHealth', hidden: false });
     expect(parsed[2]).toEqual({ id: 'stats', hidden: false });
     expect(serializeDashboardWidgets(parsed)).toBe(
-      '-savedViews,journalHealth,stats,trends,upcomingBills,recentTransactions'
+      '-savedViews,journalHealth,stats,trends,upcomingBills,recentTransactions,budgets'
     );
   });
 

--- a/lib/dashboard/widgets.ts
+++ b/lib/dashboard/widgets.ts
@@ -7,6 +7,7 @@ export const WIDGET_IDS = [
   'savedViews',
   'recentTransactions',
   'journalHealth',
+  'budgets',
 ] as const;
 export type WidgetId = (typeof WIDGET_IDS)[number];
 
@@ -26,6 +27,7 @@ export const WIDGET_LABELS: Record<WidgetId, string> = {
   savedViews: 'Saved views',
   recentTransactions: 'Recent transactions',
   journalHealth: 'Journal health',
+  budgets: 'Budgets',
 };
 
 export const dashboardWidgetsSchema = z.array(

--- a/lib/journal/recurring.test.ts
+++ b/lib/journal/recurring.test.ts
@@ -114,3 +114,35 @@ describe(':handled: state line', () => {
     );
   });
 });
+
+describe(':budget: tag', () => {
+  const draft = {
+    period: 'every 1 months from 2026/07/01',
+    note: 'Groceries budget',
+    uid: '01HZX5G5KJDS9HQRYK8E5T0DJC',
+    budget: true,
+    postings: [
+      { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+      { account: 'Assets:Checking', amount: '', currency: '' },
+    ],
+  };
+
+  it('round-trips through format and parse without polluting note', () => {
+    const block = formatRecurring(draft);
+    expect(block).toContain('; :budget:');
+    const parsed = parseRecurringFile('main.ledger', block + '\n');
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].budget).toBe(true);
+    expect(parsed[0].note).toBe('Groceries budget');
+  });
+
+  it('is absent by default and changes the fingerprint when set', () => {
+    const { budget: _budget, ...plain } = draft;
+    const block = formatRecurring(plain);
+    expect(block).not.toContain(':budget:');
+    expect(
+      parseRecurringFile('main.ledger', block + '\n')[0].budget
+    ).toBeUndefined();
+    expect(fingerprintRecurring(plain)).not.toBe(fingerprintRecurring(draft));
+  });
+});

--- a/lib/journal/recurring.ts
+++ b/lib/journal/recurring.ts
@@ -46,6 +46,7 @@ export const recurringDraftSchema = z.object({
   note: noteSchema,
   uid: uidSchema,
   handled: handledSchema,
+  budget: z.boolean().optional(),
   postings: z
     .array(postingSchema)
     .min(2, 'At least 2 postings are required')
@@ -80,6 +81,7 @@ export type ParsedRecurring = RecurringDraft & {
 export const formatRecurring = (draft: RecurringDraft): string => {
   const header = `~ ${draft.period}`;
   const uidLines = draft.uid ? [`    ; :uid: ${draft.uid}`] : [];
+  const budgetLines = draft.budget ? ['    ; :budget:'] : [];
   const handledLines = draft.handled
     ? [`    ; :handled: ${draft.handled}`]
     : [];
@@ -89,9 +91,14 @@ export const formatRecurring = (draft: RecurringDraft): string => {
     .filter(Boolean)
     .map((line) => `    ; ${line}`);
   const postings = draft.postings.map(formatPosting);
-  return [header, ...uidLines, ...handledLines, ...noteLines, ...postings].join(
-    '\n'
-  );
+  return [
+    header,
+    ...uidLines,
+    ...budgetLines,
+    ...handledLines,
+    ...noteLines,
+    ...postings,
+  ].join('\n');
 };
 
 export const fingerprintRecurring = (draft: RecurringDraft): string =>
@@ -99,6 +106,7 @@ export const fingerprintRecurring = (draft: RecurringDraft): string =>
 
 const RECURRING_HEADER_REGEX = /^~\s+(\S.*)$/;
 const HANDLED_LINE_REGEX = /^\s*;\s*:handled:\s*(\d{4}-\d{2}-\d{2})\s*$/;
+const BUDGET_LINE_REGEX = /^\s*;\s*:budget:\s*$/;
 const COMMENT_LINE_REGEX = /^\s*;\s?(.*)$/;
 
 const parseRecurringBlock = (
@@ -113,6 +121,7 @@ const parseRecurringBlock = (
 
   let uid: string | undefined;
   let handled: string | undefined;
+  let budget: boolean | undefined;
   const noteLines: string[] = [];
   const postings: ParsedPosting[] = [];
 
@@ -122,6 +131,10 @@ const parseRecurringBlock = (
     const uidMatch = line.match(UID_LINE_REGEX);
     if (uidMatch) {
       uid = uidMatch[1];
+      continue;
+    }
+    if (BUDGET_LINE_REGEX.test(line)) {
+      budget = true;
       continue;
     }
     const handledMatch = line.match(HANDLED_LINE_REGEX);
@@ -143,6 +156,7 @@ const parseRecurringBlock = (
     period: header[1].trim(),
     uid,
     handled,
+    budget,
     note: noteLines.length > 0 ? noteLines.join('\n') : undefined,
     postings,
   };

--- a/lib/journal/service.budget.test.ts
+++ b/lib/journal/service.budget.test.ts
@@ -47,6 +47,27 @@ describe('JournalService.addBudget / listBudgets', () => {
     expect(text).not.toContain(':handled:');
   });
 
+  it('rejects a budget line with no Expenses account and writes nothing', async () => {
+    const result = await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      postings: [
+        { account: 'Personal:Care', amount: '50', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors.postings).toBe(
+        'Budget lines must target an Expenses account.'
+      );
+    }
+    const mainLedgerExists = await fs
+      .access(path.join(getJournalDir('test-user'), 'main.ledger'))
+      .then(() => true)
+      .catch(() => false);
+    expect(mainLedgerExists).toBe(false);
+  });
+
   it('listBudgets returns only budget rules; listRecurring still returns both', async () => {
     await service.addBudget('test-user', {
       schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },

--- a/lib/journal/service.budget.test.ts
+++ b/lib/journal/service.budget.test.ts
@@ -75,4 +75,69 @@ describe('JournalService.addBudget / listBudgets', () => {
     const result = await service.addBudget('test-user', { postings: [] });
     expect(result.ok).toBe(false);
   });
+
+  it('deletes a budget rule when ruleKind is budget', async () => {
+    await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      postings: [
+        { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    const [rule] = await service.listBudgets('test-user');
+    const result = await service.deleteRecurring('test-user', {
+      kind: 'delete',
+      uid: rule!.uid!,
+      expectedFingerprint: rule!.fingerprint,
+      ruleKind: 'budget',
+    });
+    expect(result.ok).toBe(true);
+    expect(await service.listBudgets('test-user')).toHaveLength(0);
+  });
+
+  it('refuses to delete a recurring rule as a budget', async () => {
+    await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-01-05' },
+        note: 'Netflix',
+        postings: [
+          { account: 'Expenses:Subscriptions', amount: '15', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-17'
+    );
+    const [rule] = await service.listRecurring('test-user');
+    const result = await service.deleteRecurring('test-user', {
+      kind: 'delete',
+      uid: rule!.uid!,
+      expectedFingerprint: rule!.fingerprint,
+      ruleKind: 'budget',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('This entry is not a budget line.');
+    }
+    expect(await service.listRecurring('test-user')).toHaveLength(1);
+  });
+
+  it('refuses to delete a budget rule as recurring', async () => {
+    await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      postings: [
+        { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    const [rule] = await service.listBudgets('test-user');
+    const result = await service.deleteRecurring('test-user', {
+      kind: 'delete',
+      uid: rule!.uid!,
+      expectedFingerprint: rule!.fingerprint,
+      ruleKind: 'recurring',
+    });
+    expect(result.ok).toBe(false);
+    expect(await service.listBudgets('test-user')).toHaveLength(1);
+  });
 });

--- a/lib/journal/service.budget.test.ts
+++ b/lib/journal/service.budget.test.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getJournalDir } from './layout';
+import { JournalRepository } from './repository';
+import { JournalService } from './service';
+import { resetObjectStore } from '@/lib/storage';
+import {
+  setupTestDb,
+  teardownTestDb,
+  type TestDbContext,
+} from '@/lib/test-utils/db';
+
+describe('JournalService.addBudget / listBudgets', () => {
+  let ctx: TestDbContext;
+  let service: JournalService;
+
+  beforeEach(async () => {
+    resetObjectStore();
+    ctx = await setupTestDb('journal-budget-');
+    await ctx.insertUser('test-user', 'Test', 'test@example.com');
+    service = new JournalService(new JournalRepository(ctx.db));
+    await fs.mkdir(getJournalDir('test-user'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await teardownTestDb(ctx);
+    resetObjectStore();
+  });
+
+  it('writes a :budget: tagged directive with no :handled: line', async () => {
+    const result = await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      note: 'Groceries budget',
+      postings: [
+        { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    const text = await fs.readFile(
+      path.join(getJournalDir('test-user'), 'main.ledger'),
+      'utf-8'
+    );
+    expect(text).toContain('~ every 1 months from 2026/07/01');
+    expect(text).toContain('; :budget:');
+    expect(text).not.toContain(':handled:');
+  });
+
+  it('listBudgets returns only budget rules; listRecurring still returns both', async () => {
+    await service.addBudget('test-user', {
+      schedule: { unit: 'month', count: 1, anchor: '2026-07-01' },
+      postings: [
+        { account: 'Expenses:Food', amount: '400', currency: 'USD' },
+        { account: 'Assets:Checking', amount: '', currency: '' },
+      ],
+    });
+    await service.addRecurring(
+      'test-user',
+      {
+        schedule: { unit: 'month', count: 1, anchor: '2026-01-05' },
+        note: 'Netflix',
+        postings: [
+          { account: 'Expenses:Subscriptions', amount: '15', currency: 'USD' },
+          { account: 'Assets:Checking', amount: '', currency: '' },
+        ],
+      },
+      '2026-07-17'
+    );
+    expect(await service.listBudgets('test-user')).toHaveLength(1);
+    expect(await service.listRecurring('test-user')).toHaveLength(2);
+  });
+
+  it('rejects an invalid draft with fieldErrors', async () => {
+    const result = await service.addBudget('test-user', { postings: [] });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/lib/journal/service.recurring-occurrence.test.ts
+++ b/lib/journal/service.recurring-occurrence.test.ts
@@ -172,6 +172,31 @@ describe('JournalService.postRecurringOccurrence / skipRecurringOccurrence', () 
       });
       expect(result.ok).toBe(false); // oldest unhandled is 2026-08-05 (> today) — nothing due
     });
+
+    it('rejects posting a budget-tagged rule', async () => {
+      const block = [
+        '~ every 1 months from 2026/01/01',
+        '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DBB',
+        '    ; :budget:',
+        '    Expenses:Food                            USD 400',
+        '    Assets:Checking                          USD -400',
+        '',
+      ].join('\n');
+      await fs.writeFile(
+        path.join(getJournalDir('test-user'), 'main.ledger'),
+        block
+      );
+      await push('test-user');
+      const rules = await service.listRecurring('test-user');
+      const result = await service.postRecurringOccurrence('test-user', {
+        uid: rules[0].uid!,
+        expectedFingerprint: rules[0].fingerprint,
+        dueDate: '2026-07-01',
+        today: '2026-07-17',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.message).toContain('Budget');
+    });
   });
 
   describe('skipRecurringOccurrence', () => {
@@ -190,6 +215,31 @@ describe('JournalService.postRecurringOccurrence / skipRecurringOccurrence', () 
       );
       expect(text).toContain('; :handled: 2026-07-05');
       expect(text).not.toContain('2026-07-05 Netflix');
+    });
+
+    it('rejects skipping a budget-tagged rule', async () => {
+      const block = [
+        '~ every 1 months from 2026/01/01',
+        '    ; :uid: 01HZX5G5KJDS9HQRYK8E5T0DBB',
+        '    ; :budget:',
+        '    Expenses:Food                            USD 400',
+        '    Assets:Checking                          USD -400',
+        '',
+      ].join('\n');
+      await fs.writeFile(
+        path.join(getJournalDir('test-user'), 'main.ledger'),
+        block
+      );
+      await push('test-user');
+      const rules = await service.listRecurring('test-user');
+      const result = await service.skipRecurringOccurrence('test-user', {
+        uid: rules[0].uid!,
+        expectedFingerprint: rules[0].fingerprint,
+        dueDate: '2026-07-01',
+        today: '2026-07-17',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.message).toContain('Budget');
     });
 
     it('posting a rule defined in an included file leaves the include untouched', async () => {

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -454,6 +454,13 @@ export class JournalService {
           message: 'Recurring entry not found.',
         };
       }
+      if (rule.budget) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'Budget lines cannot be posted.',
+        };
+      }
       if (rule.fingerprint !== input.expectedFingerprint) {
         return {
           ok: false,

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -257,30 +257,15 @@ export class JournalService {
     return result;
   }
 
-  async addRecurring(
+  // Shared write body for periodic (`~`) directives: quota check, append,
+  // ledger-verify, push, rollback on failure. Used by both addRecurring
+  // (bills, tracks :handled:) and addBudget (budget lines, no :handled:).
+  private async appendPeriodicDirective(
     userId: string,
-    rawDraft: unknown,
-    today: string
+    draft: RecurringDraft,
+    uid: string
   ): Promise<AddTransactionResult> {
-    const parsed = recurringCreateSchema.safeParse(rawDraft);
-    if (!parsed.success) {
-      const fieldErrors: Record<string, string> = {};
-      for (const issue of parsed.error.issues) {
-        const key = issue.path.join('.') || 'form';
-        if (!fieldErrors[key]) fieldErrors[key] = issue.message;
-      }
-      return { ok: false, reason: 'invalid', fieldErrors };
-    }
-
     return withUserLock(userId, async () => {
-      const uid = generateUid();
-      const { schedule, ...rest } = parsed.data;
-      const draft: RecurringDraft = {
-        ...rest,
-        period: serializeSchedule(schedule),
-        handled: lastOccurrenceBefore(schedule, today) ?? undefined,
-        uid,
-      };
       await pull(userId);
       const { mainPath } = await this.repo.ensureLayout(userId);
       const snapshot = await this.repo.readFile(mainPath);
@@ -330,6 +315,61 @@ export class JournalService {
       invalidateCache(userId);
       return { ok: true, uid };
     });
+  }
+
+  async addRecurring(
+    userId: string,
+    rawDraft: unknown,
+    today: string
+  ): Promise<AddTransactionResult> {
+    const parsed = recurringCreateSchema.safeParse(rawDraft);
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const key = issue.path.join('.') || 'form';
+        if (!fieldErrors[key]) fieldErrors[key] = issue.message;
+      }
+      return { ok: false, reason: 'invalid', fieldErrors };
+    }
+
+    const uid = generateUid();
+    const { schedule, ...rest } = parsed.data;
+    const draft: RecurringDraft = {
+      ...rest,
+      period: serializeSchedule(schedule),
+      handled: lastOccurrenceBefore(schedule, today) ?? undefined,
+      uid,
+    };
+    return this.appendPeriodicDirective(userId, draft, uid);
+  }
+
+  async addBudget(
+    userId: string,
+    rawDraft: unknown
+  ): Promise<AddTransactionResult> {
+    const parsed = recurringCreateSchema.safeParse(rawDraft);
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const key = issue.path.join('.') || 'form';
+        if (!fieldErrors[key]) fieldErrors[key] = issue.message;
+      }
+      return { ok: false, reason: 'invalid', fieldErrors };
+    }
+
+    const uid = generateUid();
+    const { schedule, ...rest } = parsed.data;
+    const draft: RecurringDraft = {
+      ...rest,
+      period: serializeSchedule(schedule),
+      budget: true,
+      uid,
+    };
+    return this.appendPeriodicDirective(userId, draft, uid);
+  }
+
+  async listBudgets(userId: string): Promise<ParsedRecurring[]> {
+    return (await this.listRecurring(userId)).filter((rule) => rule.budget);
   }
 
   async deleteRecurring(

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -358,6 +358,19 @@ export class JournalService {
       return { ok: false, reason: 'invalid', fieldErrors };
     }
 
+    const hasExpensesAccount = parsed.data.postings.some(
+      (p) => p.account === 'Expenses' || p.account.startsWith('Expenses:')
+    );
+    if (!hasExpensesAccount) {
+      return {
+        ok: false,
+        reason: 'invalid',
+        fieldErrors: {
+          postings: 'Budget lines must target an Expenses account.',
+        },
+      };
+    }
+
     const uid = generateUid();
     const { schedule, ...rest } = parsed.data;
     const draft: RecurringDraft = {

--- a/lib/journal/service.ts
+++ b/lib/journal/service.ts
@@ -65,6 +65,7 @@ export type WriteDeleteInput = {
   kind: 'delete';
   uid: string;
   expectedFingerprint: string;
+  ruleKind?: 'budget' | 'recurring';
 };
 
 export type WriteInput = WriteEditInput | WriteDeleteInput;
@@ -406,6 +407,20 @@ export class JournalService {
           ok: false,
           reason: 'stale',
           message: 'This recurring entry was modified somewhere else.',
+        };
+      }
+      if (input.ruleKind === 'budget' && !current.budget) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'This entry is not a budget line.',
+        };
+      }
+      if (input.ruleKind === 'recurring' && current.budget) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'This entry is not a recurring transaction.',
         };
       }
 


### PR DESCRIPTION
## Summary

Allowance-style budgets (the Monarch/Lunch-Money/Actual-Tracking model — research-verified as the right fit for a journal-as-truth design; envelope semantics are out of scope by design since their stateful math can't be delegated to ledger):

- **Budget lines are `; :budget:`-tagged `~` periodic directives** in the journal, created with the same structured-schedule form, uid/fingerprint, and verify/rollback write path as recurring bills. Plain ledger parses everything (tags are comments).
- **Ledger computes the whole report.** The `budget` report with a `get_at(display_total, …)` format emits account | actual | budgeted | difference (difference computed inside ledger via value expressions), `bal --unbudgeted` catches spending with no allowance, and the YTD cumulative column is the `budget` command over a Jan-1 span. JS parses pipe rows and renders; the sole numeric use is `usedRatio` for progress-bar geometry, taken from ledger-emitted `quantity()` fields.
- **Recurring bills count as allowances automatically** (Actual's schedule-template pattern, a deliberate spec decision) — the report labels bill-derived rows "from your bills"; explicit budget lines stack on top.
- **/budgets page**: create form (Expenses accounts enforced server-side), budget-vs-actual table with progress bars and YTD over/under, uid-keyed "Your budget lines" management (every line individually deletable even when accounts collide), unbudgeted section. **Dashboard** gains a Budgets widget (top categories by % used).
- **Guard rails**: budget rules are excluded from the recurring due queue, can never be posted/skipped into transactions, and deletes are kind-scoped (`ruleKind`) so a budgets-page delete can't remove a bill or vice versa. Each guard carries a regression test.

Empirical ledger 3.4.1 findings documented in LEDGER-AUDIT.md: `get_at(display_total, 1)` is the negated allowance; `neg()` fails in budget format context (use `0 - …`); `reg --budget`'s running total is global across accounts, not per-account.

## Test plan

- 1170 tests green; tsc, lint, `pnpm build` clean.
- New coverage: `:budget:` round-trip + fingerprint participation, due-queue/post-skip exclusion, kind-guarded deletes (both directions), report parsers incl. real-ledger integration tests for both the budget format and `--unbudgeted` (grand-total row handling), same-account line-collision component test, Expenses-account validation.
- Real-ledger sanity: journal with a budget line + bill + transactions parses via `ledger stats`; the budget query shows both allowance sources.
- [ ] Manual walk (needs authenticated session): create a budget on /budgets → row appears with correct amounts → dashboard widget shows it → delete line → row reverts to bill-derived/empty.