### PR TITLE
fix: robust register separators + reusable add-transaction button

### DIFF
--- a/app/api/payees/export/route.ts
+++ b/app/api/payees/export/route.ts
@@ -2,7 +2,7 @@ import { requireUser } from '@/lib/auth/require-user';
 import { csvDownload } from '@/lib/csv';
 import { createLogger } from '@/lib/log';
 import { payeeRowsToCsv } from '@/lib/payees/csv';
-import { parsePayeeRows } from '@/lib/payees/parse';
+import { PAYEE_REGISTER_FORMAT, parsePayeeRows } from '@/lib/payees/parse';
 import { getBaseCurrency } from '@/lib/settings';
 import { parseISODateStrict } from '@/utils/date';
 import runLedger from '@/utils/runLedger';
@@ -32,7 +32,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       '--sort',
       '-display_amount',
       '--format',
-      'NNN%P|%t\n',
+      PAYEE_REGISTER_FORMAT,
     ];
     if (start) args.push('-b', start);
     if (end) args.push('-e', end);

--- a/app/api/reconcile/export/route.ts
+++ b/app/api/reconcile/export/route.ts
@@ -1,4 +1,5 @@
 import { parseReconcileRows } from '@/features/reconcile/Reconcile.utils';
+import { registerFormat } from '@/features/transactions/row/registerRows';
 import { requireUser } from '@/lib/auth/require-user';
 import { csvDownload } from '@/lib/csv';
 import { createLogger } from '@/lib/log';
@@ -25,7 +26,7 @@ export async function GET(): Promise<Response> {
         '--sort',
         'date',
         '--format',
-        'NNN%D|%P|%A|%t\n',
+        registerFormat(['%D', '%P', '%A', '%t']),
       ],
       { sortByDate: false }
     );

--- a/features/dashboard/Dashboard.tsx
+++ b/features/dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import BudgetsWidget from '@/features/budgets/BudgetsWidget';
 import { getBudgetReport } from '@/features/budgets/report';
 import { getCashFlow } from '@/features/monthlyComparison/MonthlyComparison.utils';
 import { buildDueList } from '@/features/recurring/dueList';
+import AddTransactionButton from '@/features/transactions/AddTransactionButton';
 import { loadJournalTransactions } from '@/features/transactions/loadJournalTransactions';
 import { pageTransactions } from '@/features/transactions/pageTransactions';
 import TransactionRow from '@/features/transactions/row/TransactionRow';
@@ -354,12 +355,7 @@ const Dashboard = async () => {
             >
               View all →
             </Link>
-            <Link
-              href="/transactions/new"
-              className={buttonVariants({ size: 'sm' })}
-            >
-              Add transaction
-            </Link>
+            <AddTransactionButton />
           </div>
         </div>
         {recent.length === 0 ? (

--- a/features/payees/Payees.tsx
+++ b/features/payees/Payees.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { TableScroll } from '@/components/ui/table';
 import SaveViewButton from '@/features/savedViews/SaveViewButton';
 import { requireUser } from '@/lib/auth/require-user';
-import { parsePayeeRows } from '@/lib/payees/parse';
+import { PAYEE_REGISTER_FORMAT, parsePayeeRows } from '@/lib/payees/parse';
 import { savedViewService } from '@/lib/savedViews';
 import { getBaseCurrency } from '@/lib/settings';
 import { parseISODate, toISODate } from '@/utils/date';
@@ -53,7 +53,7 @@ const Payees = async ({ from: fromParam, to: toParam }: Props) => {
       '--sort',
       '-display_amount',
       '--format',
-      'NNN%P|%t\n',
+      PAYEE_REGISTER_FORMAT,
     ],
     { sortByDate: false }
   );

--- a/features/reconcile/Reconcile.tsx
+++ b/features/reconcile/Reconcile.tsx
@@ -3,6 +3,7 @@ import ExportButton from '@/components/ExportButton';
 import Help from '@/components/Help';
 import PageContainer from '@/components/PageContainer';
 import TransactionRow from '@/features/transactions/row/TransactionRow';
+import { registerFormat } from '@/features/transactions/row/registerRows';
 import { getBaseCurrency } from '@/lib/settings';
 import runLedger from '@/utils/runLedger';
 
@@ -22,7 +23,7 @@ const Reconcile = async () => {
       '--sort',
       'date',
       '--format',
-      'NNN%D|%P|%A|%t|%(note)\n',
+      registerFormat(['%D', '%P', '%A', '%t']),
     ],
     { sortByDate: false }
   );

--- a/features/reconcile/Reconcile.utils.test.ts
+++ b/features/reconcile/Reconcile.utils.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { parseReconcileRows } from './Reconcile.utils';
 import {
-  FIELD_SEP,
-  RECORD_SEP,
+  FIELD_SEPARATOR,
+  RECORD_SEPARATOR,
 } from '@/features/transactions/row/registerRows';
 
 const NOW = Date.UTC(2026, 4, 22);
 
 // Build a reconcile register line with the real separators, trailing newline
 // as ledger emits it.
-const row = (...fields: string[]) => `${RECORD_SEP}${fields.join(FIELD_SEP)}\n`;
+const row = (...fields: string[]) =>
+  `${RECORD_SEPARATOR}${fields.join(FIELD_SEPARATOR)}\n`;
 
 describe('parseReconcileRows', () => {
   it('returns an empty array for empty stdout', () => {

--- a/features/reconcile/Reconcile.utils.test.ts
+++ b/features/reconcile/Reconcile.utils.test.ts
@@ -1,17 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { parseReconcileRows } from './Reconcile.utils';
+import {
+  FIELD_SEP,
+  RECORD_SEP,
+} from '@/features/transactions/row/registerRows';
 
 const NOW = Date.UTC(2026, 4, 22);
+
+// Build a reconcile register line with the real separators, trailing newline
+// as ledger emits it.
+const row = (...fields: string[]) => `${RECORD_SEP}${fields.join(FIELD_SEP)}\n`;
 
 describe('parseReconcileRows', () => {
   it('returns an empty array for empty stdout', () => {
     expect(parseReconcileRows('', NOW)).toEqual([]);
   });
 
-  it('parses NNN-delimited rows into typed records', () => {
+  it('parses delimited rows into typed records', () => {
     const stdout =
-      "NNN2026-05-01|Trader Joe's|Expenses:Food|USD 42\n" +
-      'NNN2026-05-15|Landlord|Expenses:Rent|USD 1500\n';
+      row('2026-05-01', "Trader Joe's", 'Expenses:Food', 'USD 42') +
+      row('2026-05-15', 'Landlord', 'Expenses:Rent', 'USD 1500');
     const rows = parseReconcileRows(stdout, NOW);
     expect(rows).toHaveLength(2);
     expect(rows[0].account).toBe('Expenses:Food');
@@ -19,10 +27,9 @@ describe('parseReconcileRows', () => {
   });
 
   it('preserves ledger order (which is oldest-first via --sort date)', () => {
-    // ledger emits oldest-first; the parser must not reorder.
     const stdout =
-      'NNN2026-01-01|old|Expenses:Rent|USD 1500\n' +
-      'NNN2026-05-15|recent|Expenses:Coffee|USD 5\n';
+      row('2026-01-01', 'old', 'Expenses:Rent', 'USD 1500') +
+      row('2026-05-15', 'recent', 'Expenses:Coffee', 'USD 5');
     const rows = parseReconcileRows(stdout, NOW);
     expect(rows[0].account).toBe('Expenses:Rent');
     expect(rows[1].account).toBe('Expenses:Coffee');
@@ -30,23 +37,22 @@ describe('parseReconcileRows', () => {
   });
 
   it('computes days since the row date', () => {
-    const stdout = 'NNN2026-05-15|x|Expenses:Coffee|USD 5\n';
+    const stdout = row('2026-05-15', 'x', 'Expenses:Coffee', 'USD 5');
     const rows = parseReconcileRows(stdout, NOW);
     expect(rows[0].days).toBe(7);
   });
 
   it('skips malformed rows', () => {
     const stdout =
-      'NNN\n' + // empty date column
-      'NNN2026-05-15|||\n' + // valid (empty payee/account/amount but date present)
-      'NNN2026-05-01|p|a|amt\n';
+      row('') + // empty date column
+      row('2026-05-15', '', '', '') + // valid (empty fields but date present)
+      row('2026-05-01', 'p', 'a', 'amt');
     const rows = parseReconcileRows(stdout, NOW);
-    // The fully empty entry is filtered; the others keep going.
     expect(rows.every((r) => r.date)).toBe(true);
   });
 
   it('trims whitespace from columns', () => {
-    const stdout = 'NNN 2026-05-01 |  payee  | account | amount\n';
+    const stdout = row(' 2026-05-01 ', '  payee  ', ' account ', ' amount ');
     const rows = parseReconcileRows(stdout, NOW);
     expect(rows[0].payee).toBe('payee');
     expect(rows[0].account).toBe('account');
@@ -54,22 +60,34 @@ describe('parseReconcileRows', () => {
   });
 
   it('extracts uid from a 5th %(note) column', () => {
-    const stdout =
-      'NNN2026-05-01|Coffee|Expenses:Food|USD 5| :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z\n';
-    const [row] = parseReconcileRows(stdout, NOW);
-    expect(row.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
+    const stdout = row(
+      '2026-05-01',
+      'Coffee',
+      'Expenses:Food',
+      'USD 5',
+      ' :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z'
+    );
+    const [r] = parseReconcileRows(stdout, NOW);
+    expect(r.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
   });
 
   it('leaves uid undefined when the note has no uid tag', () => {
-    const stdout = 'NNN2026-05-01|Coffee|Expenses:Food|USD 5|\n';
-    const [row] = parseReconcileRows(stdout, NOW);
-    expect(row.uid).toBeUndefined();
+    const stdout = row('2026-05-01', 'Coffee', 'Expenses:Food', 'USD 5', '');
+    const [r] = parseReconcileRows(stdout, NOW);
+    expect(r.uid).toBeUndefined();
   });
 
-  it('rejoins note columns so a pipe inside the note cannot drop the uid', () => {
-    const stdout =
-      'NNN2026-05-01|Coffee|Expenses:Food|USD 5|a|b| :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z\n';
-    const [row] = parseReconcileRows(stdout, NOW);
-    expect(row.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
+  it('rejoins note columns so a separator inside the note cannot drop the uid', () => {
+    const stdout = row(
+      '2026-05-01',
+      'Coffee',
+      'Expenses:Food',
+      'USD 5',
+      'a',
+      'b',
+      ' :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z'
+    );
+    const [r] = parseReconcileRows(stdout, NOW);
+    expect(r.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
   });
 });

--- a/features/reconcile/Reconcile.utils.ts
+++ b/features/reconcile/Reconcile.utils.ts
@@ -11,7 +11,7 @@ export type ReconcileRow = {
 };
 
 /**
- * Parses the `NNN%D|%P|%A|%t|%(note)\n` output of
+ * Parses the `registerFormat(['%D', '%P', '%A', '%t'])` output of
  * `ledger reg --uncleared --sort date` into typed rows, dropping malformed
  * lines. Row order is ledger's (oldest-first) — no JS re-sort. `now` is
  * injected so the `days` field is deterministic in tests.

--- a/features/transactions/AddTransactionButton.tsx
+++ b/features/transactions/AddTransactionButton.tsx
@@ -1,0 +1,26 @@
+import QuickEntry from './QuickEntry';
+import { requireUser } from '@/lib/auth/require-user';
+import { getAvailableCurrencies } from '@/lib/settings';
+import { templateRepository } from '@/lib/templates';
+import { getAccountSuggestions } from '@/lib/transactions/suggestions';
+
+// Self-loading add-transaction split button (all quick-entry variants).
+// Drop it anywhere; it fetches its own accounts/currency/templates.
+// The shared edit dialog it drives is mounted once in the app shell.
+// ponytail: re-runs `ledger accounts` per render; add a cache wrapper if it
+// shows up in profiling.
+export default async function AddTransactionButton() {
+  const user = await requireUser();
+  const [accounts, { base }, templates] = await Promise.all([
+    getAccountSuggestions(),
+    getAvailableCurrencies(),
+    templateRepository.list(user.id),
+  ]);
+  return (
+    <QuickEntry
+      accounts={accounts}
+      defaultCurrency={base}
+      templates={templates}
+    />
+  );
+}

--- a/features/transactions/QuickEntrySlot.tsx
+++ b/features/transactions/QuickEntrySlot.tsx
@@ -1,30 +1,15 @@
-import QuickEntry from './QuickEntry';
+import AddTransactionButton from './AddTransactionButton';
 import TransactionEditDialog from './TransactionEditDialog';
 import { getOptionalUser } from '@/lib/auth/require-user';
-import { getAvailableCurrencies } from '@/lib/settings';
-import { templateRepository } from '@/lib/templates';
-import { getAccountSuggestions } from '@/lib/transactions/suggestions';
 
-// Server wrapper: loads the account list + base currency + saved templates and
-// hands them to the client quick-entry split button, and mounts the shared
-// edit dialog. Placed in the app header slot so both are reachable from every
-// page. ponytail: re-runs `ledger accounts` per page render; add a cache
-// wrapper if it shows up in profiling.
+// App-header slot: the add-transaction button plus the shared edit dialog,
+// mounted once so both are reachable from every page.
 export default async function QuickEntrySlot() {
   const user = await getOptionalUser();
   if (!user) return null;
-  const [accounts, { base }, templates] = await Promise.all([
-    getAccountSuggestions(),
-    getAvailableCurrencies(),
-    templateRepository.list(user.id),
-  ]);
   return (
     <>
-      <QuickEntry
-        accounts={accounts}
-        defaultCurrency={base}
-        templates={templates}
-      />
+      <AddTransactionButton />
       <TransactionEditDialog />
     </>
   );

--- a/features/transactions/row/registerRows.test.ts
+++ b/features/transactions/row/registerRows.test.ts
@@ -1,29 +1,61 @@
 import { describe, expect, it } from 'vitest';
-import { parseAccountRegister } from './registerRows';
+import { FIELD_SEP, RECORD_SEP, parseAccountRegister } from './registerRows';
+
+// Build a register line the way ledger would, using the real separators.
+const row = (...fields: string[]) => `${RECORD_SEP}${fields.join(FIELD_SEP)}`;
 
 describe('parseAccountRegister', () => {
   it('parses date/payee/amount/total and extracts the uid from the note', () => {
-    const stdout =
-      'NNN2026/01/01|Coffee|$ -5.00|$ -5.00| :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z';
-    const [row] = parseAccountRegister(stdout);
-    expect(row.date).toBe('2026/01/01');
-    expect(row.payee).toBe('Coffee');
-    expect(row.amount).toBe('$ -5.00');
-    expect(row.runningTotal).toBe('$ -5.00');
-    expect(row.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
+    const stdout = row(
+      '2026/01/01',
+      'Coffee',
+      '$ -5.00',
+      '$ -5.00',
+      ' :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z'
+    );
+    const [parsed] = parseAccountRegister(stdout);
+    expect(parsed.date).toBe('2026/01/01');
+    expect(parsed.payee).toBe('Coffee');
+    expect(parsed.amount).toBe('$ -5.00');
+    expect(parsed.runningTotal).toBe('$ -5.00');
+    expect(parsed.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
   });
 
   it('has no uid when the note lacks one (actions disabled downstream)', () => {
-    const stdout = 'NNN2026/01/02|Book|$ -20.00|$ -25.00|';
-    const [row] = parseAccountRegister(stdout);
-    expect(row.uid).toBeUndefined();
+    const stdout = row('2026/01/02', 'Book', '$ -20.00', '$ -25.00', '');
+    const [parsed] = parseAccountRegister(stdout);
+    expect(parsed.uid).toBeUndefined();
   });
 
   it('keeps a multi-commodity running total intact and preserves a note pipe', () => {
+    const stdout = row(
+      '2026/03/01',
+      'Split',
+      'KIRT 100',
+      '$ -5.00\nKIRT 100',
+      'a|b :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z'
+    );
+    const [parsed] = parseAccountRegister(stdout);
+    expect(parsed.runningTotal).toBe('$ -5.00\nKIRT 100');
+    expect(parsed.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
+  });
+
+  it('parses a row whose uid contains the old "NNN" marker without corruption', () => {
+    // Regression: a ULID may contain "NNN" (its alphabet includes N). Splitting
+    // on "NNN" shifted the next chunk into an "Invalid Date" row and dropped
+    // the uid. Control-char separators keep the row and uid intact.
     const stdout =
-      'NNN2026/03/01|Split|KIRT 100|$ -5.00\nKIRT 100|a|b :uid: 01HZY0Z9QK8G7F6E5D4C3B2A1Z';
-    const [row] = parseAccountRegister(stdout);
-    expect(row.runningTotal).toBe('$ -5.00\nKIRT 100');
-    expect(row.uid).toBe('01HZY0Z9QK8G7F6E5D4C3B2A1Z');
+      row(
+        '2026/07/12',
+        'ghaza khoshk',
+        'KIRT -9000',
+        'KIRT -9000',
+        ' :uid: 01HZXNNN8E5T0DJC5G5KJDQRYK'
+      ) + row('2026/07/10', 'earlier', 'KIRT -100', 'KIRT -9100', '');
+    const rows = parseAccountRegister(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].date).toBe('2026/07/12');
+    expect(rows[0].uid).toBe('01HZXNNN8E5T0DJC5G5KJDQRYK');
+    expect(rows[1].date).toBe('2026/07/10');
   });
 });

--- a/features/transactions/row/registerRows.test.ts
+++ b/features/transactions/row/registerRows.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { FIELD_SEP, RECORD_SEP, parseAccountRegister } from './registerRows';
+import {
+  FIELD_SEPARATOR,
+  RECORD_SEPARATOR,
+  parseAccountRegister,
+} from './registerRows';
 
 // Build a register line the way ledger would, using the real separators.
-const row = (...fields: string[]) => `${RECORD_SEP}${fields.join(FIELD_SEP)}`;
+const row = (...fields: string[]) =>
+  `${RECORD_SEPARATOR}${fields.join(FIELD_SEPARATOR)}\n`;
 
 describe('parseAccountRegister', () => {
   it('parses date/payee/amount/total and extracts the uid from the note', () => {

--- a/features/transactions/row/registerRows.ts
+++ b/features/transactions/row/registerRows.ts
@@ -11,16 +11,16 @@ import { uidFromNote } from '@/lib/journal/uid';
 export const RECORD_SEP = '\x1e';
 export const FIELD_SEP = '\x1f';
 
-// Row separator `RECORD_SEP`; fields joined by `FIELD_SEP`. `%T` (total) may
-// span multiple commodities (embedded newlines, no field sep); `%(note)` is
-// taken as the rejoined remainder after the four fixed leading fields.
-export const REGISTER_FORMAT = `${RECORD_SEP}%D${FIELD_SEP}%P${FIELD_SEP}%t${FIELD_SEP}%T${FIELD_SEP}%(note)`;
-
 // Compose a register format from a field list, e.g. `['%D', '%P', '%A', '%t']`
 // followed by `%(note)`. Keeps every splitRegisterRows caller on the same
 // separators so the split below stays correct.
 export const registerFormat = (leadingFields: string[]): string =>
   `${RECORD_SEP}${[...leadingFields, '%(note)'].join(FIELD_SEP)}\n`;
+
+// Row separator `RECORD_SEP`; fields joined by `FIELD_SEP`. `%T` (total) may
+// span multiple commodities (embedded newlines, no field sep); `%(note)` is
+// taken as the rejoined remainder after the four fixed leading fields.
+export const REGISTER_FORMAT = registerFormat(['%D', '%P', '%t', '%T']);
 
 export type RegisterRow = {
   /** Trimmed leading fixed fields, positional per surface. */

--- a/features/transactions/row/registerRows.ts
+++ b/features/transactions/row/registerRows.ts
@@ -8,16 +8,16 @@ import { uidFromNote } from '@/lib/journal/uid';
 // like "NNN" appears inside a uid such as `01HZXNNN…`, splitting mid-record and
 // rendering the next chunk as an "Invalid Date" row. Control chars can never
 // occur in a date, amount, ULID, or a normally-typed note.
-export const RECORD_SEP = '\x1e';
-export const FIELD_SEP = '\x1f';
+export const RECORD_SEPARATOR = '\x1e';
+export const FIELD_SEPARATOR = '\x1f';
 
 // Compose a register format from a field list, e.g. `['%D', '%P', '%A', '%t']`
 // followed by `%(note)`. Keeps every splitRegisterRows caller on the same
 // separators so the split below stays correct.
 export const registerFormat = (leadingFields: string[]): string =>
-  `${RECORD_SEP}${[...leadingFields, '%(note)'].join(FIELD_SEP)}\n`;
+  `${RECORD_SEPARATOR}${[...leadingFields, '%(note)'].join(FIELD_SEPARATOR)}\n`;
 
-// Row separator `RECORD_SEP`; fields joined by `FIELD_SEP`. `%T` (total) may
+// Row separator `RECORD_SEPARATOR`; fields joined by `FIELD_SEPARATOR`. `%T` (total) may
 // span multiple commodities (embedded newlines, no field sep); `%(note)` is
 // taken as the rejoined remainder after the four fixed leading fields.
 export const REGISTER_FORMAT = registerFormat(['%D', '%P', '%t', '%T']);
@@ -37,12 +37,12 @@ export type RegisterRow = {
  */
 export const splitRegisterRows = (stdout: string): RegisterRow[] =>
   stdout
-    .split(RECORD_SEP)
-    .map((line) => line.split(FIELD_SEP))
+    .split(RECORD_SEPARATOR)
+    .map((line) => line.split(FIELD_SEPARATOR))
     .filter((cols) => cols.length >= 4 && cols[0].trim())
     .map((cols) => ({
       cols: cols.map((s) => s.trim()),
-      uid: uidFromNote(cols.slice(4).join(FIELD_SEP)) ?? undefined,
+      uid: uidFromNote(cols.slice(4).join(FIELD_SEPARATOR)) ?? undefined,
     }));
 
 export const parseAccountRegister = (stdout: string): TransactionRowView[] =>

--- a/features/transactions/row/registerRows.ts
+++ b/features/transactions/row/registerRows.ts
@@ -1,33 +1,48 @@
 import type { TransactionRowView } from './rowView';
 import { uidFromNote } from '@/lib/journal/uid';
 
-// Row separator `NNN`; fields joined by `|`. `%T` (total) may span multiple
-// commodities (embedded newlines, no `|`); `%(note)` may itself contain `|`, so
-// it is taken as the rejoined remainder after the four fixed leading fields.
-export const REGISTER_FORMAT = 'NNN%D|%P|%t|%T|%(note)';
+// Record/field separators for `ledger reg --format`. ASCII RS (0x1e) and US
+// (0x1f) are used instead of a printable marker because a printable one
+// collides with content: ULID uids (carried in `%(note)`) draw from an
+// alphabet that includes the letter, and a payee/note is free text — a marker
+// like "NNN" appears inside a uid such as `01HZXNNN…`, splitting mid-record and
+// rendering the next chunk as an "Invalid Date" row. Control chars can never
+// occur in a date, amount, ULID, or a normally-typed note.
+export const RECORD_SEP = '\x1e';
+export const FIELD_SEP = '\x1f';
+
+// Row separator `RECORD_SEP`; fields joined by `FIELD_SEP`. `%T` (total) may
+// span multiple commodities (embedded newlines, no field sep); `%(note)` is
+// taken as the rejoined remainder after the four fixed leading fields.
+export const REGISTER_FORMAT = `${RECORD_SEP}%D${FIELD_SEP}%P${FIELD_SEP}%t${FIELD_SEP}%T${FIELD_SEP}%(note)`;
+
+// Compose a register format from a field list, e.g. `['%D', '%P', '%A', '%t']`
+// followed by `%(note)`. Keeps every splitRegisterRows caller on the same
+// separators so the split below stays correct.
+export const registerFormat = (leadingFields: string[]): string =>
+  `${RECORD_SEP}${[...leadingFields, '%(note)'].join(FIELD_SEP)}\n`;
 
 export type RegisterRow = {
-  /** Trimmed leading fixed fields (`%D|%P|…`), positional per surface. */
+  /** Trimmed leading fixed fields, positional per surface. */
   cols: string[];
   /** Uid extracted from the note (the rejoined remainder after `cols[3]`). */
   uid?: string;
 };
 
 /**
- * Splits `ledger reg --format 'NNN…|…'` output into trimmed columns plus the
- * uid carried in the note. Shared by every register surface (account register,
- * dashboard recent, reconcile) so they agree on the malformed-line guard and
- * the note-is-the-remainder rule. A `|` inside a note can't drop the uid, and a
- * short/blank chunk is dropped rather than rendered as an empty row.
+ * Splits `ledger reg --format` output into trimmed columns plus the uid carried
+ * in the note. Shared by every register surface (account register, reconcile)
+ * so they agree on the malformed-line guard and the note-is-the-remainder rule.
+ * A short/blank chunk is dropped rather than rendered as an empty row.
  */
 export const splitRegisterRows = (stdout: string): RegisterRow[] =>
   stdout
-    .split('NNN')
-    .map((line) => line.split('|'))
+    .split(RECORD_SEP)
+    .map((line) => line.split(FIELD_SEP))
     .filter((cols) => cols.length >= 4 && cols[0].trim())
     .map((cols) => ({
       cols: cols.map((s) => s.trim()),
-      uid: uidFromNote(cols.slice(4).join('|')) ?? undefined,
+      uid: uidFromNote(cols.slice(4).join(FIELD_SEP)) ?? undefined,
     }));
 
 export const parseAccountRegister = (stdout: string): TransactionRowView[] =>

--- a/lib/payees/parse.test.ts
+++ b/lib/payees/parse.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { parsePayeeRows } from './parse';
+import {
+  FIELD_SEPARATOR,
+  RECORD_SEPARATOR,
+} from '@/features/transactions/row/registerRows';
+
+const row = (payee: string, amount: string) =>
+  `${RECORD_SEPARATOR}${payee}${FIELD_SEPARATOR}${amount}\n`;
 
 describe('parsePayeeRows', () => {
   it('returns an empty array for empty input', () => {
@@ -10,7 +17,9 @@ describe('parsePayeeRows', () => {
     // ledger already collapsed + sorted descending via --by-payee --collapse
     // --sort '-display_amount'; the parser must not re-order.
     const stdout =
-      'NNNWhole Foods|$ 100.00\nNNNAmazon|$ 20.00\nNNNCafe|$ 12.50\n';
+      row('Whole Foods', '$ 100.00') +
+      row('Amazon', '$ 20.00') +
+      row('Cafe', '$ 12.50');
     expect(parsePayeeRows(stdout)).toEqual([
       { payee: 'Whole Foods', total: 100 },
       { payee: 'Amazon', total: 20 },
@@ -19,21 +28,23 @@ describe('parsePayeeRows', () => {
   });
 
   it('drops the Commodities revalued pseudo-payee', () => {
-    const stdout = 'NNNWhole Foods|$ 100.00\nNNNCommodities revalued|$ 12.00\n';
+    const stdout =
+      row('Whole Foods', '$ 100.00') + row('Commodities revalued', '$ 12.00');
     expect(parsePayeeRows(stdout)).toEqual([
       { payee: 'Whole Foods', total: 100 },
     ]);
   });
 
   it('skips zero and negative totals', () => {
-    const stdout = 'NNNWhole Foods|$ 100.00\nNNNRefund|$ -5.00\n';
+    const stdout = row('Whole Foods', '$ 100.00') + row('Refund', '$ -5.00');
     expect(parsePayeeRows(stdout)).toEqual([
       { payee: 'Whole Foods', total: 100 },
     ]);
   });
 
   it('parses amounts with a leading commodity, commas, or bare numbers', () => {
-    const stdout = 'NNNX|$ 1,234.50\nNNNY|USD 7\nNNNZ|42.00\n';
+    const stdout =
+      row('X', '$ 1,234.50') + row('Y', 'USD 7') + row('Z', '42.00');
     expect(parsePayeeRows(stdout)).toEqual([
       { payee: 'X', total: 1234.5 },
       { payee: 'Y', total: 7 },

--- a/lib/payees/parse.ts
+++ b/lib/payees/parse.ts
@@ -1,6 +1,15 @@
+import {
+  FIELD_SEPARATOR,
+  RECORD_SEPARATOR,
+} from '@/features/transactions/row/registerRows';
 import parseAmountColumn from '@/utils/parseAmountColumn';
 
 export type PayeeRow = { payee: string; total: number };
+
+// Format for the by-payee register surfaces (Payees page + CSV export). A
+// payee is free text, so it uses the shared control-char separators instead of
+// a printable marker that could appear inside a payee.
+export const PAYEE_REGISTER_FORMAT = `${RECORD_SEPARATOR}%P${FIELD_SEPARATOR}%t\n`;
 
 // Under `-X`, ledger emits a synthetic `Commodities revalued` posting for
 // mark-to-market gains. `--by-payee` groups it as if it were a real payee; it
@@ -10,16 +19,16 @@ const isPseudoPayee = (payee: string): boolean =>
 
 /**
  * Parse `ledger reg ^Expenses --by-payee --collapse -X <base>
- * --sort '-display_amount' --format 'NNN%P|%t\n'` output. Ledger already
- * collapses to one converted row per payee and sorts them descending, so this
- * only maps each `NNN<payee>|<amount>` chunk to a typed row, drops the
- * revaluation pseudo-payee, and keeps positive spend — no JS re-summing or
- * re-sorting (that was the reimplementation ledger does better).
+ * --sort '-display_amount' --format PAYEE_REGISTER_FORMAT` output. Ledger
+ * already collapses to one converted row per payee and sorts them descending,
+ * so this only maps each `<payee><FIELD_SEPARATOR><amount>` record to a typed
+ * row, drops the revaluation pseudo-payee, and keeps positive spend — no JS
+ * re-summing or re-sorting (that was the reimplementation ledger does better).
  */
 export const parsePayeeRows = (stdout: string): PayeeRow[] => {
   const rows: PayeeRow[] = [];
-  for (const chunk of stdout.split('NNN')) {
-    const [payee, amount] = chunk.split('|').map((s) => s.trim());
+  for (const chunk of stdout.split(RECORD_SEPARATOR)) {
+    const [payee, amount] = chunk.split(FIELD_SEPARATOR).map((s) => s.trim());
     if (!payee || !amount || isPseudoPayee(payee)) continue;
     const total = parseAmountColumn(amount);
     if (total > 0) rows.push({ payee, total });


### PR DESCRIPTION
## Invalid Date on account register

Register surfaces (account register at `/accounts/[account]`, reconcile) split `ledger reg --format` output on the literal string **`NNN`**. A ULID uid — emitted in `%(note)` — uses an alphabet that includes the letter **N**, so a uid like `01HZX`**`NNN`**`8E5T…` split mid-record: the trailing chunk shifted into an **"Invalid Date"** row and the uid was silently dropped. Free-text notes/payees containing `NNN` hit the same fault.

Fix: delimit records/fields with ASCII **RS (0x1e)** and **US (0x1f)**, which can never appear in a date, amount, ULID, or a normally-typed note. `parseAccountRegister` and `parseReconcileRows` now compose their format from the shared `registerFormat()` helper so both stay in lockstep.

Regression test added: a row whose uid contains `NNN` parses intact.

> Scope note: other ad-hoc `NNN`-split parsers (payees, net worth, monthly, periodic balance) emit only `%A/%P/%D/%t/%T` — no uid — so they are far less exposed and left untouched here.

## Reusable add-transaction button

Extracted the header quick-entry split button into a self-loading `AddTransactionButton` server component (fetches its own accounts/currency/templates). The header slot and the dashboard "Recent transactions" header both render it, so the dashboard button now matches the header's full entry-variant behavior instead of being a plain link.